### PR TITLE
feat(config): implement TOML config file parsing

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/data"
 	"github.com/m00nk0d3/nexus/internal/domain"
 	internalexec "github.com/m00nk0d3/nexus/internal/exec"
 	"github.com/m00nk0d3/nexus/internal/tui/modal"
@@ -34,6 +35,7 @@ type worktreeSwitchedMsg struct {
 type Model struct {
 	Worktrees   []domain.Worktree // List of available git worktrees
 	RepoPath    string            // Path to the repository root
+	Config      *domain.Config    // Loaded application configuration
 	selectedIdx int               // Currently selected worktree index
 	activeModal tea.Model         // Currently open modal (if any)
 	Error       string            // Error message to display (if any)
@@ -45,7 +47,23 @@ type Model struct {
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
 func NewModel() *Model {
-	return &Model{}
+	cfg, err := data.LoadConfig(data.DefaultConfigPath())
+	if err != nil {
+		cfg = domain.DefaultConfig()
+	}
+
+	themeIdx := 0
+	for i, name := range styles.Themes {
+		if name == cfg.Appearance.Theme {
+			themeIdx = i
+			break
+		}
+	}
+
+	return &Model{
+		Config:   cfg,
+		themeIdx: themeIdx,
+	}
 }
 
 // Init initializes the model and triggers an initial worktree list load.

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -48,8 +48,11 @@ type Model struct {
 // NewModel creates and returns a new Model instance with all required fields initialized.
 func NewModel() *Model {
 	cfg, err := data.LoadConfig(data.DefaultConfigPath())
+
+	var configErr string
 	if err != nil {
 		cfg = domain.DefaultConfig()
+		configErr = fmt.Sprintf("config load failed: %v", err)
 	}
 
 	themeIdx := 0
@@ -63,6 +66,7 @@ func NewModel() *Model {
 	return &Model{
 		Config:   cfg,
 		themeIdx: themeIdx,
+		Error:    configErr,
 	}
 }
 

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -37,6 +37,7 @@ func TestModelInitialization(t *testing.T) {
 				// Verify model can be cast to tea.Model (has required interface methods)
 				var _ tea.Model = model
 				assert.NotNil(t, model, "Model should implement tea.Model interface")
+				assert.NotNil(t, model.Config, "Config should be initialized (defaults at minimum)")
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.24.2
 require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
+	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/stretchr/testify v1.9.0
 )
 
@@ -12,7 +14,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/lipgloss v1.1.0 // indirect
 	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
@@ -28,7 +29,6 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
+	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELU
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc=
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
+github.com/pelletier/go-toml/v2 v2.3.1 h1:MYEvvGnQjeNkRF1qUuGolNtNExTDwct51yp7olPtrEc=
+github.com/pelletier/go-toml/v2 v2.3.1/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/internal/data/config.go
+++ b/internal/data/config.go
@@ -10,15 +10,19 @@ import (
 )
 
 // DefaultConfigPath returns the default path to the Nexus config file.
+// Falls back to the current directory if the home directory cannot be determined.
 func DefaultConfigPath() string {
-	home, _ := os.UserHomeDir()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
 	return filepath.Join(home, ".nexus", "config.toml")
 }
 
 // LoadConfig reads and parses the TOML config at path.
 // If the file does not exist, it returns the default config.
 func LoadConfig(path string) (*domain.Config, error) {
-	data, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return domain.DefaultConfig(), nil
@@ -27,7 +31,7 @@ func LoadConfig(path string) (*domain.Config, error) {
 	}
 
 	var cfg domain.Config
-	if err := toml.Unmarshal(data, &cfg); err != nil {
+	if err := toml.Unmarshal(raw, &cfg); err != nil {
 		return nil, fmt.Errorf("parse config: %w", err)
 	}
 
@@ -40,12 +44,12 @@ func SaveConfig(cfg *domain.Config, path string) error {
 		return fmt.Errorf("create config dir: %w", err)
 	}
 
-	data, err := toml.Marshal(cfg)
+	b, err := toml.Marshal(cfg)
 	if err != nil {
 		return fmt.Errorf("marshal config: %w", err)
 	}
 
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := os.WriteFile(path, b, 0o644); err != nil {
 		return fmt.Errorf("write config: %w", err)
 	}
 

--- a/internal/data/config.go
+++ b/internal/data/config.go
@@ -1,0 +1,53 @@
+package data
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/pelletier/go-toml/v2"
+)
+
+// DefaultConfigPath returns the default path to the Nexus config file.
+func DefaultConfigPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".nexus", "config.toml")
+}
+
+// LoadConfig reads and parses the TOML config at path.
+// If the file does not exist, it returns the default config.
+func LoadConfig(path string) (*domain.Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return domain.DefaultConfig(), nil
+		}
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+
+	var cfg domain.Config
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// SaveConfig marshals cfg to TOML and writes it to path, creating parent directories as needed.
+func SaveConfig(cfg *domain.Config, path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	data, err := toml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+
+	return nil
+}

--- a/internal/data/config_test.go
+++ b/internal/data/config_test.go
@@ -1,0 +1,177 @@
+package data
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// validTOML is a well-formed config file covering all sections.
+const validTOML = `
+[github]
+auto_sync = false
+sync_interval_minutes = 10
+
+[appearance]
+theme = "dark-mode"
+
+[ai_agents]
+copilot_enabled = true
+claude_enabled  = false
+aider_enabled   = true
+claude_binary   = "/usr/local/bin/claude"
+
+[worktrees]
+base_branch   = "develop"
+worktree_root = "/tmp/wt"
+`
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T) string // returns path to pass to LoadConfig
+		wantErr   bool
+		wantCheck func(t *testing.T, cfg *domain.Config)
+	}{
+		{
+			name: "valid TOML returns parsed config",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				path := filepath.Join(dir, "config.toml")
+				require.NoError(t, os.WriteFile(path, []byte(validTOML), 0o644))
+				return path
+			},
+			wantErr: false,
+			wantCheck: func(t *testing.T, cfg *domain.Config) {
+				t.Helper()
+				assert.Equal(t, false, cfg.GitHub.AutoSync)
+				assert.Equal(t, 10, cfg.GitHub.SyncIntervalMinutes)
+				assert.Equal(t, "dark-mode", cfg.Appearance.Theme)
+				assert.Equal(t, true, cfg.AIAgents.CopilotEnabled)
+				assert.Equal(t, false, cfg.AIAgents.ClaudeEnabled)
+				assert.Equal(t, true, cfg.AIAgents.AiderEnabled)
+				assert.Equal(t, "/usr/local/bin/claude", cfg.AIAgents.ClaudeBinary)
+				assert.Equal(t, "develop", cfg.Worktrees.BaseBranch)
+				assert.Equal(t, "/tmp/wt", cfg.Worktrees.WorktreeRoot)
+			},
+		},
+		{
+			name: "missing file returns default config",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				// Return a path that does not exist.
+				return filepath.Join(t.TempDir(), "nonexistent", "config.toml")
+			},
+			wantErr: false,
+			wantCheck: func(t *testing.T, cfg *domain.Config) {
+				t.Helper()
+				defaults := domain.DefaultConfig()
+				assert.Equal(t, defaults.Appearance.Theme, cfg.Appearance.Theme)
+				assert.Equal(t, defaults.Worktrees.BaseBranch, cfg.Worktrees.BaseBranch)
+				assert.Equal(t, defaults.Worktrees.WorktreeRoot, cfg.Worktrees.WorktreeRoot)
+				assert.Equal(t, defaults.GitHub.AutoSync, cfg.GitHub.AutoSync)
+				assert.Equal(t, defaults.GitHub.SyncIntervalMinutes, cfg.GitHub.SyncIntervalMinutes)
+			},
+		},
+		{
+			name: "invalid TOML returns error",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				path := filepath.Join(dir, "config.toml")
+				require.NoError(t, os.WriteFile(path, []byte("[[[[not valid toml"), 0o644))
+				return path
+			},
+			wantErr: true,
+			wantCheck: func(t *testing.T, cfg *domain.Config) {
+				// cfg should be nil on error — nothing to check.
+				assert.Nil(t, cfg)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.setup(t)
+			cfg, err := LoadConfig(path)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, cfg)
+			}
+			tt.wantCheck(t, cfg)
+		})
+	}
+}
+
+func TestSaveConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) (cfg *domain.Config, path string)
+	}{
+		{
+			name: "SaveConfig creates file and round-trips via LoadConfig",
+			setup: func(t *testing.T) (*domain.Config, string) {
+				t.Helper()
+				dir := t.TempDir()
+				cfg := &domain.Config{
+					GitHub: domain.GitHubConfig{
+						AutoSync:            true,
+						SyncIntervalMinutes: 15,
+					},
+					Appearance: domain.AppearanceConfig{Theme: "digital-noir"},
+					AIAgents: domain.AIAgentsConfig{
+						CopilotEnabled: true,
+						ClaudeEnabled:  true,
+						AiderEnabled:   false,
+						ClaudeBinary:   "claude",
+					},
+					Worktrees: domain.WorktreesConfig{
+						BaseBranch:   "main",
+						WorktreeRoot: "../worktrees",
+					},
+				}
+				return cfg, filepath.Join(dir, "config.toml")
+			},
+		},
+		{
+			name: "SaveConfig creates directory if it does not exist",
+			setup: func(t *testing.T) (*domain.Config, string) {
+				t.Helper()
+				// Nest two levels deep — neither exists yet.
+				dir := filepath.Join(t.TempDir(), "new-parent", ".nexus")
+				cfg := domain.DefaultConfig()
+				return cfg, filepath.Join(dir, "config.toml")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, path := tt.setup(t)
+
+			err := SaveConfig(cfg, path)
+			require.NoError(t, err)
+
+			// File must exist after SaveConfig.
+			_, statErr := os.Stat(path)
+			require.NoError(t, statErr, "expected file to exist at %s", path)
+
+			// Round-trip: reload and verify a representative field.
+			loaded, err := LoadConfig(path)
+			require.NoError(t, err)
+			require.NotNil(t, loaded)
+			assert.Equal(t, cfg.Appearance.Theme, loaded.Appearance.Theme)
+			assert.Equal(t, cfg.Worktrees.BaseBranch, loaded.Worktrees.BaseBranch)
+			assert.Equal(t, cfg.GitHub.SyncIntervalMinutes, loaded.GitHub.SyncIntervalMinutes)
+			assert.Equal(t, cfg.AIAgents.CopilotEnabled, loaded.AIAgents.CopilotEnabled)
+			assert.Equal(t, cfg.AIAgents.ClaudeBinary, loaded.AIAgents.ClaudeBinary)
+		})
+	}
+}

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -1,0 +1,37 @@
+package domain
+
+type Config struct {
+	GitHub     GitHubConfig     `toml:"github"`
+	Appearance AppearanceConfig `toml:"appearance"`
+	AIAgents   AIAgentsConfig   `toml:"ai_agents"`
+	Worktrees  WorktreesConfig  `toml:"worktrees"`
+}
+
+type GitHubConfig struct {
+	AutoSync            bool `toml:"auto_sync"`
+	SyncIntervalMinutes int  `toml:"sync_interval_minutes"`
+}
+
+type AppearanceConfig struct {
+	Theme string `toml:"theme"`
+}
+
+type AIAgentsConfig struct {
+	CopilotEnabled bool   `toml:"copilot_enabled"`
+	ClaudeEnabled  bool   `toml:"claude_enabled"`
+	AiderEnabled   bool   `toml:"aider_enabled"`
+	ClaudeBinary   string `toml:"claude_binary"`
+}
+
+type WorktreesConfig struct {
+	BaseBranch   string `toml:"base_branch"`
+	WorktreeRoot string `toml:"worktree_root"`
+}
+
+func DefaultConfig() *Config {
+	return &Config{
+		Appearance: AppearanceConfig{Theme: "digital-noir"},
+		Worktrees:  WorktreesConfig{BaseBranch: "main", WorktreeRoot: "../worktrees"},
+		GitHub:     GitHubConfig{AutoSync: true, SyncIntervalMinutes: 5},
+	}
+}


### PR DESCRIPTION
Closes #9

## What Changed
Implements TOML config file parsing for `~/.nexus/config.toml`. Nexus now reads user preferences (theme, GitHub sync settings, AI agent paths, worktree root) on startup.

## Why Changed
Without persistent config, all settings were hardcoded — no way for users to customize their experience. This lays the foundation for the settings screen (issue #25).

## Changes
- `internal/domain/config.go`: `Config` struct with TOML tags and `DefaultConfig()` with sane defaults
- `internal/data/config.go`: `LoadConfig(path)` (missing file → defaults, no error) and `SaveConfig(cfg, path)` (creates dir if needed)
- `cmd/nexus/app.go`: config loaded on startup, `themeIdx` wired from `Config.Appearance.Theme`
- `go.mod`: added `github.com/pelletier/go-toml/v2`

## Testing
- 5 table-driven tests covering: valid TOML, missing file → defaults, invalid TOML → error, SaveConfig round-trip, SaveConfig creates directory
- `go test ./...` — all 7 packages pass