### PR TITLE
feat(exec): add GitHubClient with ListOpenPRs and GetPR

### DIFF
--- a/.copilot/agent-memory/tdd-enforcer/MEMORY.md
+++ b/.copilot/agent-memory/tdd-enforcer/MEMORY.md
@@ -1,0 +1,35 @@
+# TDD Enforcer Memory — nexus (m00nk0d3/nexus)
+
+## Project Stack
+- Go (backend only), located at repo root
+- Test runner: go test ./internal/...
+
+## Test Commands
+- Run all tests: go test ./internal/exec/... ./internal/domain/...
+- Run with verbose output: go test -v ./internal/exec/... ./internal/domain/...
+- Filter specific test: go test -run TestName ./internal/exec/...
+
+## Architecture Pattern
+- internal/domain/ — pure structs, no deps (Issue, PullRequest, Worktree…)
+- internal/exec/ — gh/git CLI wrappers; use injected commandRunner for testability
+- Constructor pair: NewXxx(repoPath) calls NewXxxWithRunner(repoPath, runGhCommand)
+- Tests always use NewXxxWithRunner with a mock runner func
+
+## Test Conventions (exec package)
+- Mock runner: unc(_ string, args ...string) (string, error) { return output, err }
+- Capture args: ar capturedArgs []string inside the runner closure
+- Table-driven tests for happy path, error, empty, edge cases in one 	ests := []struct{...} block
+- Use 	estify/assert + 	estify/require; equire.NoError, ssert.Contains, ssert.Equal
+
+## Error Wrapping Convention
+- mt.Errorf("list open prs: %w", err) — verb phrase prefix, then %w
+- Parse errors: mt.Errorf("parse pr list: %w", err)
+- Single-item fetch: mt.Errorf("get pr: %w", err) / mt.Errorf("parse pr: %w", err)
+
+## JSON Mapping Pattern (gh CLI)
+- Inner structs (ghLabel, ghAuthor, ghIssue, ghPR) kept unexported in the exec package
+- Labels always mapped via make([]string, len(g.Labels)) to guarantee non-nil slice
+- Shared mapping extracted to ghXxxToDomain(g ghXxx) domain.Xxx helper to avoid duplication
+
+## Completed Issues
+- Issue #8: Added domain.PullRequest, GitHubClient with ListOpenPRs/GetPR — 12 new tests, all green

--- a/internal/domain/pr.go
+++ b/internal/domain/pr.go
@@ -1,0 +1,12 @@
+package domain
+
+// PullRequest represents a GitHub pull request.
+type PullRequest struct {
+	Number  int
+	Title   string
+	Branch  string
+	Author  string
+	State   string // "OPEN", "MERGED", "CLOSED"
+	Labels  []string
+	IsDraft bool
+}

--- a/internal/exec/github.go
+++ b/internal/exec/github.go
@@ -74,6 +74,110 @@ func parseIssueList(raw string) ([]domain.Issue, error) {
 	return issues, nil
 }
 
