### PR TITLE
feat(exec): add git worktree wrapper command coverage

### DIFF
--- a/internal/exec/git.go
+++ b/internal/exec/git.go
@@ -111,11 +111,17 @@ func runGitCommand(repoPath string, args ...string) (string, error) {
 	cmd.Dir = repoPath
 
 	out, err := cmd.CombinedOutput()
+	output := string(out)
 	if err != nil {
+		trimmedOutput := strings.TrimSpace(output)
+		if trimmedOutput != "" {
+			return "", fmt.Errorf("run git %s: %w; output: %s", strings.Join(args, " "), err, trimmedOutput)
+		}
+
 		return "", fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
 	}
 
-	return string(out), nil
+	return output, nil
 }
 
 func parseWorktreeListPorcelain(porcelain string) ([]domain.Worktree, error) {

--- a/internal/exec/git.go
+++ b/internal/exec/git.go
@@ -1,11 +1,172 @@
 package exec
 
+import (
+	"fmt"
+	osexec "os/exec"
+	"strings"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+)
+
+const (
+	worktreePrefix   = "worktree "
+	headPrefix       = "HEAD "
+	branchPrefix     = "branch "
+	branchHeadPrefix = "refs/heads/"
+	detachedMarker   = "detached"
+	cleanMarker      = "clean"
+	lockedMarker     = "locked"
+	lockedWithReason = "locked "
+)
+
 // GitCommand represents a git command executor
 type GitCommand struct {
 	repoPath string
+	runner   commandRunner
 }
+
+type commandRunner func(repoPath string, args ...string) (string, error)
 
 // NewGitCommand creates a new git command executor
 func NewGitCommand(repoPath string) *GitCommand {
-	return &GitCommand{repoPath: repoPath}
+	return NewGitCommandWithRunner(repoPath, runGitCommand)
+}
+
+// NewGitCommandWithRunner creates a git command executor with an injected runner.
+func NewGitCommandWithRunner(repoPath string, runner commandRunner) *GitCommand {
+	return &GitCommand{
+		repoPath: repoPath,
+		runner:   runner,
+	}
+}
+
+// ListWorktrees returns worktrees from `git worktree list --porcelain`.
+func (g *GitCommand) ListWorktrees() ([]domain.Worktree, error) {
+	output, err := g.run("list worktrees", "worktree", "list", "--porcelain")
+	if err != nil {
+		return nil, err
+	}
+
+	worktrees, err := parseWorktreeListPorcelain(output)
+	if err != nil {
+		return nil, fmt.Errorf("parse worktree porcelain: %w", err)
+	}
+
+	return worktrees, nil
+}
+
+// AddWorktree adds a new worktree at path for branch.
+func (g *GitCommand) AddWorktree(path, branch string) error {
+	return g.runNoOutput("add worktree", "worktree", "add", path, branch)
+}
+
+// RemoveWorktree removes the worktree at path.
+func (g *GitCommand) RemoveWorktree(path string, force bool) error {
+	args := []string{"worktree", "remove"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, path)
+
+	return g.runNoOutput("remove worktree", args...)
+}
+
+// PruneWorktrees prunes stale worktree metadata.
+func (g *GitCommand) PruneWorktrees() error {
+	return g.runNoOutput("prune worktrees", "worktree", "prune")
+}
+
+// LockWorktree locks the worktree at path, optionally with a reason.
+func (g *GitCommand) LockWorktree(path, reason string) error {
+	args := []string{"worktree", "lock"}
+	if reason != "" {
+		args = append(args, "--reason", reason)
+	}
+	args = append(args, path)
+
+	return g.runNoOutput("lock worktree", args...)
+}
+
+// UnlockWorktree unlocks the worktree at path.
+func (g *GitCommand) UnlockWorktree(path string) error {
+	return g.runNoOutput("unlock worktree", "worktree", "unlock", path)
+}
+
+func (g *GitCommand) run(op string, args ...string) (string, error) {
+	output, err := g.runner(g.repoPath, args...)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", op, err)
+	}
+
+	return output, nil
+}
+
+func (g *GitCommand) runNoOutput(op string, args ...string) error {
+	_, err := g.run(op, args...)
+	return err
+}
+
+func runGitCommand(repoPath string, args ...string) (string, error) {
+	cmd := osexec.Command("git", args...)
+	cmd.Dir = repoPath
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("run git %s: %w", strings.Join(args, " "), err)
+	}
+
+	return string(out), nil
+}
+
+func parseWorktreeListPorcelain(porcelain string) ([]domain.Worktree, error) {
+	var (
+		worktrees []domain.Worktree
+		current   *domain.Worktree
+	)
+
+	appendCurrent := func() {
+		if current != nil {
+			worktrees = append(worktrees, *current)
+		}
+	}
+
+	lines := strings.Split(porcelain, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		if path, ok := strings.CutPrefix(line, worktreePrefix); ok {
+			appendCurrent()
+			current = &domain.Worktree{
+				Path: path,
+			}
+			continue
+		}
+
+		if current == nil {
+			return nil, fmt.Errorf("metadata before worktree: %q", line)
+		}
+
+		switch {
+		case strings.HasPrefix(line, headPrefix):
+			current.CommitSHA = strings.TrimPrefix(line, headPrefix)
+		case strings.HasPrefix(line, branchPrefix):
+			branchRef := strings.TrimPrefix(line, branchPrefix)
+			current.Branch = strings.TrimPrefix(branchRef, branchHeadPrefix)
+		case line == detachedMarker:
+			if current.Branch == "" {
+				current.Branch = detachedMarker
+			}
+		case line == cleanMarker:
+			current.IsClean = true
+		case line == lockedMarker || strings.HasPrefix(line, lockedWithReason):
+			current.IsLocked = true
+		}
+	}
+
+	appendCurrent()
+
+	return worktrees, nil
 }

