### PR TITLE
feat(data): implement PR-to-worktree linking algorithm

### DIFF
--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -126,7 +126,7 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 		status := worktreeStatus(wt)
 		ghID := ""
 		if wt.LinkedPR != nil {
-			ghID = fmt.Sprintf("%d", *wt.LinkedPR)
+			ghID = fmt.Sprintf("%d", wt.LinkedPR.Number)
 		}
 		if i == selectedIdx {
 			row := fmt.Sprintf("%-18s %-*s %-8s %-10s %-6s", name, pathWidth, path, status, "—", ghID)

--- a/internal/data/link.go
+++ b/internal/data/link.go
@@ -27,18 +27,30 @@ func LinkWorktreesToPRs(db *DB, worktrees []domain.Worktree, prs []domain.PullRe
 			wt.LinkedPR = &matched
 		}
 		result[i] = wt
+	}
 
+	tx, err := db.Conn.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("link worktrees to prs: begin tx: %w", err)
+	}
+
+	for _, wt := range result {
 		// Persist: NULL when no PR matched, PR number otherwise.
 		var linkedPR interface{}
 		if wt.LinkedPR != nil {
 			linkedPR = wt.LinkedPR.Number
 		}
-		if _, err := db.Conn.Exec(
+		if _, err := tx.Exec(
 			"UPDATE worktrees SET linked_pr=? WHERE path=?",
 			linkedPR, wt.Path,
 		); err != nil {
+			_ = tx.Rollback()
 			return nil, fmt.Errorf("link worktrees to prs: update worktree %s: %w", wt.Path, err)
 		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("link worktrees to prs: commit: %w", err)
 	}
 
 	return result, nil

--- a/internal/data/link.go
+++ b/internal/data/link.go
@@ -1,0 +1,45 @@
+package data
+
+import (
+	"fmt"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+)
+
+// LinkWorktreesToPRs matches each worktree to its corresponding pull request by
+// branch name, then persists the linked_pr column to the database.
+//
+// When multiple PRs share the same branch, the one with the highest Number wins.
+// Worktrees with no matching PR have LinkedPR set to nil and linked_pr set to NULL.
+func LinkWorktreesToPRs(db *DB, worktrees []domain.Worktree, prs []domain.PullRequest) ([]domain.Worktree, error) {
+	// Build map: branch → highest-numbered PR.
+	prByBranch := make(map[string]domain.PullRequest, len(prs))
+	for _, pr := range prs {
+		if existing, ok := prByBranch[pr.Branch]; !ok || pr.Number > existing.Number {
+			prByBranch[pr.Branch] = pr
+		}
+	}
+
+	result := make([]domain.Worktree, len(worktrees))
+	for i, wt := range worktrees {
+		if pr, ok := prByBranch[wt.Branch]; ok {
+			matched := pr
+			wt.LinkedPR = &matched
+		}
+		result[i] = wt
+
+		// Persist: NULL when no PR matched, PR number otherwise.
+		var linkedPR interface{}
+		if wt.LinkedPR != nil {
+			linkedPR = wt.LinkedPR.Number
+		}
+		if _, err := db.Conn.Exec(
+			"UPDATE worktrees SET linked_pr=? WHERE path=?",
+			linkedPR, wt.Path,
+		); err != nil {
+			return nil, fmt.Errorf("link worktrees to prs: update worktree %s: %w", wt.Path, err)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/data/link_test.go
+++ b/internal/data/link_test.go
@@ -1,0 +1,117 @@
+package data_test
+
+import (
+	"testing"
+
+	"github.com/m00nk0d3/nexus/internal/data"
+	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLinkWorktreesToPRs exercises LinkWorktreesToPRs across four behaviours:
+//  1. exact branch match → LinkedPR points at the matched PR
+//  2. no branch match    → LinkedPR remains nil
+//  3. duplicate branches → the PR with the highest number wins
+//  4. persistence        → the linked_pr column is updated in SQLite
+func TestLinkWorktreesToPRs(t *testing.T) {
+	t.Run("exact match links correctly", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		worktrees := []domain.Worktree{
+			{Path: "/repo/feat-issue-13", Branch: "feat/issue-13"},
+		}
+		prs := []domain.PullRequest{
+			{Number: 13, Title: "feat: link PRs to worktrees", Branch: "feat/issue-13", State: "OPEN"},
+		}
+
+		got, err := data.LinkWorktreesToPRs(db, worktrees, prs)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+
+		require.NotNil(t, got[0].LinkedPR, "LinkedPR should be set for an exact branch match")
+		assert.Equal(t, 13, got[0].LinkedPR.Number)
+		assert.Equal(t, "feat/issue-13", got[0].LinkedPR.Branch)
+	})
+
+	t.Run("no match leaves LinkedPR nil", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		worktrees := []domain.Worktree{
+			{Path: "/repo/feat-issue-13", Branch: "feat/issue-13"},
+		}
+		prs := []domain.PullRequest{
+			{Number: 99, Title: "unrelated PR", Branch: "other-branch", State: "OPEN"},
+		}
+
+		got, err := data.LinkWorktreesToPRs(db, worktrees, prs)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+
+		assert.Nil(t, got[0].LinkedPR, "LinkedPR should be nil when no PR branch matches the worktree branch")
+	})
+
+	t.Run("duplicate branch picks highest PR number", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		worktrees := []domain.Worktree{
+			{Path: "/repo/feat-issue-13", Branch: "feat/issue-13"},
+		}
+		prs := []domain.PullRequest{
+			{Number: 5, Title: "older PR", Branch: "feat/issue-13", State: "OPEN"},
+			{Number: 42, Title: "newer PR", Branch: "feat/issue-13", State: "OPEN"},
+		}
+
+		got, err := data.LinkWorktreesToPRs(db, worktrees, prs)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+
+		require.NotNil(t, got[0].LinkedPR, "LinkedPR should be set when at least one PR matches")
+		assert.Equal(t, 42, got[0].LinkedPR.Number, "should pick the highest PR number when branch is duplicated")
+	})
+
+	t.Run("result is persisted to SQLite", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		const (
+			worktreePath   = "/repo/feat-issue-13"
+			worktreeBranch = "feat/issue-13"
+			prNumber       = 13
+		)
+
+		// Pre-insert the worktree row so LinkWorktreesToPRs has a row to UPDATE.
+		_, err = db.Conn.Exec(
+			"INSERT INTO worktrees (path, branch) VALUES (?, ?)",
+			worktreePath, worktreeBranch,
+		)
+		require.NoError(t, err, "inserting the seed worktree row should succeed")
+
+		worktrees := []domain.Worktree{
+			{Path: worktreePath, Branch: worktreeBranch},
+		}
+		prs := []domain.PullRequest{
+			{Number: prNumber, Title: "feat: link PRs to worktrees", Branch: worktreeBranch, State: "OPEN"},
+		}
+
+		_, err = data.LinkWorktreesToPRs(db, worktrees, prs)
+		require.NoError(t, err)
+
+		// Read back the persisted linked_pr value.
+		var gotLinkedPR int
+		err = db.Conn.QueryRow(
+			"SELECT linked_pr FROM worktrees WHERE path = ?",
+			worktreePath,
+		).Scan(&gotLinkedPR)
+		require.NoError(t, err, "querying linked_pr after linking should return a row")
+
+		assert.Equal(t, prNumber, gotLinkedPR, "linked_pr column should be persisted to SQLite")
+	})
+}

--- a/internal/data/link_test.go
+++ b/internal/data/link_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestLinkWorktreesToPRs exercises LinkWorktreesToPRs across four behaviours:
-//  1. exact branch match → LinkedPR points at the matched PR
-//  2. no branch match    → LinkedPR remains nil
-//  3. duplicate branches → the PR with the highest number wins
-//  4. persistence        → the linked_pr column is updated in SQLite
+// TestLinkWorktreesToPRs exercises LinkWorktreesToPRs across five behaviours:
+//  1. exact branch match  → LinkedPR points at the matched PR
+//  2. no branch match     → LinkedPR remains nil
+//  3. duplicate branches  → the PR with the highest number wins
+//  4. match persisted     → linked_pr column is updated in SQLite
+//  5. no-match persisted  → linked_pr column is set to NULL in SQLite
 func TestLinkWorktreesToPRs(t *testing.T) {
 	t.Run("exact match links correctly", func(t *testing.T) {
 		db, err := data.NewDB(":memory:")
@@ -113,5 +114,44 @@ func TestLinkWorktreesToPRs(t *testing.T) {
 		require.NoError(t, err, "querying linked_pr after linking should return a row")
 
 		assert.Equal(t, prNumber, gotLinkedPR, "linked_pr column should be persisted to SQLite")
+	})
+
+	t.Run("unmatched worktree persists NULL to SQLite", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		const (
+			worktreePath   = "/repo/feat-issue-13"
+			worktreeBranch = "feat/issue-13"
+		)
+
+		// Pre-seed worktree row with a linked_pr value so we can confirm it is
+		// cleared to NULL when no PR matches.
+		_, err = db.Conn.Exec(
+			"INSERT INTO worktrees (path, branch, linked_pr) VALUES (?, ?, ?)",
+			worktreePath, worktreeBranch, 99,
+		)
+		require.NoError(t, err, "inserting the seed worktree row should succeed")
+
+		worktrees := []domain.Worktree{
+			{Path: worktreePath, Branch: worktreeBranch},
+		}
+		prs := []domain.PullRequest{
+			{Number: 99, Title: "unrelated PR", Branch: "other-branch", State: "OPEN"},
+		}
+
+		_, err = data.LinkWorktreesToPRs(db, worktrees, prs)
+		require.NoError(t, err)
+
+		// linked_pr must be NULL — scan into *int so a NULL value doesn't cause an error.
+		var gotLinkedPR *int
+		err = db.Conn.QueryRow(
+			"SELECT linked_pr FROM worktrees WHERE path = ?",
+			worktreePath,
+		).Scan(&gotLinkedPR)
+		require.NoError(t, err, "querying linked_pr after linking should return a row")
+
+		assert.Nil(t, gotLinkedPR, "linked_pr column should be NULL when no PR matches the worktree branch")
 	})
 }

--- a/internal/domain/worktree.go
+++ b/internal/domain/worktree.go
@@ -7,5 +7,5 @@ type Worktree struct {
 	CommitSHA  string
 	IsClean    bool
 	IsLocked   bool
-	LinkedPR   *int
+	LinkedPR   *PullRequest
 }


### PR DESCRIPTION
Closes #13

## What Changed
Implements the algorithm that matches local worktree branches to GitHub PR branches and persists the associations in SQLite — powering the `GH:ID` column in the worktree list.

## Why
Phase 2 requires the worktree list to show linked PR numbers. Without this linking step, the `LinkedPR` field on `domain.Worktree` was always nil.

## Changes
- `domain.Worktree.LinkedPR` promoted from `*int` to `*PullRequest` (full PR value, no extra lookups needed)
- `internal/data/link.go`: `LinkWorktreesToPRs()` — exact branch match, highest-number wins on ties, persists via `UPDATE worktrees SET linked_pr=?`
- `internal/data/link_test.go`: 4 table-driven subtests (exact match, no match, duplicate branch, SQLite persistence)
- `cmd/nexus/renderer.go`: updated dereference to use `.LinkedPR.Number`

## Testing
- TDD: tests written first (RED), then implementation (GREEN)
- `go test ./...` — all 7 packages pass
- `go build ./...` — zero compilation errors