### PR TITLE
feat(app): add background GitHub sync goroutine

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -181,6 +182,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.issues = msg.issues
 			m.lastSynced = msg.syncedAt
 		}
+		// On error, m.prs and m.issues intentionally retain their previous values
+		// so the UI continues to show the last known good data.
 		// Schedule next periodic sync tick.
 		return m, tea.Tick(m.Config.GitHub.SyncInterval(), func(t time.Time) tea.Msg {
 			return syncTickMsg{}
@@ -233,11 +236,7 @@ func (m *Model) syncGitHubCmd() tea.Cmd {
 		prCmd := internalexec.NewPRCommand(repoPath)
 		issues, issErr := issueCmd.ListOpenIssues()
 		prs, prErr := prCmd.ListOpenPRs()
-		err := issErr
-		if err == nil {
-			err = prErr
-		}
-		return githubSyncedMsg{prs: prs, issues: issues, err: err, syncedAt: time.Now()}
+		return githubSyncedMsg{prs: prs, issues: issues, err: errors.Join(issErr, prErr), syncedAt: time.Now()}
 	}
 }
 

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/m00nk0d3/nexus/internal/data"
@@ -30,6 +31,17 @@ type worktreeSwitchedMsg struct {
 	err error // Error during switch, if any
 }
 
+// githubSyncedMsg carries the result of a background GitHub PR/issue sync.
+type githubSyncedMsg struct {
+	prs      []domain.PullRequest
+	issues   []domain.Issue
+	err      error
+	syncedAt time.Time
+}
+
+// syncTickMsg triggers the next periodic GitHub sync.
+type syncTickMsg struct{}
+
 // Model represents the root Bubbletea model for the Nexus TUI application.
 // It manages the list of git worktrees, user interactions, and active modals.
 type Model struct {
@@ -43,6 +55,11 @@ type Model struct {
 	activeNav   int               // Index of the active nav rail section (0=W,1=I,2=P,3=T)
 	width       int               // Terminal width in columns; 0 means use default
 	height      int               // Terminal height in rows; 0 means use default
+	prs         []domain.PullRequest // Latest synced pull requests
+	issues      []domain.Issue       // Latest synced issues
+	lastSynced  time.Time            // When the last successful GitHub sync completed
+	syncErr     error                // Error from the most recent GitHub sync attempt
+	syncing     bool                 // True while a background GitHub sync is in progress
 }
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
@@ -70,9 +87,10 @@ func NewModel() *Model {
 	}
 }
 
-// Init initializes the model and triggers an initial worktree list load.
+// Init initializes the model and triggers an initial worktree list load and GitHub sync.
 func (m *Model) Init() tea.Cmd {
-	return m.refreshWorktreesCmd()
+	m.syncing = true
+	return tea.Batch(m.refreshWorktreesCmd(), m.syncGitHubCmd())
 }
 
 // Update handles incoming messages and returns an updated model and command.
@@ -155,6 +173,23 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+	case githubSyncedMsg:
+		m.syncing = false
+		m.syncErr = msg.err
+		if msg.err == nil {
+			m.prs = msg.prs
+			m.issues = msg.issues
+			m.lastSynced = msg.syncedAt
+		}
+		// Schedule next periodic sync tick.
+		return m, tea.Tick(m.Config.GitHub.SyncInterval(), func(t time.Time) tea.Msg {
+			return syncTickMsg{}
+		})
+
+	case syncTickMsg:
+		m.syncing = true
+		return m, m.syncGitHubCmd()
+
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
@@ -169,7 +204,7 @@ func (m *Model) View() string {
 	if m.activeModal != nil {
 		baseView = m.activeModal.View()
 	} else {
-		baseView = renderFull(m.Worktrees, m.selectedIdx, m.RepoPath, m.themeIdx, m.activeNav, m.width, m.height)
+		baseView = renderFull(m.Worktrees, m.selectedIdx, m.RepoPath, m.themeIdx, m.activeNav, m.width, m.height, m.syncing, m.lastSynced, m.syncErr)
 	}
 
 	if m.Error == "" {
@@ -187,6 +222,22 @@ func (m *Model) fetchIssuesCmd() tea.Cmd {
 		cmd := internalexec.NewIssueCommand(repoPath)
 		issues, err := cmd.ListOpenIssues()
 		return issuesFetchedMsg{issues: issues, err: err}
+	}
+}
+
+// syncGitHubCmd returns a Cmd that fetches open PRs and issues from GitHub in the background.
+func (m *Model) syncGitHubCmd() tea.Cmd {
+	repoPath := m.RepoPath
+	return func() tea.Msg {
+		issueCmd := internalexec.NewIssueCommand(repoPath)
+		prCmd := internalexec.NewPRCommand(repoPath)
+		issues, issErr := issueCmd.ListOpenIssues()
+		prs, prErr := prCmd.ListOpenPRs()
+		err := issErr
+		if err == nil {
+			err = prErr
+		}
+		return githubSyncedMsg{prs: prs, issues: issues, err: err, syncedAt: time.Now()}
 	}
 }
 

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/m00nk0d3/nexus/internal/domain"
@@ -510,6 +511,103 @@ func TestModel_T_KeyCyclesTheme(t *testing.T) {
 			assert.Equal(t, tt.wantThemeIdx, model.themeIdx)
 		})
 	}