+// GitHubClient wraps the gh CLI for GitHub pull request operations.
+type GitHubClient struct {
+	repoPath string
+	runner   commandRunner
+}
+
+// NewGitHubClient creates a new GitHubClient using the real gh CLI.
+func NewGitHubClient(repoPath string) *GitHubClient {
+	return NewGitHubClientWithRunner(repoPath, runGhCommand)
+}
+
+// NewGitHubClientWithRunner creates a GitHubClient with an injected runner for testing.
+func NewGitHubClientWithRunner(repoPath string, runner commandRunner) *GitHubClient {
+	return &GitHubClient{repoPath: repoPath, runner: runner}
+}
+
+const prFields = "number,title,headRefName,author,state,labels,isDraft"
+
+// ListOpenPRs returns all open pull requests via `gh pr list`.
+func (c *GitHubClient) ListOpenPRs() ([]domain.PullRequest, error) {
+	output, err := c.runner(c.repoPath, "pr", "list", "--json", prFields, "--state", "open")
+	if err != nil {
+		return nil, fmt.Errorf("list open prs: %w", err)
+	}
+
+	prs, err := parsePRList(output)
+	if err != nil {
+		return nil, err
+	}
+
+	return prs, nil
+}
+
+// GetPR returns a single pull request by number via `gh pr view`.
+func (c *GitHubClient) GetPR(number int) (*domain.PullRequest, error) {
+	output, err := c.runner(c.repoPath, "pr", "view", fmt.Sprintf("%d", number), "--json", prFields)
+	if err != nil {
+		return nil, fmt.Errorf("get pr: %w", err)
+	}
+
+	pr, err := parsePR(output)
+	if err != nil {
+		return nil, err
+	}
+
+	return pr, nil
+}
+
+// ghAuthor is the JSON shape for the author object returned by gh.
+type ghAuthor struct {
+	Login string `json:"login"`
+}
+
+// ghPR is the JSON shape returned by `gh pr list/view --json ...`.
+type ghPR struct {
+	Number      int       `json:"number"`
+	Title       string    `json:"title"`
+	HeadRefName string    `json:"headRefName"`
+	Author      ghAuthor  `json:"author"`
+	State       string    `json:"state"`
+	Labels      []ghLabel `json:"labels"`
+	IsDraft     bool      `json:"isDraft"`
+}
+
+func ghPRToDomain(g ghPR) domain.PullRequest {
+	labels := make([]string, len(g.Labels))
+	for i, l := range g.Labels {
+		labels[i] = l.Name
+	}
+	return domain.PullRequest{
+		Number:  g.Number,
+		Title:   g.Title,
+		Branch:  g.HeadRefName,
+		Author:  g.Author.Login,
+		State:   g.State,
+		Labels:  labels,
+		IsDraft: g.IsDraft,
+	}
+}
+
+func parsePRList(raw string) ([]domain.PullRequest, error) {
+	var gh []ghPR
+	if err := json.Unmarshal([]byte(raw), &gh); err != nil {
+		return nil, fmt.Errorf("parse pr list: %w", err)
+	}
+
+	prs := make([]domain.PullRequest, 0, len(gh))
+	for _, g := range gh {
+		prs = append(prs, ghPRToDomain(g))
+	}
+
+	return prs, nil
+}
+
+func parsePR(raw string) (*domain.PullRequest, error) {
+	var g ghPR
+	if err := json.Unmarshal([]byte(raw), &g); err != nil {
+		return nil, fmt.Errorf("parse pr: %w", err)
+	}
+
+	pr := ghPRToDomain(g)
+	return &pr, nil
+}
+
 func runGhCommand(repoPath string, args ...string) (string, error) {
 	cmd := osexec.Command("gh", args...)
 	cmd.Dir = repoPath

--- a/internal/exec/github.go
+++ b/internal/exec/github.go
@@ -74,26 +74,26 @@ func parseIssueList(raw string) ([]domain.Issue, error) {
 	return issues, nil
 }
 
-// GitHubClient wraps the gh CLI for GitHub pull request operations.
-type GitHubClient struct {
+// PRCommand wraps the gh CLI for GitHub pull request operations.
+type PRCommand struct {
 	repoPath string
 	runner   commandRunner
 }
 
-// NewGitHubClient creates a new GitHubClient using the real gh CLI.
-func NewGitHubClient(repoPath string) *GitHubClient {
-	return NewGitHubClientWithRunner(repoPath, runGhCommand)
+// NewPRCommand creates a new PRCommand using the real gh CLI.
+func NewPRCommand(repoPath string) *PRCommand {
+	return NewPRCommandWithRunner(repoPath, runGhCommand)
 }
 
-// NewGitHubClientWithRunner creates a GitHubClient with an injected runner for testing.
-func NewGitHubClientWithRunner(repoPath string, runner commandRunner) *GitHubClient {
-	return &GitHubClient{repoPath: repoPath, runner: runner}
+// NewPRCommandWithRunner creates a PRCommand with an injected runner for testing.
+func NewPRCommandWithRunner(repoPath string, runner commandRunner) *PRCommand {
+	return &PRCommand{repoPath: repoPath, runner: runner}
 }
 
 const prFields = "number,title,headRefName,author,state,labels,isDraft"
 
 // ListOpenPRs returns all open pull requests via `gh pr list`.
-func (c *GitHubClient) ListOpenPRs() ([]domain.PullRequest, error) {
+func (c *PRCommand) ListOpenPRs() ([]domain.PullRequest, error) {
 	output, err := c.runner(c.repoPath, "pr", "list", "--json", prFields, "--state", "open")
 	if err != nil {
 		return nil, fmt.Errorf("list open prs: %w", err)
@@ -108,7 +108,7 @@ func (c *GitHubClient) ListOpenPRs() ([]domain.PullRequest, error) {
 }
 
 // GetPR returns a single pull request by number via `gh pr view`.
-func (c *GitHubClient) GetPR(number int) (*domain.PullRequest, error) {
+func (c *PRCommand) GetPR(number int) (*domain.PullRequest, error) {
 	output, err := c.runner(c.repoPath, "pr", "view", fmt.Sprintf("%d", number), "--json", prFields)
 	if err != nil {
 		return nil, fmt.Errorf("get pr: %w", err)

--- a/internal/exec/github_test.go
+++ b/internal/exec/github_test.go
@@ -134,19 +134,17 @@ func TestListOpenIssues_MapsDomainsCorrectly(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// GitHubClient — PullRequest tests
+// PRCommand — PullRequest tests
 // ---------------------------------------------------------------------------
 
-func TestNewGitHubClient(t *testing.T) {
-	client := NewGitHubClient("/repo")
+func TestNewPRCommand(t *testing.T) {
+	client := NewPRCommand("/repo")
 	assert.NotNil(t, client)
 	assert.Equal(t, "/repo", client.repoPath)
 	assert.NotNil(t, client.runner)
 }
 
 func TestListOpenPRs(t *testing.T) {
-	const prFields = "number,title,headRefName,author,state,labels,isDraft"
-
 	twoPRsJSON := `[
 		{"number":1,"title":"Add login","headRefName":"feat/login","author":{"login":"alice"},"state":"OPEN","labels":[{"name":"enhancement"}],"isDraft":false},
 		{"number":2,"title":"WIP: refactor","headRefName":"chore/refactor","author":{"login":"bob"},"state":"OPEN","labels":[{"name":"wip"},{"name":"refactor"}],"isDraft":true}
@@ -222,7 +220,7 @@ func TestListOpenPRs(t *testing.T) {
 				return tt.runnerOut, tt.runnerErr
 			}
 
-			client := NewGitHubClientWithRunner("/repo", runner)
+			client := NewPRCommandWithRunner("/repo", runner)
 			prs, err := client.ListOpenPRs()
 
 			if tt.wantErr {
@@ -247,8 +245,6 @@ func TestListOpenPRs(t *testing.T) {
 }
 
 func TestGetPR(t *testing.T) {
-	const prFields = "number,title,headRefName,author,state,labels,isDraft"
-
 	validPRJSON := `{"number":42,"title":"Implement feature","headRefName":"feat/feature","author":{"login":"frank"},"state":"MERGED","labels":[{"name":"feature"}],"isDraft":false}`
 
 	tests := []struct {
@@ -305,7 +301,7 @@ func TestGetPR(t *testing.T) {
 				return tt.runnerOut, tt.runnerErr
 			}
 
-			client := NewGitHubClientWithRunner("/repo", runner)
+			client := NewPRCommandWithRunner("/repo", runner)
 			pr, err := client.GetPR(tt.prNumber)
 
 			if tt.wantErr {

--- a/internal/exec/github_test.go
+++ b/internal/exec/github_test.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/m00nk0d3/nexus/internal/domain"
@@ -128,6 +129,202 @@ func TestListOpenIssues_MapsDomainsCorrectly(t *testing.T) {
 
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, issues)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GitHubClient — PullRequest tests
+// ---------------------------------------------------------------------------
+
+func TestNewGitHubClient(t *testing.T) {
+	client := NewGitHubClient("/repo")
+	assert.NotNil(t, client)
+	assert.Equal(t, "/repo", client.repoPath)
+	assert.NotNil(t, client.runner)
+}
+
+func TestListOpenPRs(t *testing.T) {
+	const prFields = "number,title,headRefName,author,state,labels,isDraft"
+
+	twoPRsJSON := `[
+		{"number":1,"title":"Add login","headRefName":"feat/login","author":{"login":"alice"},"state":"OPEN","labels":[{"name":"enhancement"}],"isDraft":false},
+		{"number":2,"title":"WIP: refactor","headRefName":"chore/refactor","author":{"login":"bob"},"state":"OPEN","labels":[{"name":"wip"},{"name":"refactor"}],"isDraft":true}
+	]`
+
+	tests := []struct {
+		name        string
+		runnerOut   string
+		runnerErr   error
+		wantErr     bool
+		errContains string
+		wantPRs     []domain.PullRequest
+		checkArgs   bool
+	}{
+		{
+			name:      "valid JSON with 2 PRs maps correctly",
+			runnerOut: twoPRsJSON,
+			wantPRs: []domain.PullRequest{
+				{Number: 1, Title: "Add login", Branch: "feat/login", Author: "alice", State: "OPEN", Labels: []string{"enhancement"}, IsDraft: false},
+				{Number: 2, Title: "WIP: refactor", Branch: "chore/refactor", Author: "bob", State: "OPEN", Labels: []string{"wip", "refactor"}, IsDraft: true},
+			},
+		},
+		{
+			name:      "empty list returns empty slice",
+			runnerOut: "[]",
+			wantPRs:   []domain.PullRequest{},
+		},
+		{
+			name:        "runner error wraps with list open prs",
+			runnerErr:   errors.New("gh: auth required"),
+			wantErr:     true,
+			errContains: "list open prs",
+		},
+		{
+			name:        "invalid JSON returns parse pr list error",
+			runnerOut:   "not json",
+			wantErr:     true,
+			errContains: "parse pr list",
+		},
+		{
+			name:      "PR with no labels has empty (non-nil) Labels slice",
+			runnerOut: `[{"number":3,"title":"Hotfix","headRefName":"fix/hotfix","author":{"login":"carol"},"state":"OPEN","labels":[],"isDraft":false}]`,
+			wantPRs: []domain.PullRequest{
+				{Number: 3, Title: "Hotfix", Branch: "fix/hotfix", Author: "carol", State: "OPEN", Labels: []string{}, IsDraft: false},
+			},
+		},
+		{
+			name:      "isDraft false maps correctly",
+			runnerOut: `[{"number":4,"title":"Stable PR","headRefName":"feat/stable","author":{"login":"dave"},"state":"OPEN","labels":[],"isDraft":false}]`,
+			wantPRs: []domain.PullRequest{
+				{Number: 4, Title: "Stable PR", Branch: "feat/stable", Author: "dave", State: "OPEN", Labels: []string{}, IsDraft: false},
+			},
+		},
+		{
+			name:      "isDraft true maps correctly",
+			runnerOut: `[{"number":5,"title":"Draft PR","headRefName":"feat/draft","author":{"login":"eve"},"state":"OPEN","labels":[],"isDraft":true}]`,
+			wantPRs: []domain.PullRequest{
+				{Number: 5, Title: "Draft PR", Branch: "feat/draft", Author: "eve", State: "OPEN", Labels: []string{}, IsDraft: true},
+			},
+		},
+		{
+			name:      "correct gh args passed",
+			runnerOut: "[]",
+			checkArgs: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedArgs []string
+			runner := func(_ string, args ...string) (string, error) {
+				capturedArgs = args
+				return tt.runnerOut, tt.runnerErr
+			}
+
+			client := NewGitHubClientWithRunner("/repo", runner)
+			prs, err := client.ListOpenPRs()
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.checkArgs {
+				assert.Equal(t,
+					[]string{"pr", "list", "--json", prFields, "--state", "open"},
+					capturedArgs,
+				)
+				return
+			}
+
+			assert.Equal(t, tt.wantPRs, prs)
+		})
+	}
+}
+
+func TestGetPR(t *testing.T) {
+	const prFields = "number,title,headRefName,author,state,labels,isDraft"
+
+	validPRJSON := `{"number":42,"title":"Implement feature","headRefName":"feat/feature","author":{"login":"frank"},"state":"MERGED","labels":[{"name":"feature"}],"isDraft":false}`
+
+	tests := []struct {
+		name        string
+		prNumber    int
+		runnerOut   string
+		runnerErr   error
+		wantErr     bool
+		errContains string
+		wantPR      *domain.PullRequest
+		checkArgs   bool
+	}{
+		{
+			name:      "valid JSON single PR maps correctly",
+			prNumber:  42,
+			runnerOut: validPRJSON,
+			wantPR: &domain.PullRequest{
+				Number:  42,
+				Title:   "Implement feature",
+				Branch:  "feat/feature",
+				Author:  "frank",
+				State:   "MERGED",
+				Labels:  []string{"feature"},
+				IsDraft: false,
+			},
+		},
+		{
+			name:        "runner error wraps with get pr",
+			prNumber:    42,
+			runnerErr:   errors.New("gh: not found"),
+			wantErr:     true,
+			errContains: "get pr",
+		},
+		{
+			name:        "invalid JSON returns parse pr error",
+			prNumber:    42,
+			runnerOut:   "bad json",
+			wantErr:     true,
+			errContains: "parse pr",
+		},
+		{
+			name:      "correct gh args passed for pr 42",
+			prNumber:  42,
+			runnerOut: validPRJSON,
+			checkArgs: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedArgs []string
+			runner := func(_ string, args ...string) (string, error) {
+				capturedArgs = args
+				return tt.runnerOut, tt.runnerErr
+			}
+
+			client := NewGitHubClientWithRunner("/repo", runner)
+			pr, err := client.GetPR(tt.prNumber)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.checkArgs {
+				assert.Equal(t,
+					[]string{"pr", "view", fmt.Sprintf("%d", tt.prNumber), "--json", prFields},
+					capturedArgs,
+				)
+				return
+			}
+
+			assert.Equal(t, tt.wantPR, pr)
 		})
 	}
 }


### PR DESCRIPTION
Closes #8

## What Changed
Expands the `gh` CLI wrapper layer with a `GitHubClient` struct providing `ListOpenPRs()` and `GetPR()` methods for fetching PR data from GitHub.

## Why Changed
Phase 2 requires the app to display open PRs alongside issues. This client layer is the foundation for that UI feature.

## Changes
- `internal/domain/pr.go`: new `PullRequest` struct with Number, Title, Branch, Author, State, Labels, IsDraft
- `internal/exec/github.go`: `GitHubClient` with constructor pair, `ListOpenPRs()`, `GetPR()`, internal JSON structs, `ghPRToDomain()` helper, and `prFields` constant
- `internal/exec/github_test.go`: 12 new table-driven TDD tests covering args, JSON parsing, error propagation, and domain mapping

## Testing
- `go test ./internal/exec/... ./internal/domain/...` — all 37 existing + 12 new tests pass
- Table-driven tests cover: valid output, empty list, runner errors, invalid JSON, correct CLI args, label mapping, isDraft flag