### PR TITLE
feat(data): implement GitHub data cache with SQLite (#11)

### DIFF
--- a/internal/data/github_repo.go
+++ b/internal/data/github_repo.go
@@ -1,0 +1,166 @@
+package data
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/m00nk0d3/nexus/internal/exec"
+)
+
+// GitHubRepository persists and retrieves GitHub PR and Issue data from SQLite.
+type GitHubRepository struct {
+	db *DB
+}
+
+// NewGitHubRepository creates a new GitHubRepository backed by the given DB.
+func NewGitHubRepository(db *DB) *GitHubRepository {
+	return &GitHubRepository{db: db}
+}
+
+// UpsertPRs inserts or replaces all provided pull requests in the cache.
+func (r *GitHubRepository) UpsertPRs(prs []domain.PullRequest) error {
+	for _, pr := range prs {
+		labels, err := json.Marshal(pr.Labels)
+		if err != nil {
+			return fmt.Errorf("upsert prs: marshal labels for pr %d: %w", pr.Number, err)
+		}
+
+		_, err = r.db.Conn.Exec(`
+			INSERT INTO github_prs (number, title, branch, author, state, is_draft, labels, synced_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+			ON CONFLICT(number) DO UPDATE SET
+				title     = excluded.title,
+				branch    = excluded.branch,
+				author    = excluded.author,
+				state     = excluded.state,
+				is_draft  = excluded.is_draft,
+				labels    = excluded.labels,
+				synced_at = CURRENT_TIMESTAMP
+		`, pr.Number, pr.Title, pr.Branch, pr.Author, pr.State, pr.IsDraft, string(labels))
+		if err != nil {
+			return fmt.Errorf("upsert prs: %w", err)
+		}
+	}
+	return nil
+}
+
+// GetPRs returns all cached pull requests from the database.
+func (r *GitHubRepository) GetPRs() ([]domain.PullRequest, error) {
+	rows, err := r.db.Conn.Query(`
+		SELECT number, title, branch, author, state, is_draft, labels
+		FROM github_prs
+		ORDER BY number
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("get prs: %w", err)
+	}
+	defer rows.Close()
+
+	var prs []domain.PullRequest
+	for rows.Next() {
+		var pr domain.PullRequest
+		var labelsJSON string
+		var isDraftInt int
+
+		if err := rows.Scan(&pr.Number, &pr.Title, &pr.Branch, &pr.Author, &pr.State, &isDraftInt, &labelsJSON); err != nil {
+			return nil, fmt.Errorf("get prs: scan row: %w", err)
+		}
+
+		pr.IsDraft = isDraftInt != 0
+
+		if err := json.Unmarshal([]byte(labelsJSON), &pr.Labels); err != nil {
+			return nil, fmt.Errorf("get prs: parse labels for pr %d: %w", pr.Number, err)
+		}
+
+		prs = append(prs, pr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("get prs: rows error: %w", err)
+	}
+
+	if prs == nil {
+		prs = []domain.PullRequest{}
+	}
+	return prs, nil
+}
+
+// UpsertIssues inserts or replaces all provided issues in the cache.
+func (r *GitHubRepository) UpsertIssues(issues []domain.Issue) error {
+	for _, issue := range issues {
+		labels, err := json.Marshal(issue.Labels)
+		if err != nil {
+			return fmt.Errorf("upsert issues: marshal labels for issue %d: %w", issue.Number, err)
+		}
+
+		_, err = r.db.Conn.Exec(`
+			INSERT INTO github_issues (number, title, state, labels, synced_at)
+			VALUES (?, ?, '', ?, CURRENT_TIMESTAMP)
+			ON CONFLICT(number) DO UPDATE SET
+				title     = excluded.title,
+				labels    = excluded.labels,
+				synced_at = CURRENT_TIMESTAMP
+		`, issue.Number, issue.Title, string(labels))
+		if err != nil {
+			return fmt.Errorf("upsert issues: %w", err)
+		}
+	}
+	return nil
+}
+
+// GetIssues returns all cached issues from the database.
+func (r *GitHubRepository) GetIssues() ([]domain.Issue, error) {
+	rows, err := r.db.Conn.Query(`
+		SELECT number, title, labels
+		FROM github_issues
+		ORDER BY number
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("get issues: %w", err)
+	}
+	defer rows.Close()
+
+	var issues []domain.Issue
+	for rows.Next() {
+		var issue domain.Issue
+		var labelsJSON string
+
+		if err := rows.Scan(&issue.Number, &issue.Title, &labelsJSON); err != nil {
+			return nil, fmt.Errorf("get issues: scan row: %w", err)
+		}
+
+		if err := json.Unmarshal([]byte(labelsJSON), &issue.Labels); err != nil {
+			return nil, fmt.Errorf("get issues: parse labels for issue %d: %w", issue.Number, err)
+		}
+
+		issues = append(issues, issue)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("get issues: rows error: %w", err)
+	}
+
+	if issues == nil {
+		issues = []domain.Issue{}
+	}
+	return issues, nil
+}
+
+// SyncPRs fetches open PRs from GitHub via the client and upserts them into the cache.
+// On CLI error, the existing cached data is preserved and the error is returned.
+func (r *GitHubRepository) SyncPRs(client *exec.PRCommand) error {
+	prs, err := client.ListOpenPRs()
+	if err != nil {
+		return fmt.Errorf("sync prs: %w", err)
+	}
+	return r.UpsertPRs(prs)
+}
+
+// SyncIssues fetches open issues from GitHub via the client and upserts them into the cache.
+// On CLI error, the existing cached data is preserved and the error is returned.
+func (r *GitHubRepository) SyncIssues(client *exec.IssueCommand) error {
+	issues, err := client.ListOpenIssues()
+	if err != nil {
+		return fmt.Errorf("sync issues: %w", err)
+	}
+	return r.UpsertIssues(issues)
+}