+}
+
+// TestModel_Init_ReturnsSyncCmd verifies that Init() returns a non-nil Cmd,
+// meaning it schedules the initial background GitHub sync in addition to
+// refreshing the worktree list.
+func TestModel_Init_ReturnsSyncCmd(t *testing.T) {
+	model := NewModel()
+	require.NotNil(t, model)
+
+	cmd := model.Init()
+
+	assert.NotNil(t, cmd, "Init() must return a Cmd to trigger GitHub sync")
+}
+
+// TestModel_GithubSyncedMsg_StoresPRsAndIssues verifies that receiving a
+// githubSyncedMsg via Update() correctly stores the synced data into the model.
+func TestModel_GithubSyncedMsg_StoresPRsAndIssues(t *testing.T) {
+	tests := []struct {
+		name            string
+		msg             githubSyncedMsg
+		wantPRLen       int
+		wantPRNumber    int
+		wantIssueLen    int
+		wantIssueNumber int
+		wantLastSynced  bool
+		wantSyncErr     string
+		wantSyncing     bool
+	}{
+		{
+			name: "stores prs and issues from sync message",
+			msg: githubSyncedMsg{
+				prs:      []domain.PullRequest{{Number: 42}},
+				issues:   []domain.Issue{{Number: 7}},
+				syncedAt: time.Now(),
+			},
+			wantPRLen:       1,
+			wantPRNumber:    42,
+			wantIssueLen:    1,
+			wantIssueNumber: 7,
+			wantLastSynced:  true,
+			wantSyncing:     false,
+		},
+		{
+			name:        "stores sync error without crashing",
+			msg:         githubSyncedMsg{err: errors.New("api down")},
+			wantSyncErr: "api down",
+			wantSyncing: false,
+		},
+		{
+			name:        "sets syncing=false after sync completes",
+			msg:         githubSyncedMsg{prs: nil, issues: nil},
+			wantSyncing: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+
+			updated, _ := model.Update(tt.msg)
+			m, ok := updated.(*Model)
+			require.True(t, ok, "Update must return *Model")
+
+			if tt.wantPRLen > 0 {
+				require.Len(t, m.prs, tt.wantPRLen, "prs slice length mismatch")
+				assert.Equal(t, tt.wantPRNumber, m.prs[0].Number, "PR number mismatch")
+			}
+
+			if tt.wantIssueLen > 0 {
+				require.Len(t, m.issues, tt.wantIssueLen, "issues slice length mismatch")
+				assert.Equal(t, tt.wantIssueNumber, m.issues[0].Number, "issue number mismatch")
+			}
+
+			if tt.wantLastSynced {
+				assert.False(t, m.lastSynced.IsZero(), "lastSynced must be set to a non-zero time")
+			}
+
+			if tt.wantSyncErr != "" {
+				require.NotNil(t, m.syncErr, "syncErr must not be nil")
+				assert.Contains(t, m.syncErr.Error(), tt.wantSyncErr, "syncErr message mismatch")
+			}
+
+			assert.Equal(t, tt.wantSyncing, m.syncing, "syncing flag mismatch")
+		})
+	}
+}
+
+// TestModel_SyncTickMsg_TriggersSyncCmd verifies that receiving a syncTickMsg
+// via Update() returns a non-nil Cmd to schedule the next background GitHub sync.
+func TestModel_SyncTickMsg_TriggersSyncCmd(t *testing.T) {
+	model := NewModel()
+	require.NotNil(t, model)
+
+	_, cmd := model.Update(syncTickMsg{})
+
+	assert.NotNil(t, cmd, "syncTickMsg must trigger a sync Cmd")
 }
 
 func TestModel_WindowSizeMsg_StoresTerminalWidth(t *testing.T) {

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -45,7 +45,7 @@ var navItems = []navItem{
 // renderFull builds the complete 3-pane TUI layout.
 // termWidth is the terminal column count; 0 falls back to defaultTermWidth.
 // termHeight is the terminal row count; 0 disables explicit panel height.
-func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, themeIdx, activeNav, termWidth, termHeight int) string {
+func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, themeIdx, activeNav, termWidth, termHeight int, syncing bool, lastSynced time.Time, syncErr error) string {
 	if termWidth <= 0 {
 		termWidth = defaultTermWidth
 	}
@@ -72,7 +72,7 @@ func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, t
 	list := renderWorktreePanel(worktrees, selectedIdx, theme, listInner, panelHeight)
 	ctx := renderContextPanel(worktrees, selectedIdx, theme, panelHeight)
 	mainRow := lipgloss.JoinHorizontal(lipgloss.Top, nav, list, ctx)
-	footer := renderFooterBar(theme, time.Now().UTC().Format("2006-01-02"), termWidth)
+	footer := renderFooterBar(theme, time.Now().UTC().Format("2006-01-02"), termWidth, syncing, lastSynced, syncErr)
 	actionBar := renderActionBar(theme, termWidth)
 
 	return lipgloss.JoinVertical(lipgloss.Left, header, mainRow, footer, actionBar)
@@ -167,10 +167,30 @@ func renderContextPanel(worktrees []domain.Worktree, selectedIdx int, theme styl
 	return st.Render(content)
 }
 
-func renderFooterBar(theme styles.Theme, date string, termWidth int) string {
-	return theme.GetStyle("status-bar").Width(termWidth).Render(
-		fmt.Sprintf("%s  [%s]", footerHints, date),
-	)
+func renderFooterBar(theme styles.Theme, date string, termWidth int, syncing bool, lastSynced time.Time, syncErr error) string {
+	left := fmt.Sprintf("%s  [%s]", footerHints, date)
+
+	var syncStatus string
+	switch {
+	case syncErr != nil:
+		syncStatus = "✗ sync err"
+	case syncing:
+		syncStatus = "⟳ syncing"
+	case !lastSynced.IsZero():
+		mins := int(time.Since(lastSynced).Minutes())
+		if mins < 1 {
+			syncStatus = "✓ synced just now"
+		} else {
+			syncStatus = fmt.Sprintf("✓ synced %dm ago", mins)
+		}
+	}
+
+	content := left
+	if syncStatus != "" {
+		content = left + "  " + syncStatus
+	}
+
+	return theme.GetStyle("status-bar").Width(termWidth).Render(content)
 }
 
 func renderActionBar(theme styles.Theme, termWidth int) string {

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/m00nk0d3/nexus/internal/domain"
 	"github.com/stretchr/testify/assert"
@@ -240,6 +242,55 @@ func TestRenderFull_WorktreeStatusMapping(t *testing.T) {
 			assert.Contains(t, view, tt.expectedName)
 			assert.Contains(t, view, tt.worktree.Path)
 			assert.Contains(t, view, tt.expectedStatus)
+		})
+	}
+}
+
+func TestRenderFooterBar_SyncStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		syncing    bool
+		lastSynced time.Time
+		syncErr    error
+		wantIn     string
+	}{
+		{
+			name:    "shows syncing indicator while sync is in progress",
+			syncing: true,
+			wantIn:  "⟳ syncing",
+		},
+		{
+			name:       "shows synced time when last sync succeeded",
+			lastSynced: time.Now().Add(-3 * time.Minute),
+			wantIn:     "✓ synced 3m ago",
+		},
+		{
+			name:       "shows synced just now when under one minute",
+			lastSynced: time.Now().Add(-30 * time.Second),
+			wantIn:     "✓ synced just now",
+		},
+		{
+			name:    "shows error indicator on sync failure",
+			syncErr: errors.New("api rate limited"),
+			wantIn:  "✗ sync err",
+		},
+		{
+			name:   "shows nothing when never synced and not syncing",
+			wantIn: "NEXUS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.syncing = tt.syncing
+			model.lastSynced = tt.lastSynced
+			model.syncErr = tt.syncErr
+
+			view := model.View()
+
+			assert.Contains(t, view, tt.wantIn)
 		})
 	}
 }

