### PR TITLE
feat(ui): render worktree list screen

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/domain"
 )
 
 // Model represents the root Bubbletea model for the Nexus TUI application.
 // It holds the current state of the application.
 type Model struct {
-	// Add fields here as the application grows
+	Worktrees []domain.Worktree
 }
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
@@ -42,5 +43,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // View returns a string representation of the model's current state.
 // This is rendered to the terminal on each update.
 func (m *Model) View() string {
+	if len(m.Worktrees) > 0 {
+		return renderWorktreeList(m.Worktrees)
+	}
+
 	return "Nexus TUI"
 }

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+)
+
+func renderWorktreeList(worktrees []domain.Worktree) string {
+	var b strings.Builder
+
+	b.WriteString("Name\tPath\tStatus\tCommit SHA\tLocked\n")
+
+	for _, wt := range worktrees {
+		status := "dirty"
+		if wt.IsClean {
+			status = "clean"
+		}
+
+		locked := "unlocked"
+		if wt.IsLocked {
+			locked = "locked"
+		}
+
+		b.WriteString(filepath.Base(wt.Path))
+		b.WriteString("\t")
+		b.WriteString(wt.Path)
+		b.WriteString("\t")
+		b.WriteString(status)
+		b.WriteString("\t")
+		b.WriteString(wt.CommitSHA)
+		b.WriteString("\t")
+		b.WriteString(locked)
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelView_WithWorktrees_ContainsListHeaders(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers []string
+	}{
+		{
+			name:    "renders required worktree list headers",
+			headers: []string{"Name", "Path", "Status", "Commit SHA", "Locked"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+
+			model.Worktrees = []domain.Worktree{
+				{
+					Path:      filepath.Join("worktrees", "feature-issue-4"),
+					CommitSHA: "0123456789abcdef",
+					IsClean:   true,
+					IsLocked:  false,
+				},
+			}
+
+			view := model.View()
+
+			for _, header := range tt.headers {
+				assert.Contains(t, view, header)
+			}
+		})
+	}
+}
+
+func TestModelView_WithWorktreeRow_MapsDomainFieldsToRenderedValues(t *testing.T) {
+	tests := []struct {
+		name             string
+		worktree         domain.Worktree
+		expectedStatus   string
+		expectedLockText string
+	}{
+		{
+			name: "maps clean and unlocked worktree",
+			worktree: domain.Worktree{
+				Path:      filepath.Join("tmp", "wt-clean"),
+				CommitSHA: "aaaaaaaaaaaaaaaa",
+				IsClean:   true,
+				IsLocked:  false,
+			},
+			expectedStatus:   "clean",
+			expectedLockText: "unlocked",
+		},
+		{
+			name: "maps dirty and locked worktree",
+			worktree: domain.Worktree{
+				Path:      filepath.Join("tmp", "wt-dirty"),
+				CommitSHA: "bbbbbbbbbbbbbbbb",
+				IsClean:   false,
+				IsLocked:  true,
+			},
+			expectedStatus:   "dirty",
+			expectedLockText: "locked",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+
+			model.Worktrees = []domain.Worktree{tt.worktree}
+
+			view := model.View()
+
+			expectedName := filepath.Base(tt.worktree.Path)
+			assert.Contains(t, view, expectedName)
+			assert.Contains(t, view, tt.worktree.Path)
+			assert.Contains(t, view, tt.expectedStatus)
+			assert.Contains(t, view, tt.worktree.CommitSHA)
+			assert.Contains(t, view, tt.expectedLockText)
+		})
+	}
+}


### PR DESCRIPTION
Display git worktrees in the TUI so users can inspect workspace state at a glance without leaving the app.

This improves branch-based workflows by surfacing path, status, commit SHA, and lock state in one view.

Refs: #4

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