--- a/internal/data/github_repo_test.go
+++ b/internal/data/github_repo_test.go
@@ -1,0 +1,266 @@
+package data
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/m00nk0d3/nexus/internal/exec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestDB returns an in-memory SQLite DB with the full schema applied.
+func newTestDB(t *testing.T) *DB {
+	t.Helper()
+	db, err := NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+// ---------------------------------------------------------------------------
+// PR tests
+// ---------------------------------------------------------------------------
+
+func TestGitHubRepository_GetPRs_EmptyDB(t *testing.T) {
+	repo := NewGitHubRepository(newTestDB(t))
+
+	prs, err := repo.GetPRs()
+
+	require.NoError(t, err)
+	assert.Empty(t, prs)
+}
+
+func TestGitHubRepository_UpsertAndGetPRs(t *testing.T) {
+	repo := NewGitHubRepository(newTestDB(t))
+
+	input := []domain.PullRequest{
+		{Number: 1, Title: "Add login", Branch: "feat/login", Author: "alice", State: "OPEN", Labels: []string{"enhancement"}, IsDraft: false},
+		{Number: 2, Title: "WIP: refactor", Branch: "chore/refactor", Author: "bob", State: "OPEN", Labels: []string{"wip", "refactor"}, IsDraft: true},
+	}
+
+	err := repo.UpsertPRs(input)
+	require.NoError(t, err)
+
+	prs, err := repo.GetPRs()
+	require.NoError(t, err)
+	require.Len(t, prs, 2)
+
+	// Sort by number for deterministic comparison.
+	byNumber := func(slice []domain.PullRequest) map[int]domain.PullRequest {
+		m := make(map[int]domain.PullRequest)
+		for _, p := range slice {
+			m[p.Number] = p
+		}
+		return m
+	}
+
+	got := byNumber(prs)
+	assert.Equal(t, input[0], got[1])
+	assert.Equal(t, input[1], got[2])
+}
+
+func TestGitHubRepository_UpsertPRs_UpdatesExisting(t *testing.T) {
+	repo := NewGitHubRepository(newTestDB(t))
+
+	original := []domain.PullRequest{
+		{Number: 1, Title: "Original title", Branch: "feat/original", Author: "alice", State: "OPEN", Labels: []string{}, IsDraft: false},
+	}
+	require.NoError(t, repo.UpsertPRs(original))
+
+	updated := []domain.PullRequest{
+		{Number: 1, Title: "Updated title", Branch: "feat/original", Author: "alice", State: "MERGED", Labels: []string{"done"}, IsDraft: false},
+	}
+	require.NoError(t, repo.UpsertPRs(updated))
+
+	prs, err := repo.GetPRs()
+	require.NoError(t, err)
+	require.Len(t, prs, 1)
+	assert.Equal(t, "Updated title", prs[0].Title)
+	assert.Equal(t, "MERGED", prs[0].State)
+	assert.Equal(t, []string{"done"}, prs[0].Labels)
+}
+
+// ---------------------------------------------------------------------------
+// Issue tests
+// ---------------------------------------------------------------------------
+
+func TestGitHubRepository_GetIssues_EmptyDB(t *testing.T) {
+	repo := NewGitHubRepository(newTestDB(t))
+
+	issues, err := repo.GetIssues()
+
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+}
+
+func TestGitHubRepository_UpsertAndGetIssues(t *testing.T) {
+	repo := NewGitHubRepository(newTestDB(t))
+
+	input := []domain.Issue{
+		{Number: 10, Title: "Fix the bug", Labels: []string{"bug"}},
+		{Number: 11, Title: "Add a feature", Labels: []string{"enhancement", "phase-1"}},
+	}
+
+	require.NoError(t, repo.UpsertIssues(input))
+
+	issues, err := repo.GetIssues()
+	require.NoError(t, err)
+	require.Len(t, issues, 2)
+
+	byNumber := func(slice []domain.Issue) map[int]domain.Issue {
+		m := make(map[int]domain.Issue)
+		for _, i := range slice {
+			m[i.Number] = i
+		}
+		return m
+	}
+
+	got := byNumber(issues)
+	assert.Equal(t, input[0], got[10])
+	assert.Equal(t, input[1], got[11])
+}
+
+func TestGitHubRepository_UpsertIssues_UpdatesExisting(t *testing.T) {
+	repo := NewGitHubRepository(newTestDB(t))
+
+	original := []domain.Issue{
+		{Number: 5, Title: "Original issue", Labels: []string{"bug"}},
+	}
+	require.NoError(t, repo.UpsertIssues(original))
+
+	updated := []domain.Issue{
+		{Number: 5, Title: "Updated issue title", Labels: []string{"bug", "priority-high"}},
+	}
+	require.NoError(t, repo.UpsertIssues(updated))
+
+	issues, err := repo.GetIssues()
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, "Updated issue title", issues[0].Title)
+	assert.Equal(t, []string{"bug", "priority-high"}, issues[0].Labels)
+}
+
+// ---------------------------------------------------------------------------
+// Sync tests
+// ---------------------------------------------------------------------------
+
+func TestGitHubRepository_SyncPRs_Success(t *testing.T) {
+	repo := NewGitHubRepository(newTestDB(t))
+
+	rawJSON := `[
+		{"number":1,"title":"Add login","headRefName":"feat/login","author":{"login":"alice"},"state":"OPEN","labels":[{"name":"enhancement"}],"isDraft":false},
+		{"number":2,"title":"WIP: refactor","headRefName":"chore/refactor","author":{"login":"bob"},"state":"OPEN","labels":[{"name":"wip"}],"isDraft":true}
+	]`
+	mockRunner := func(_ string, _ ...string) (string, error) {
+		return rawJSON, nil
+	}
+	client := exec.NewPRCommandWithRunner("/repo", mockRunner)
+
+	err := repo.SyncPRs(client)
+	require.NoError(t, err)
+
+	prs, err := repo.GetPRs()
+	require.NoError(t, err)
+	require.Len(t, prs, 2)
+
+	byNumber := func(slice []domain.PullRequest) map[int]domain.PullRequest {
+		m := make(map[int]domain.PullRequest)
+		for _, p := range slice {
+			m[p.Number] = p
+		}
+		return m
+	}
+	got := byNumber(prs)
+	assert.Equal(t, "Add login", got[1].Title)
+	assert.Equal(t, "alice", got[1].Author)
+	assert.Equal(t, []string{"enhancement"}, got[1].Labels)
+	assert.Equal(t, true, got[2].IsDraft)
+}
+
+func TestGitHubRepository_SyncPRs_CLIError_PreservesCachedData(t *testing.T) {
+	repo := NewGitHubRepository(newTestDB(t))
+
+	// Pre-load cache with one PR.
+	cached := []domain.PullRequest{
+		{Number: 99, Title: "Cached PR", Branch: "feat/cached", Author: "carol", State: "OPEN", Labels: []string{}, IsDraft: false},
+	}
+	require.NoError(t, repo.UpsertPRs(cached))
+
+	// SyncPRs with a runner that always fails.
+	failRunner := func(_ string, _ ...string) (string, error) {
+		return "", errors.New("gh: network error")
+	}
+	client := exec.NewPRCommandWithRunner("/repo", failRunner)
+
+	err := repo.SyncPRs(client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network error")
+
+	// Cached data must still be there.
+	prs, err := repo.GetPRs()
+	require.NoError(t, err)
+	require.Len(t, prs, 1)
+	assert.Equal(t, 99, prs[0].Number)
+	assert.Equal(t, "Cached PR", prs[0].Title)
+}
+
+func TestGitHubRepository_SyncIssues_Success(t *testing.T) {
+	repo := NewGitHubRepository(newTestDB(t))
+
+	rawJSON := `[
+		{"number":10,"title":"Fix the bug","labels":[{"name":"bug"}]},
+		{"number":11,"title":"Add a feature","labels":[{"name":"enhancement"}]}
+	]`
+	mockRunner := func(_ string, _ ...string) (string, error) {
+		return rawJSON, nil
+	}
+	client := exec.NewIssueCommandWithRunner("/repo", mockRunner)
+
+	err := repo.SyncIssues(client)
+	require.NoError(t, err)
+
+	issues, err := repo.GetIssues()
+	require.NoError(t, err)
+	require.Len(t, issues, 2)
+
+	byNumber := func(slice []domain.Issue) map[int]domain.Issue {
+		m := make(map[int]domain.Issue)
+		for _, i := range slice {
+			m[i.Number] = i
+		}
+		return m
+	}
+	got := byNumber(issues)
+	assert.Equal(t, "Fix the bug", got[10].Title)
+	assert.Equal(t, []string{"bug"}, got[10].Labels)
+	assert.Equal(t, "Add a feature", got[11].Title)
+}
+
+func TestGitHubRepository_SyncIssues_CLIError_PreservesCachedData(t *testing.T) {
+	repo := NewGitHubRepository(newTestDB(t))
+
+	// Pre-load cache with one issue.
+	cached := []domain.Issue{
+		{Number: 42, Title: "Cached issue", Labels: []string{"cached"}},
+	}
+	require.NoError(t, repo.UpsertIssues(cached))
+
+	// SyncIssues with a runner that always fails.
+	failRunner := func(_ string, _ ...string) (string, error) {
+		return "", errors.New("gh: auth required")
+	}
+	client := exec.NewIssueCommandWithRunner("/repo", failRunner)
+
+	err := repo.SyncIssues(client)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth required")
+
+	// Cached data must still be there.
+	issues, err := repo.GetIssues()
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, 42, issues[0].Number)
+	assert.Equal(t, "Cached issue", issues[0].Title)
+}

