### PR TITLE
feat(app): implement worktree switch on Enter key (#6)

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -1,29 +1,41 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/m00nk0d3/nexus/internal/domain"
-	"github.com/m00nk0d3/nexus/internal/exec"
+	internalexec "github.com/m00nk0d3/nexus/internal/exec"
 	"github.com/m00nk0d3/nexus/internal/tui/modal"
 )
 
 // issuesFetchedMsg carries the result of a background gh issue list call.
 type issuesFetchedMsg struct {
-	issues []domain.Issue
-	err    error
+	issues []domain.Issue // List of fetched issues, or nil on error
+	err    error          // Error during fetch, if any
 }
 
 // worktreeOpDoneMsg carries the result of an add/remove worktree operation.
 type worktreeOpDoneMsg struct {
-	err error
+	err error // Error during operation, if any
+}
+
+// worktreeSwitchedMsg carries the result of switching to a worktree.
+type worktreeSwitchedMsg struct {
+	err error // Error during switch, if any
 }
 
 // Model represents the root Bubbletea model for the Nexus TUI application.
+// It manages the list of git worktrees, user interactions, and active modals.
 type Model struct {
-	Worktrees   []domain.Worktree
-	RepoPath    string
-	selectedIdx int
-	activeModal tea.Model
+	Worktrees   []domain.Worktree // List of available git worktrees
+	RepoPath    string            // Path to the repository root
+	selectedIdx int               // Currently selected worktree index
+	activeModal tea.Model         // Currently open modal (if any)
+	Error       string            // Error message to display (if any)
 }
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
@@ -60,6 +72,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.Type {
+		case tea.KeyEnter:
+			if len(m.Worktrees) > 0 {
+				return m, m.switchWorktreeCmd(m.Worktrees[m.selectedIdx].Path)
+			}
+			return m, nil
 		case tea.KeyCtrlC:
 			return m, tea.Quit
 		case tea.KeyCtrlN:
@@ -87,6 +104,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Refresh the worktree list after an add/remove operation.
 		return m, m.refreshWorktreesCmd()
 
+	case worktreeSwitchedMsg:
+		if msg.err != nil {
+			m.Error = fmt.Sprintf("Failed to switch worktree: %v", msg.err)
+			return m, nil
+		}
+		// Refresh worktrees after switching back
+		return m, m.refreshWorktreesCmd()
+
 	case worktreesRefreshedMsg:
 		if msg.err == nil {
 			m.Worktrees = msg.worktrees
@@ -112,11 +137,12 @@ func (m *Model) View() string {
 	return "Nexus TUI"
 }
 
-// fetchIssuesCmd returns a Cmd that fetches open GitHub issues in the background.
+// fetchIssuesCmd returns a Cmd that fetches open GitHub issues in the background,
+// allowing the user to create worktrees from issues.
 func (m *Model) fetchIssuesCmd() tea.Cmd {
 	repoPath := m.RepoPath
 	return func() tea.Msg {
-		cmd := exec.NewIssueCommand(repoPath)
+		cmd := internalexec.NewIssueCommand(repoPath)
 		issues, err := cmd.ListOpenIssues()
 		return issuesFetchedMsg{issues: issues, err: err}
 	}
@@ -126,7 +152,7 @@ func (m *Model) fetchIssuesCmd() tea.Cmd {
 func (m *Model) addWorktreeCmd(branch, path string) tea.Cmd {
 	repoPath := m.RepoPath
 	return func() tea.Msg {
-		cmd := exec.NewGitCommand(repoPath)
+		cmd := internalexec.NewGitCommand(repoPath)
 		err := cmd.AddWorktreeNewBranch(path, branch, "main")
 		return worktreeOpDoneMsg{err: err}
 	}
@@ -136,10 +162,43 @@ func (m *Model) addWorktreeCmd(branch, path string) tea.Cmd {
 func (m *Model) removeWorktreeCmd(path string) tea.Cmd {
 	repoPath := m.RepoPath
 	return func() tea.Msg {
-		cmd := exec.NewGitCommand(repoPath)
+		cmd := internalexec.NewGitCommand(repoPath)
 		err := cmd.RemoveWorktree(path, true)
 		return worktreeOpDoneMsg{err: err}
 	}
+}
+
+// switchWorktreeCmd returns a Cmd that launches a shell in the specified worktree directory,
+// allowing the user to work within the worktree before returning to the TUI.
+func (m *Model) switchWorktreeCmd(path string) tea.Cmd {
+	cmd := buildShellCmd(path)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		return worktreeSwitchedMsg{err: err}
+	})
+}
+
+// buildShellCmd constructs a platform-appropriate shell command for the given directory.
+// On Windows, it uses cmd.exe with /K flag to keep the shell open.
+// On Unix-like systems, it uses the SHELL environment variable, defaulting to /bin/sh.
+func buildShellCmd(path string) *exec.Cmd {
+	if runtime.GOOS == "windows" {
+		return exec.Command("cmd", "/K", "cd", path)
+	}
+
+	shell := getShell()
+	cmd := exec.Command(shell)
+	cmd.Dir = path
+	return cmd
+}
+
+// getShell returns the user's preferred shell, or /bin/sh as a fallback.
+// It reads the SHELL environment variable on Unix-like systems.
+func getShell() string {
+	shell := os.Getenv("SHELL")
+	if shell != "" {
+		return shell
+	}
+	return "/bin/sh"
 }
 
 // worktreesRefreshedMsg carries the result of refreshing the worktree list.
@@ -152,7 +211,7 @@ type worktreesRefreshedMsg struct {
 func (m *Model) refreshWorktreesCmd() tea.Cmd {
 	repoPath := m.RepoPath
 	return func() tea.Msg {
-		cmd := exec.NewGitCommand(repoPath)
+		cmd := internalexec.NewGitCommand(repoPath)
 		worktrees, err := cmd.ListWorktrees()
 		return worktreesRefreshedMsg{worktrees: worktrees, err: err}
 	}

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -181,11 +181,22 @@ func (m *Model) switchWorktreeCmd(path string) tea.Cmd {
 // On Windows, it uses cmd.exe with /K flag to keep the shell open.
 // On Unix-like systems, it uses the SHELL environment variable, defaulting to /bin/sh.
 func buildShellCmd(path string) *exec.Cmd {
-	if runtime.GOOS == "windows" {
-		return exec.Command("cmd", "/K", "cd", path)
+	return buildShellCmdForOS(path, runtime.GOOS, getShell())
+}
+
+// buildShellCmdForOS constructs a shell command for a specific OS and shell value.
+// It exists to keep buildShellCmd testable across platforms.
+func buildShellCmdForOS(path, goos, shell string) *exec.Cmd {
+	if goos == "windows" {
+		cmd := exec.Command("cmd", "/K")
+		cmd.Dir = path
+		return cmd
 	}
 
-	shell := getShell()
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+
 	cmd := exec.Command(shell)
 	cmd.Dir = path
 	return cmd

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -73,8 +73,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.Type {
 		case tea.KeyEnter:
-			if len(m.Worktrees) > 0 {
-				return m, m.switchWorktreeCmd(m.Worktrees[m.selectedIdx].Path)
+			if selected, ok := m.selectedWorktree(); ok {
+				return m, m.switchWorktreeCmd(selected.Path)
 			}
 			return m, nil
 		case tea.KeyCtrlC:
@@ -82,8 +82,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyCtrlN:
 			return m, m.fetchIssuesCmd()
 		case tea.KeyCtrlD:
-			if len(m.Worktrees) > 0 {
-				m.activeModal = modal.NewDeleteModal(m.Worktrees[m.selectedIdx])
+			if selected, ok := m.selectedWorktree(); ok {
+				m.activeModal = modal.NewDeleteModal(selected)
 			}
 		case tea.KeyUp:
 			if m.selectedIdx > 0 {
@@ -109,12 +109,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.Error = fmt.Sprintf("Failed to switch worktree: %v", msg.err)
 			return m, nil
 		}
+		m.Error = ""
 		// Refresh worktrees after switching back
 		return m, m.refreshWorktreesCmd()
 
 	case worktreesRefreshedMsg:
 		if msg.err == nil {
 			m.Worktrees = msg.worktrees
+			m.clampSelectedIdx()
 		}
 
 	case tea.WindowSizeMsg:
@@ -126,15 +128,20 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View returns a string representation of the model's current state.
 func (m *Model) View() string {
+	baseView := ""
 	if m.activeModal != nil {
-		return m.activeModal.View()
+		baseView = m.activeModal.View()
+	} else if len(m.Worktrees) > 0 {
+		baseView = renderWorktreeList(m.Worktrees)
+	} else {
+		baseView = "Nexus TUI"
 	}
 
-	if len(m.Worktrees) > 0 {
-		return renderWorktreeList(m.Worktrees)
+	if m.Error == "" {
+		return baseView
 	}
 
-	return "Nexus TUI"
+	return fmt.Sprintf("Error: %s\n\n%s", m.Error, baseView)
 }
 
 // fetchIssuesCmd returns a Cmd that fetches open GitHub issues in the background,
@@ -225,5 +232,29 @@ func (m *Model) refreshWorktreesCmd() tea.Cmd {
 		cmd := internalexec.NewGitCommand(repoPath)
 		worktrees, err := cmd.ListWorktrees()
 		return worktreesRefreshedMsg{worktrees: worktrees, err: err}
+	}
+}
+
+func (m *Model) selectedWorktree() (domain.Worktree, bool) {
+	if len(m.Worktrees) == 0 || m.selectedIdx < 0 || m.selectedIdx >= len(m.Worktrees) {
+		return domain.Worktree{}, false
+	}
+
+	return m.Worktrees[m.selectedIdx], true
+}
+
+func (m *Model) clampSelectedIdx() {
+	if len(m.Worktrees) == 0 {
+		m.selectedIdx = 0
+		return
+	}
+
+	if m.selectedIdx < 0 {
+		m.selectedIdx = 0
+		return
+	}
+
+	if m.selectedIdx >= len(m.Worktrees) {
+		m.selectedIdx = len(m.Worktrees) - 1
 	}
 }

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -165,6 +166,109 @@ func TestModelIntegration(t *testing.T) {
 			// Verify View works after update
 			updatedView := updatedModel.View()
 			assert.IsType(t, "", updatedView, "View should work after update: %s", tt.description)
+		})
+	}
+}
+
+// TestModel_Enter_TriggersSwitch verifies that pressing Enter on a selected worktree
+// returns a tea.Cmd to switch to that worktree
+func TestModel_Enter_TriggersSwitch(t *testing.T) {
+	tests := []struct {
+		name            string
+		worktrees       []interface{} // Will be converted to domain.Worktree
+		selectedIdx     int
+		description     string
+		wantCmdNotNil   bool
+	}{
+		{
+			name: "enter on first worktree returns switch command",
+			worktrees: []interface{}{
+				map[string]interface{}{"Path": "/home/user/repos/wt1", "Branch": "main", "CommitSHA": "abc123", "IsClean": true, "IsLocked": false, "LinkedPR": nil},
+				map[string]interface{}{"Path": "/home/user/repos/wt2", "Branch": "feature", "CommitSHA": "def456", "IsClean": false, "IsLocked": false, "LinkedPR": nil},
+			},
+			selectedIdx:   0,
+			description:   "Should return a Cmd to switch to first worktree",
+			wantCmdNotNil: true,
+		},
+		{
+			name: "enter on second worktree returns switch command",
+			worktrees: []interface{}{
+				map[string]interface{}{"Path": "/home/user/repos/wt1", "Branch": "main", "CommitSHA": "abc123", "IsClean": true, "IsLocked": false, "LinkedPR": nil},
+				map[string]interface{}{"Path": "/home/user/repos/wt2", "Branch": "feature", "CommitSHA": "def456", "IsClean": false, "IsLocked": false, "LinkedPR": nil},
+			},
+			selectedIdx:   1,
+			description:   "Should return a Cmd to switch to second worktree",
+			wantCmdNotNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup: Create model with populated Worktrees list
+			model := NewModel()
+			require.NotNil(t, model, "Model creation should succeed")
+
+			// Convert test data to domain.Worktree
+			worktrees := make([]domain.Worktree, len(tt.worktrees))
+			for i, wtData := range tt.worktrees {
+				data := wtData.(map[string]interface{})
+				worktrees[i] = domain.Worktree{
+					Path:      data["Path"].(string),
+					Branch:    data["Branch"].(string),
+					CommitSHA: data["CommitSHA"].(string),
+					IsClean:   data["IsClean"].(bool),
+					IsLocked:  data["IsLocked"].(bool),
+				}
+			}
+			model.Worktrees = worktrees
+			model.selectedIdx = tt.selectedIdx
+
+			// Action: Call Update with tea.KeyEnter
+			updatedModel, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+			// Assert: Model is returned
+			assert.NotNil(t, updatedModel, "Update should return model: %s", tt.description)
+
+			// Assert: A Cmd is returned (for switching worktree)
+			if tt.wantCmdNotNil {
+				assert.NotNil(t, cmd, "Update should return a Cmd for switching worktree: %s", tt.description)
+			}
+		})
+	}
+}
+
+// TestModel_Enter_EmptyList_NoOp verifies that pressing Enter on an empty worktree list
+// does not trigger a switch command
+func TestModel_Enter_EmptyList_NoOp(t *testing.T) {
+	tests := []struct {
+		name            string
+		description     string
+		wantCmdNil      bool
+	}{
+		{
+			name:            "enter on empty list returns nil command",
+			description:     "Should return nil Cmd when no worktrees exist",
+			wantCmdNil:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup: Create model with empty Worktrees list
+			model := NewModel()
+			require.NotNil(t, model, "Model creation should succeed")
+			require.Empty(t, model.Worktrees, "Worktrees should be empty initially")
+
+			// Action: Call Update with tea.KeyEnter
+			updatedModel, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+			// Assert: Model is returned
+			assert.NotNil(t, updatedModel, "Update should return model: %s", tt.description)
+
+			// Assert: Cmd is nil (no-op)
+			if tt.wantCmdNil {
+				assert.Nil(t, cmd, "Update should return nil Cmd for empty list: %s", tt.description)
+			}
 		})
 	}
 }

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -13,9 +14,9 @@ import (
 // with all required fields properly initialized
 func TestModelInitialization(t *testing.T) {
 	tests := []struct {
-		name             string
-		wantModelNotNil  bool
-		wantHasFields    bool
+		name            string
+		wantModelNotNil bool
+		wantHasFields   bool
 	}{
 		{
 			name:            "creates new model successfully",
@@ -27,11 +28,11 @@ func TestModelInitialization(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			model := NewModel()
-			
+
 			if tt.wantModelNotNil {
 				assert.NotNil(t, model, "Model should not be nil")
 			}
-			
+
 			if tt.wantHasFields {
 				// Verify model can be cast to tea.Model (has required interface methods)
 				var _ tea.Model = model
@@ -45,11 +46,11 @@ func TestModelInitialization(t *testing.T) {
 // and returns (tea.Model, tea.Cmd) as required by Bubbletea interface
 func TestModelUpdate(t *testing.T) {
 	tests := []struct {
-		name           string
-		msg            tea.Msg
-		wantModel      bool
-		wantCmdNotNil  bool
-		description    string
+		name          string
+		msg           tea.Msg
+		wantModel     bool
+		wantCmdNotNil bool
+		description   string
 	}{
 		{
 			name:          "update accepts tea.KeyMsg",
@@ -100,10 +101,10 @@ func TestModelUpdate(t *testing.T) {
 // representation of the model's current state
 func TestModelView(t *testing.T) {
 	tests := []struct {
-		name                string
-		wantViewNotEmpty    bool
-		wantViewIsString    bool
-		description         string
+		name             string
+		wantViewNotEmpty bool
+		wantViewIsString bool
+		description      string
 	}{
 		{
 			name:             "view returns string representation",
@@ -174,11 +175,11 @@ func TestModelIntegration(t *testing.T) {
 // returns a tea.Cmd to switch to that worktree
 func TestModel_Enter_TriggersSwitch(t *testing.T) {
 	tests := []struct {
-		name            string
-		worktrees       []interface{} // Will be converted to domain.Worktree
-		selectedIdx     int
-		description     string
-		wantCmdNotNil   bool
+		name          string
+		worktrees     []interface{} // Will be converted to domain.Worktree
+		selectedIdx   int
+		description   string
+		wantCmdNotNil bool
 	}{
 		{
 			name: "enter on first worktree returns switch command",
@@ -241,14 +242,14 @@ func TestModel_Enter_TriggersSwitch(t *testing.T) {
 // does not trigger a switch command
 func TestModel_Enter_EmptyList_NoOp(t *testing.T) {
 	tests := []struct {
-		name            string
-		description     string
-		wantCmdNil      bool
+		name        string
+		description string
+		wantCmdNil  bool
 	}{
 		{
-			name:            "enter on empty list returns nil command",
-			description:     "Should return nil Cmd when no worktrees exist",
-			wantCmdNil:      true,
+			name:        "enter on empty list returns nil command",
+			description: "Should return nil Cmd when no worktrees exist",
+			wantCmdNil:  true,
 		},
 	}
 
@@ -268,6 +269,121 @@ func TestModel_Enter_EmptyList_NoOp(t *testing.T) {
 			// Assert: Cmd is nil (no-op)
 			if tt.wantCmdNil {
 				assert.Nil(t, cmd, "Update should return nil Cmd for empty list: %s", tt.description)
+			}
+		})
+	}
+}
+
+func TestBuildShellCmdForOS_Windows_UsesCmdKAndDir(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected []string
+	}{
+		{
+			name:     "windows path with spaces",
+			path:     `C:\Users\dev\My Worktree`,
+			expected: []string{"cmd", "/K"},
+		},
+		{
+			name:     "windows different drive path",
+			path:     `D:\repo\wt-feature`,
+			expected: []string{"cmd", "/K"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := buildShellCmdForOS(tt.path, "windows", "")
+			require.NotNil(t, cmd)
+			assert.Equal(t, tt.expected, cmd.Args)
+			assert.Equal(t, tt.path, cmd.Dir)
+		})
+	}
+}
+
+func TestBuildShellCmdForOS_Unix_UsesShellAndFallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		shell     string
+		wantFirst string
+	}{
+		{
+			name:      "uses provided shell",
+			shell:     "/bin/zsh",
+			wantFirst: "/bin/zsh",
+		},
+		{
+			name:      "falls back to /bin/sh when shell empty",
+			shell:     "",
+			wantFirst: "/bin/sh",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := "/tmp/worktree"
+			cmd := buildShellCmdForOS(path, "linux", tt.shell)
+			require.NotNil(t, cmd)
+			require.NotEmpty(t, cmd.Args)
+			assert.Equal(t, tt.wantFirst, cmd.Args[0])
+			assert.Equal(t, path, cmd.Dir)
+		})
+	}
+}
+
+func TestGetShell_UsesEnvAndFallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		shellEnv  string
+		wantShell string
+	}{
+		{
+			name:      "uses SHELL env value when set",
+			shellEnv:  "/bin/fish",
+			wantShell: "/bin/fish",
+		},
+		{
+			name:      "falls back to /bin/sh when SHELL env empty",
+			shellEnv:  "",
+			wantShell: "/bin/sh",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("SHELL", tt.shellEnv)
+			assert.Equal(t, tt.wantShell, getShell())
+		})
+	}
+}
+
+func TestModelUpdate_WorktreeSwitchedMsg_ErrorHandling(t *testing.T) {
+	tests := []struct {
+		name         string
+		msg          worktreeSwitchedMsg
+		wantError    string
+		wantCmdIsNil bool
+	}{
+		{
+			name:         "sets model error when switch fails",
+			msg:          worktreeSwitchedMsg{err: errors.New("switch failed")},
+			wantError:    "Failed to switch worktree: switch failed",
+			wantCmdIsNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+
+			updated, cmd := model.Update(tt.msg)
+			updatedModel, ok := updated.(*Model)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantError, updatedModel.Error)
+			if tt.wantCmdIsNil {
+				assert.Nil(t, cmd)
 			}
 		})
 	}

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -274,6 +274,20 @@ func TestModel_Enter_EmptyList_NoOp(t *testing.T) {
 	}
 }
 
+func TestModel_Enter_OutOfRangeSelectedIndex_NoOp(t *testing.T) {
+	model := NewModel()
+	require.NotNil(t, model)
+
+	model.Worktrees = []domain.Worktree{
+		{Path: "/home/user/repos/wt1", Branch: "main", CommitSHA: "abc123"},
+	}
+	model.selectedIdx = 10
+
+	updatedModel, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.NotNil(t, updatedModel)
+	assert.Nil(t, cmd)
+}
+
 func TestBuildShellCmdForOS_Windows_UsesCmdKAndDir(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -387,4 +401,61 @@ func TestModelUpdate_WorktreeSwitchedMsg_ErrorHandling(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestModelUpdate_WorktreesRefreshedMsg_ClampsSelectedIndex(t *testing.T) {
+	tests := []struct {
+		name            string
+		initialSelected int
+		worktrees       []domain.Worktree
+		wantSelected    int
+	}{
+		{
+			name:            "clamps to last when selected index is too large",
+			initialSelected: 5,
+			worktrees: []domain.Worktree{
+				{Path: "/wt/a"},
+				{Path: "/wt/b"},
+			},
+			wantSelected: 1,
+		},
+		{
+			name:            "normalizes negative selected index to zero",
+			initialSelected: -3,
+			worktrees: []domain.Worktree{
+				{Path: "/wt/a"},
+			},
+			wantSelected: 0,
+		},
+		{
+			name:            "resets selected index to zero for empty list",
+			initialSelected: 2,
+			worktrees:       nil,
+			wantSelected:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.selectedIdx = tt.initialSelected
+
+			updated, cmd := model.Update(worktreesRefreshedMsg{worktrees: tt.worktrees, err: nil})
+			updatedModel, ok := updated.(*Model)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantSelected, updatedModel.selectedIdx)
+			assert.Nil(t, cmd)
+		})
+	}
+}
+
+func TestModelView_ShowsErrorMessage(t *testing.T) {
+	model := NewModel()
+	require.NotNil(t, model)
+	model.Error = "Failed to switch worktree: boom"
+
+	view := model.View()
+	assert.Contains(t, view, "Error: Failed to switch worktree: boom")
+	assert.Contains(t, view, "Nexus TUI")
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/m00nk0d3/nexus
 go 1.24.2
 
 require (
+	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/stretchr/testify v1.9.0
 )
@@ -10,7 +11,6 @@ require (
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbles v1.0.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect


### PR DESCRIPTION
Add support for switching to a selected worktree by pressing Enter.
When user selects a worktree and presses Enter:
- Nexus suspends via tea.ExecProcess
- Spawns  (Unix) or cmd /K (Windows) in worktree directory
- User can work in the shell
- On exit, Nexus resumes and refreshes the worktree list

Changes:
- Added tea.KeyEnter handler in Model.Update
- Implemented switchWorktreeCmd with cross-platform shell support
- Added helper functions: buildShellCmd, getShell
- Added worktreeSwitchedMsg message type
- Enhanced documentation with godoc comments

All tests passing (TDD: Red-Green-Refactor cycle).

Closes #6

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