--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -1,5 +1,7 @@
 package domain
 
+import "time"
+
 type Config struct {
 	GitHub     GitHubConfig     `toml:"github"`
 	Appearance AppearanceConfig `toml:"appearance"`
@@ -10,6 +12,15 @@ type Config struct {
 type GitHubConfig struct {
 	AutoSync            bool `toml:"auto_sync"`
 	SyncIntervalMinutes int  `toml:"sync_interval_minutes"`
+}
+
+// SyncInterval returns the configured sync interval as a time.Duration.
+// Defaults to 5 minutes when SyncIntervalMinutes is zero or negative.
+func (c GitHubConfig) SyncInterval() time.Duration {
+	if c.SyncIntervalMinutes <= 0 {
+		return 5 * time.Minute
+	}
+	return time.Duration(c.SyncIntervalMinutes) * time.Minute
 }
 
 type AppearanceConfig struct {

--- a/internal/domain/config_test.go
+++ b/internal/domain/config_test.go
@@ -1,0 +1,44 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGitHubConfig_SyncInterval(t *testing.T) {
+	tests := []struct {
+		name     string
+		minutes  int
+		wantDur  time.Duration
+	}{
+		{
+			name:    "zero falls back to 5 minutes",
+			minutes: 0,
+			wantDur: 5 * time.Minute,
+		},
+		{
+			name:    "negative falls back to 5 minutes",
+			minutes: -1,
+			wantDur: 5 * time.Minute,
+		},
+		{
+			name:    "positive value is used as-is",
+			minutes: 10,
+			wantDur: 10 * time.Minute,
+		},
+		{
+			name:    "one minute is the minimum valid positive value",
+			minutes: 1,
+			wantDur: 1 * time.Minute,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := GitHubConfig{SyncIntervalMinutes: tt.minutes}
+			assert.Equal(t, tt.wantDur, cfg.SyncInterval())
+		})
+	}
+}


### PR DESCRIPTION
Closes #12

Adds a background goroutine that polls GitHub for PRs and issues at a configurable interval (default: 5 minutes). The sync runs immediately on startup via `Model.Init()` and is rescheduled after each `githubSyncedMsg` using `tea.Tick`.

## What changed
- `githubSyncedMsg` + `syncTickMsg` types power the async Bubbletea event loop
- `Model` gains `prs`, `issues`, `lastSynced`, `syncErr`, `syncing` fields
- `Init()` batches worktree refresh + immediate GitHub sync
- `Update()` handles both new message types; schedules next tick after each sync
- `renderFooterBar` shows `⟳ syncing` / `✓ synced Xm ago` / `✗ sync err`
- `Config.GitHub.SyncInterval()` reads `SyncIntervalMinutes` (default: 5)

## Why
Enables the TUI to display live PR and issue data without blocking the UI, as specified in issue #12.

## Testing
- TDD: all three new tests written before production code
- `TestModel_Init_ReturnsSyncCmd` — Init returns non-nil Cmd
- `TestModel_GithubSyncedMsg_StoresPRsAndIssues` — prs/issues/syncErr stored correctly
- `TestModel_SyncTickMsg_TriggersSyncCmd` — tick fires next sync
- `go test ./...` passes all 7 packages