--- a/internal/exec/github.go
+++ b/internal/exec/github.go
@@ -27,7 +27,7 @@ func NewIssueCommandWithRunner(repoPath string, runner commandRunner) *IssueComm
 
 // ListOpenIssues returns all open GitHub issues via `gh issue list`.
 func (c *IssueCommand) ListOpenIssues() ([]domain.Issue, error) {
-	output, err := c.runner(c.repoPath, "issue", "list", "--json", "number,title,labels", "--state", "open")
+	output, err := c.runner(c.repoPath, "issue", "list", "--json", "number,title,labels", "--state", "open", "--limit", "100")
 	if err != nil {
 		return nil, fmt.Errorf("list open issues: %w", err)
 	}
@@ -94,7 +94,7 @@ const prFields = "number,title,headRefName,author,state,labels,isDraft"
 
 // ListOpenPRs returns all open pull requests via `gh pr list`.
 func (c *PRCommand) ListOpenPRs() ([]domain.PullRequest, error) {
-	output, err := c.runner(c.repoPath, "pr", "list", "--json", prFields, "--state", "open")
+	output, err := c.runner(c.repoPath, "pr", "list", "--json", prFields, "--state", "open", "--limit", "100")
 	if err != nil {
 		return nil, fmt.Errorf("list open prs: %w", err)
 	}

--- a/internal/exec/github_test.go
+++ b/internal/exec/github_test.go
@@ -102,7 +102,7 @@ func TestListOpenIssues_PassesCorrectArgs(t *testing.T) {
 	_, err := cmd.ListOpenIssues()
 
 	require.NoError(t, err)
-	assert.Equal(t, []string{"issue", "list", "--json", "number,title,labels", "--state", "open"}, capturedArgs)
+	assert.Equal(t, []string{"issue", "list", "--json", "number,title,labels", "--state", "open", "--limit", "100"}, capturedArgs)
 }
 
 func TestListOpenIssues_MapsDomainsCorrectly(t *testing.T) {
@@ -233,7 +233,7 @@ func TestListOpenPRs(t *testing.T) {
 
 			if tt.checkArgs {
 				assert.Equal(t,
-					[]string{"pr", "list", "--json", prFields, "--state", "open"},
+					[]string{"pr", "list", "--json", prFields, "--state", "open", "--limit", "100"},
 					capturedArgs,
 				)
 				return


### PR DESCRIPTION
Closes #11

## What Changed
Adds `GitHubRepository` in `internal/data/` with full upsert/query methods for PRs and Issues, backed by the existing SQLite schema. Sync methods delegate to the `exec` layer CLI commands.

## Why Changed
Issue #11 requires a repository-style data access layer that:
- Serves cached data from SQLite (offline-first)
- Refreshes via `gh` CLI on sync
- Preserves stale cache when CLI calls fail

## Changes
- `internal/data/github_repo.go`: `GitHubRepository` with `UpsertPRs`, `GetPRs`, `UpsertIssues`, `GetIssues`, `SyncPRs`, `SyncIssues`
- `internal/data/github_repo_test.go`: 10 integration tests with `:memory:` SQLite
- `internal/exec/github.go`: added `--limit 100` to `ListOpenPRs` and `ListOpenIssues`
- `internal/exec/github_test.go`: updated arg assertions for `--limit 100`

## Testing
- `go test ./internal/... -v` — all tests pass
- `go build ./...` — clean build
- Stale cache preservation tested: CLI error does not wipe cached data