--- a/internal/exec/git_test.go
+++ b/internal/exec/git_test.go
@@ -543,3 +543,11 @@ func TestGitCommand_UnlockWorktree(t *testing.T) {
 		})
 	}
 }
+
+func TestRunGitCommand_IncludesOutputOnFailure(t *testing.T) {
+	_, err := runGitCommand(t.TempDir(), "not-a-real-git-subcommand")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "run git not-a-real-git-subcommand")
+	assert.Contains(t, err.Error(), "output:")
+}

--- a/internal/exec/git_test.go
+++ b/internal/exec/git_test.go
@@ -1,9 +1,12 @@
 package exec
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/m00nk0d3/nexus/internal/domain"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewGitCommand(t *testing.T) {
@@ -24,6 +27,519 @@ func TestNewGitCommand(t *testing.T) {
 			cmd := NewGitCommand(tt.repoPath)
 			assert.NotNil(t, cmd)
 			assert.Equal(t, tt.expected, cmd.repoPath)
+		})
+	}
+}
+
+func TestParseWorktreeListPorcelain(t *testing.T) {
+	tests := []struct {
+		name        string
+		porcelain   string
+		expected    []domain.Worktree
+		expectError string
+	}{
+		{
+			name: "minimal valid porcelain parse into one worktree",
+			porcelain: "worktree /repo/main\n" +
+				"HEAD 1111111111111111111111111111111111111111\n" +
+				"branch refs/heads/main\n",
+			expected: []domain.Worktree{
+				{
+					Path:      "/repo/main",
+					CommitSHA: "1111111111111111111111111111111111111111",
+					Branch:    "main",
+				},
+			},
+		},
+		{
+			name: "multiple worktrees with detached fallback locked marker and cleanliness marker",
+			porcelain: "worktree /repo/main\n" +
+				"HEAD aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" +
+				"branch refs/heads/main\n" +
+				"clean\n" +
+				"\n" +
+				"worktree /repo/feature\n" +
+				"HEAD bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n" +
+				"detached\n" +
+				"locked reason\n",
+			expected: []domain.Worktree{
+				{
+					Path:      "/repo/main",
+					CommitSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+					Branch:    "main",
+					IsClean:   true,
+				},
+				{
+					Path:      "/repo/feature",
+					CommitSHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+					Branch:    "detached",
+					IsLocked:  true,
+				},
+			},
+		},
+		{
+			name: "metadata line before worktree returns error",
+			porcelain: "HEAD cccccccccccccccccccccccccccccccccccccccc\n" +
+				"worktree /repo/main\n",
+			expectError: "metadata before worktree",
+		},
+		{
+			name: "unknown metadata ignored",
+			porcelain: "worktree /repo/main\n" +
+				"HEAD dddddddddddddddddddddddddddddddddddddddd\n" +
+				"branch refs/heads/main\n" +
+				"custom-field value\n",
+			expected: []domain.Worktree{
+				{
+					Path:      "/repo/main",
+					CommitSHA: "dddddddddddddddddddddddddddddddddddddddd",
+					Branch:    "main",
+				},
+			},
+		},
+		{
+			name: "non heads branch ref is preserved as-is",
+			porcelain: "worktree /repo/remote\n" +
+				"HEAD eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\n" +
+				"branch refs/remotes/origin/main\n",
+			expected: []domain.Worktree{
+				{
+					Path:      "/repo/remote",
+					CommitSHA: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+					Branch:    "refs/remotes/origin/main",
+				},
+			},
+		},
+		{
+			name: "final worktree is appended without trailing newline",
+			porcelain: "worktree /repo/main\n" +
+				"HEAD ffffffffffffffffffffffffffffffffffffffff\n" +
+				"branch refs/heads/main\n" +
+				"\n" +
+				"worktree /repo/feature\n" +
+				"HEAD 9999999999999999999999999999999999999999\n" +
+				"branch refs/heads/feature",
+			expected: []domain.Worktree{
+				{
+					Path:      "/repo/main",
+					CommitSHA: "ffffffffffffffffffffffffffffffffffffffff",
+					Branch:    "main",
+				},
+				{
+					Path:      "/repo/feature",
+					CommitSHA: "9999999999999999999999999999999999999999",
+					Branch:    "feature",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := parseWorktreeListPorcelain(tt.porcelain)
+
+			if tt.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGitCommand_ListWorktrees(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoPath  string
+		output    string
+		runErr    error
+		want      []domain.Worktree
+		wantArgs  []string
+		expectErr string
+	}{
+		{
+			name:     "invokes git worktree list porcelain and parses output",
+			repoPath: "/repo/main",
+			output: "worktree /repo/main\n" +
+				"HEAD eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\n" +
+				"branch refs/heads/main\n",
+			want: []domain.Worktree{
+				{
+					Path:      "/repo/main",
+					CommitSHA: "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+					Branch:    "main",
+				},
+			},
+			wantArgs: []string{"worktree", "list", "--porcelain"},
+		},
+		{
+			name:      "returns runner error",
+			repoPath:  "/repo/main",
+			runErr:    errors.New("git failed"),
+			wantArgs:  []string{"worktree", "list", "--porcelain"},
+			expectErr: "git failed",
+		},
+		{
+			name: "returns parse error with context",
+			repoPath: "/repo/main",
+			output: "HEAD badbadbadbadbadbadbadbadbadbadbadbadbadb\n" +
+				"worktree /repo/main\n",
+			wantArgs:  []string{"worktree", "list", "--porcelain"},
+			expectErr: "parse worktree porcelain: metadata before worktree",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var called bool
+			var calledRepoPath string
+			var calledArgs []string
+
+			runner := func(repoPath string, args ...string) (string, error) {
+				called = true
+				calledRepoPath = repoPath
+				calledArgs = append([]string{}, args...)
+				return tt.output, tt.runErr
+			}
+
+			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
+
+			actual, err := cmd.ListWorktrees()
+
+			require.True(t, called, "expected command runner to be invoked")
+			assert.Equal(t, tt.repoPath, calledRepoPath)
+			assert.Equal(t, tt.wantArgs, calledArgs)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, actual)
+		})
+	}
+}
+
+func TestGitCommand_AddWorktree(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoPath  string
+		path      string
+		branch    string
+		runErr    error
+		wantArgs  []string
+		expectErr string
+	}{
+		{
+			name:     "invokes git worktree add with path and branch",
+			repoPath: "/repo/main",
+			path:     "/repo/feature",
+			branch:   "feature-branch",
+			wantArgs: []string{"worktree", "add", "/repo/feature", "feature-branch"},
+		},
+		{
+			name:      "returns runner error",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			branch:    "feature-branch",
+			runErr:    errors.New("git failed"),
+			wantArgs:  []string{"worktree", "add", "/repo/feature", "feature-branch"},
+			expectErr: "git failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var called bool
+			var calledRepoPath string
+			var calledArgs []string
+
+			runner := func(repoPath string, args ...string) (string, error) {
+				called = true
+				calledRepoPath = repoPath
+				calledArgs = append([]string{}, args...)
+				return "", tt.runErr
+			}
+
+			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
+
+			err := cmd.AddWorktree(tt.path, tt.branch)
+
+			require.True(t, called, "expected command runner to be invoked")
+			assert.Equal(t, tt.repoPath, calledRepoPath)
+			assert.Equal(t, tt.wantArgs, calledArgs)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGitCommand_RemoveWorktree(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoPath  string
+		path      string
+		force     bool
+		runErr    error
+		wantArgs  []string
+		expectErr string
+	}{
+		{
+			name:     "invokes git worktree remove without force when force false",
+			repoPath: "/repo/main",
+			path:     "/repo/feature",
+			force:    false,
+			wantArgs: []string{"worktree", "remove", "/repo/feature"},
+		},
+		{
+			name:     "invokes git worktree remove with force when force true",
+			repoPath: "/repo/main",
+			path:     "/repo/feature",
+			force:    true,
+			wantArgs: []string{"worktree", "remove", "--force", "/repo/feature"},
+		},
+		{
+			name:      "returns runner error",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			force:     true,
+			runErr:    errors.New("git failed"),
+			wantArgs:  []string{"worktree", "remove", "--force", "/repo/feature"},
+			expectErr: "git failed",
+		},
+		{
+			name:     "places force flag before dash-prefixed path",
+			repoPath: "/repo/main",
+			path:     "--path-like-argument",
+			force:    true,
+			wantArgs: []string{"worktree", "remove", "--force", "--path-like-argument"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var called bool
+			var calledRepoPath string
+			var calledArgs []string
+
+			runner := func(repoPath string, args ...string) (string, error) {
+				called = true
+				calledRepoPath = repoPath
+				calledArgs = append([]string{}, args...)
+				return "", tt.runErr
+			}
+
+			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
+
+			err := cmd.RemoveWorktree(tt.path, tt.force)
+
+			require.True(t, called, "expected command runner to be invoked")
+			assert.Equal(t, tt.repoPath, calledRepoPath)
+			assert.Equal(t, tt.wantArgs, calledArgs)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGitCommand_PruneWorktrees(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoPath  string
+		runErr    error
+		wantArgs  []string
+		expectErr string
+	}{
+		{
+			name:     "invokes git worktree prune",
+			repoPath: "/repo/main",
+			wantArgs: []string{"worktree", "prune"},
+		},
+		{
+			name:      "returns runner error",
+			repoPath:  "/repo/main",
+			runErr:    errors.New("git failed"),
+			wantArgs:  []string{"worktree", "prune"},
+			expectErr: "git failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var called bool
+			var calledRepoPath string
+			var calledArgs []string
+
+			runner := func(repoPath string, args ...string) (string, error) {
+				called = true
+				calledRepoPath = repoPath
+				calledArgs = append([]string{}, args...)
+				return "", tt.runErr
+			}
+
+			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
+
+			err := cmd.PruneWorktrees()
+
+			require.True(t, called, "expected command runner to be invoked")
+			assert.Equal(t, tt.repoPath, calledRepoPath)
+			assert.Equal(t, tt.wantArgs, calledArgs)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGitCommand_LockWorktree(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoPath  string
+		path      string
+		reason    string
+		runErr    error
+		wantArgs  []string
+		expectErr string
+	}{
+		{
+			name:     "invokes git worktree lock without reason when empty",
+			repoPath: "/repo/main",
+			path:     "/repo/feature",
+			reason:   "",
+			wantArgs: []string{"worktree", "lock", "/repo/feature"},
+		},
+		{
+			name:     "invokes git worktree lock with reason when provided",
+			repoPath: "/repo/main",
+			path:     "/repo/feature",
+			reason:   "active development",
+			wantArgs: []string{"worktree", "lock", "--reason", "active development", "/repo/feature"},
+		},
+		{
+			name:      "returns runner error",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			reason:    "active development",
+			runErr:    errors.New("git failed"),
+			wantArgs:  []string{"worktree", "lock", "--reason", "active development", "/repo/feature"},
+			expectErr: "git failed",
+		},
+		{
+			name:     "keeps reason as single argument and path last",
+			repoPath: "/repo/main",
+			path:     "/repo/feature",
+			reason:   "budget variance analysis",
+			wantArgs: []string{"worktree", "lock", "--reason", "budget variance analysis", "/repo/feature"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var called bool
+			var calledRepoPath string
+			var calledArgs []string
+
+			runner := func(repoPath string, args ...string) (string, error) {
+				called = true
+				calledRepoPath = repoPath
+				calledArgs = append([]string{}, args...)
+				return "", tt.runErr
+			}
+
+			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
+
+			err := cmd.LockWorktree(tt.path, tt.reason)
+
+			require.True(t, called, "expected command runner to be invoked")
+			assert.Equal(t, tt.repoPath, calledRepoPath)
+			assert.Equal(t, tt.wantArgs, calledArgs)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGitCommand_UnlockWorktree(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoPath  string
+		path      string
+		runErr    error
+		wantArgs  []string
+		expectErr string
+	}{
+		{
+			name:     "invokes git worktree unlock with path",
+			repoPath: "/repo/main",
+			path:     "/repo/feature",
+			wantArgs: []string{"worktree", "unlock", "/repo/feature"},
+		},
+		{
+			name:      "returns runner error",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			runErr:    errors.New("git failed"),
+			wantArgs:  []string{"worktree", "unlock", "/repo/feature"},
+			expectErr: "git failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var called bool
+			var calledRepoPath string
+			var calledArgs []string
+
+			runner := func(repoPath string, args ...string) (string, error) {
+				called = true
+				calledRepoPath = repoPath
+				calledArgs = append([]string{}, args...)
+				return "", tt.runErr
+			}
+
+			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
+
+			err := cmd.UnlockWorktree(tt.path)
+
+			require.True(t, called, "expected command runner to be invoked")
+			assert.Equal(t, tt.repoPath, calledRepoPath)
+			assert.Equal(t, tt.wantArgs, calledArgs)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Implement wrapper execution and test coverage for git worktree flows to support issue #3 completion and validate command behavior.

Closes: #3
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
