### PR TITLE
feat(tui): implement Issues and PRs view screens

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -43,6 +43,9 @@ type githubSyncedMsg struct {
 // syncTickMsg triggers the next periodic GitHub sync.
 type syncTickMsg struct{}
 
+// browserOpenErrMsg carries an error from opening an issue or PR in the browser.
+type browserOpenErrMsg struct{ err error }
+
 // activeView represents the currently active main panel view.
 type activeView int
 
@@ -216,6 +219,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+	case browserOpenErrMsg:
+		if msg.err != nil {
+			m.Error = fmt.Sprintf("Failed to open in browser: %v", msg.err)
+		}
+
 	case githubSyncedMsg:
 		m.syncing = false
 		m.syncErr = msg.err
@@ -223,6 +231,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.prs = msg.prs
 			m.issues = msg.issues
 			m.lastSynced = msg.syncedAt
+			// Clamp per-view selection indices after a sync in case the list shrank.
+			m.clampIssueIdx()
+			m.clampPRIdx()
 		}
 		// On error, m.prs and m.issues intentionally retain their previous values
 		// so the UI continues to show the last known good data.
@@ -264,19 +275,19 @@ func (m *Model) View() string {
 func (m *Model) openInBrowserCmd() tea.Cmd {
 	switch m.view {
 	case viewIssues:
-		if len(m.issues) == 0 {
+		if len(m.issues) == 0 || m.selectedIssueIdx >= len(m.issues) {
 			return nil
 		}
 		num := m.issues[m.selectedIssueIdx].Number
 		cmd := exec.Command("gh", "issue", "view", fmt.Sprintf("%d", num), "--web")
-		return tea.ExecProcess(cmd, func(err error) tea.Msg { return nil })
+		return tea.ExecProcess(cmd, func(err error) tea.Msg { return browserOpenErrMsg{err: err} })
 	case viewPRs:
-		if len(m.prs) == 0 {
+		if len(m.prs) == 0 || m.selectedPRIdx >= len(m.prs) {
 			return nil
 		}
 		num := m.prs[m.selectedPRIdx].Number
 		cmd := exec.Command("gh", "pr", "view", fmt.Sprintf("%d", num), "--web")
-		return tea.ExecProcess(cmd, func(err error) tea.Msg { return nil })
+		return tea.ExecProcess(cmd, func(err error) tea.Msg { return browserOpenErrMsg{err: err} })
 	default:
 		return nil
 	}
@@ -406,5 +417,25 @@ func (m *Model) clampSelectedIdx() {
 
 	if m.selectedIdx >= len(m.Worktrees) {
 		m.selectedIdx = len(m.Worktrees) - 1
+	}
+}
+
+func (m *Model) clampIssueIdx() {
+	if len(m.issues) == 0 {
+		m.selectedIssueIdx = 0
+		return
+	}
+	if m.selectedIssueIdx >= len(m.issues) {
+		m.selectedIssueIdx = len(m.issues) - 1
+	}
+}
+
+func (m *Model) clampPRIdx() {
+	if len(m.prs) == 0 {
+		m.selectedPRIdx = 0
+		return
+	}
+	if m.selectedPRIdx >= len(m.prs) {
+		m.selectedPRIdx = len(m.prs) - 1
 	}
 }

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -43,24 +43,35 @@ type githubSyncedMsg struct {
 // syncTickMsg triggers the next periodic GitHub sync.
 type syncTickMsg struct{}
 
+// activeView represents the currently active main panel view.
+type activeView int
+
+const (
+	viewWorktrees activeView = iota // Shows the worktree list (default)
+	viewIssues                      // Shows the GitHub issues list
+	viewPRs                         // Shows the GitHub pull requests list
+)
+
 // Model represents the root Bubbletea model for the Nexus TUI application.
 // It manages the list of git worktrees, user interactions, and active modals.
 type Model struct {
-	Worktrees   []domain.Worktree // List of available git worktrees
-	RepoPath    string            // Path to the repository root
-	Config      *domain.Config    // Loaded application configuration
-	selectedIdx int               // Currently selected worktree index
-	activeModal tea.Model         // Currently open modal (if any)
-	Error       string            // Error message to display (if any)
-	themeIdx    int               // Index into styles.Themes for the active theme
-	activeNav   int               // Index of the active nav rail section (0=W,1=I,2=P,3=T)
-	width       int               // Terminal width in columns; 0 means use default
-	height      int               // Terminal height in rows; 0 means use default
-	prs         []domain.PullRequest // Latest synced pull requests
-	issues      []domain.Issue       // Latest synced issues
-	lastSynced  time.Time            // When the last successful GitHub sync completed
-	syncErr     error                // Error from the most recent GitHub sync attempt
-	syncing     bool                 // True while a background GitHub sync is in progress
+	Worktrees        []domain.Worktree    // List of available git worktrees
+	RepoPath         string               // Path to the repository root
+	Config           *domain.Config       // Loaded application configuration
+	selectedIdx      int                  // Currently selected worktree index
+	activeModal      tea.Model            // Currently open modal (if any)
+	Error            string               // Error message to display (if any)
+	themeIdx         int                  // Index into styles.Themes for the active theme
+	view             activeView           // Currently active main panel view
+	width            int                  // Terminal width in columns; 0 means use default
+	height           int                  // Terminal height in rows; 0 means use default
+	prs              []domain.PullRequest // Latest synced pull requests
+	issues           []domain.Issue       // Latest synced issues
+	lastSynced       time.Time            // When the last successful GitHub sync completed
+	syncErr          error                // Error from the most recent GitHub sync attempt
+	syncing          bool                 // True while a background GitHub sync is in progress
+	selectedIssueIdx int                  // Currently selected issue index
+	selectedPRIdx    int                  // Currently selected PR index
 }
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
@@ -132,16 +143,47 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.activeModal = modal.NewDeleteModal(selected)
 			}
 		case tea.KeyUp:
-			if m.selectedIdx > 0 {
-				m.selectedIdx--
+			switch m.view {
+			case viewIssues:
+				if m.selectedIssueIdx > 0 {
+					m.selectedIssueIdx--
+				}
+			case viewPRs:
+				if m.selectedPRIdx > 0 {
+					m.selectedPRIdx--
+				}
+			default:
+				if m.selectedIdx > 0 {
+					m.selectedIdx--
+				}
 			}
 		case tea.KeyDown:
-			if m.selectedIdx < len(m.Worktrees)-1 {
-				m.selectedIdx++
+			switch m.view {
+			case viewIssues:
+				if m.selectedIssueIdx < len(m.issues)-1 {
+					m.selectedIssueIdx++
+				}
+			case viewPRs:
+				if m.selectedPRIdx < len(m.prs)-1 {
+					m.selectedPRIdx++
+				}
+			default:
+				if m.selectedIdx < len(m.Worktrees)-1 {
+					m.selectedIdx++
+				}
 			}
 		case tea.KeyRunes:
-			if msg.String() == "t" {
+			switch msg.String() {
+			case "t":
 				m.themeIdx = (m.themeIdx + 1) % len(styles.Themes)
+			case "w", "W":
+				m.view = viewWorktrees
+			case "i", "I":
+				m.view = viewIssues
+			case "p", "P":
+				m.view = viewPRs
+			case "g", "G":
+				return m, m.openInBrowserCmd()
 			}
 		}
 
@@ -207,7 +249,7 @@ func (m *Model) View() string {
 	if m.activeModal != nil {
 		baseView = m.activeModal.View()
 	} else {
-		baseView = renderFull(m.Worktrees, m.selectedIdx, m.RepoPath, m.themeIdx, m.activeNav, m.width, m.height, m.syncing, m.lastSynced, m.syncErr)
+		baseView = renderFull(m.Worktrees, m.selectedIdx, m.RepoPath, m.themeIdx, m.view, m.width, m.height, m.syncing, m.lastSynced, m.syncErr, m.issues, m.selectedIssueIdx, m.prs, m.selectedPRIdx)
 	}
 
 	if m.Error == "" {
@@ -215,6 +257,29 @@ func (m *Model) View() string {
 	}
 
 	return fmt.Sprintf("Error: %s\n\n%s", m.Error, baseView)
+}
+
+// openInBrowserCmd returns a Cmd that opens the selected issue or PR in the browser
+// using the gh CLI. Returns nil when in viewWorktrees or when the relevant list is empty.
+func (m *Model) openInBrowserCmd() tea.Cmd {
+	switch m.view {
+	case viewIssues:
+		if len(m.issues) == 0 {
+			return nil
+		}
+		num := m.issues[m.selectedIssueIdx].Number
+		cmd := exec.Command("gh", "issue", "view", fmt.Sprintf("%d", num), "--web")
+		return tea.ExecProcess(cmd, func(err error) tea.Msg { return nil })
+	case viewPRs:
+		if len(m.prs) == 0 {
+			return nil
+		}
+		num := m.prs[m.selectedPRIdx].Number
+		cmd := exec.Command("gh", "pr", "view", fmt.Sprintf("%d", num), "--web")
+		return tea.ExecProcess(cmd, func(err error) tea.Msg { return nil })
+	default:
+		return nil
+	}
 }
 
 // fetchIssuesCmd returns a Cmd that fetches open GitHub issues in the background,

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -610,6 +610,262 @@ func TestModel_SyncTickMsg_TriggersSyncCmd(t *testing.T) {
 	assert.NotNil(t, cmd, "syncTickMsg must trigger a sync Cmd")
 }
 
+// ---------------------------------------------------------------------------
+// Phase 2: Issues & PRs View — RED tests (features not yet implemented)
+// ---------------------------------------------------------------------------
+
+// TestModel_ViewSwitching verifies that pressing W/I/P (upper- and lower-case)
+// switches the model's active view to the correct activeView constant.
+func TestModel_ViewSwitching(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      rune
+		wantView activeView
+	}{
+		{
+			name:     "pressing W sets view to viewWorktrees",
+			key:      'W',
+			wantView: viewWorktrees,
+		},
+		{
+			name:     "pressing I sets view to viewIssues",
+			key:      'I',
+			wantView: viewIssues,
+		},
+		{
+			name:     "pressing P sets view to viewPRs",
+			key:      'P',
+			wantView: viewPRs,
+		},
+		{
+			name:     "pressing w (lowercase) sets view to viewWorktrees",
+			key:      'w',
+			wantView: viewWorktrees,
+		},
+		{
+			name:     "pressing i (lowercase) sets view to viewIssues",
+			key:      'i',
+			wantView: viewIssues,
+		},
+		{
+			name:     "pressing p (lowercase) sets view to viewPRs",
+			key:      'p',
+			wantView: viewPRs,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+
+			updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tt.key}})
+			m, ok := updated.(*Model)
+			require.True(t, ok, "Update must return *Model")
+
+			assert.Equal(t, tt.wantView, m.view)
+		})
+	}
+}
+
+// TestModel_IssueNavigation verifies that up/down navigation in viewIssues
+// moves selectedIssueIdx correctly and does NOT move the worktree selectedIdx.
+func TestModel_IssueNavigation(t *testing.T) {
+	issues := []domain.Issue{
+		{Number: 1, Title: "First"},
+		{Number: 2, Title: "Second"},
+		{Number: 3, Title: "Third"},
+	}
+
+	tests := []struct {
+		name            string
+		initialIssueIdx int
+		keyType         tea.KeyType
+		wantIssueIdx    int
+		wantWorktreeIdx int
+	}{
+		{
+			name:            "down key increments selectedIssueIdx",
+			initialIssueIdx: 0,
+			keyType:         tea.KeyDown,
+			wantIssueIdx:    1,
+			wantWorktreeIdx: 0,
+		},
+		{
+			name:            "up key decrements selectedIssueIdx",
+			initialIssueIdx: 1,
+			keyType:         tea.KeyUp,
+			wantIssueIdx:    0,
+			wantWorktreeIdx: 0,
+		},
+		{
+			name:            "up key does not go below 0 (boundary)",
+			initialIssueIdx: 0,
+			keyType:         tea.KeyUp,
+			wantIssueIdx:    0,
+			wantWorktreeIdx: 0,
+		},
+		{
+			name:            "down key does not exceed len(issues)-1 (boundary)",
+			initialIssueIdx: 2,
+			keyType:         tea.KeyDown,
+			wantIssueIdx:    2,
+			wantWorktreeIdx: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.issues = issues
+			model.view = viewIssues
+			model.selectedIssueIdx = tt.initialIssueIdx
+
+			updated, _ := model.Update(tea.KeyMsg{Type: tt.keyType})
+			m, ok := updated.(*Model)
+			require.True(t, ok, "Update must return *Model")
+
+			assert.Equal(t, tt.wantIssueIdx, m.selectedIssueIdx, "issue index mismatch")
+			assert.Equal(t, tt.wantWorktreeIdx, m.selectedIdx, "worktree idx must not change when navigating issues")
+		})
+	}
+}
+
+// TestModel_PRNavigation verifies that up/down navigation in viewPRs
+// moves selectedPRIdx correctly and does NOT move the worktree selectedIdx.
+func TestModel_PRNavigation(t *testing.T) {
+	prs := []domain.PullRequest{
+		{Number: 10, Title: "PR One"},
+		{Number: 11, Title: "PR Two"},
+		{Number: 12, Title: "PR Three"},
+	}
+
+	tests := []struct {
+		name            string
+		initialPRIdx    int
+		keyType         tea.KeyType
+		wantPRIdx       int
+		wantWorktreeIdx int
+	}{
+		{
+			name:            "down key increments selectedPRIdx",
+			initialPRIdx:    0,
+			keyType:         tea.KeyDown,
+			wantPRIdx:       1,
+			wantWorktreeIdx: 0,
+		},
+		{
+			name:            "up key decrements selectedPRIdx",
+			initialPRIdx:    1,
+			keyType:         tea.KeyUp,
+			wantPRIdx:       0,
+			wantWorktreeIdx: 0,
+		},
+		{
+			name:            "up key does not go below 0 (boundary)",
+			initialPRIdx:    0,
+			keyType:         tea.KeyUp,
+			wantPRIdx:       0,
+			wantWorktreeIdx: 0,
+		},
+		{
+			name:            "down key does not exceed len(prs)-1 (boundary)",
+			initialPRIdx:    2,
+			keyType:         tea.KeyDown,
+			wantPRIdx:       2,
+			wantWorktreeIdx: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.prs = prs
+			model.view = viewPRs
+			model.selectedPRIdx = tt.initialPRIdx
+
+			updated, _ := model.Update(tea.KeyMsg{Type: tt.keyType})
+			m, ok := updated.(*Model)
+			require.True(t, ok, "Update must return *Model")
+
+			assert.Equal(t, tt.wantPRIdx, m.selectedPRIdx, "PR index mismatch")
+			assert.Equal(t, tt.wantWorktreeIdx, m.selectedIdx, "worktree idx must not change when navigating PRs")
+		})
+	}
+}
+
+// TestModel_G_Key_OpensInBrowser verifies the [g] key opens the selected
+// issue or PR in the browser (returns non-nil Cmd), and is a no-op in
+// viewWorktrees or when the list is empty.
+func TestModel_G_Key_OpensInBrowser(t *testing.T) {
+	tests := []struct {
+		name       string
+		view       activeView
+		issues     []domain.Issue
+		prs        []domain.PullRequest
+		issueIdx   int
+		prIdx      int
+		wantCmdNil bool
+	}{
+		{
+			name:       "g in viewIssues with issue selected returns non-nil Cmd",
+			view:       viewIssues,
+			issues:     []domain.Issue{{Number: 5, Title: "Test Issue"}},
+			issueIdx:   0,
+			wantCmdNil: false,
+		},
+		{
+			name:       "g in viewPRs with PR selected returns non-nil Cmd",
+			view:       viewPRs,
+			prs:        []domain.PullRequest{{Number: 42, Title: "My PR", Branch: "feat/awesome", Author: "alice", State: "OPEN"}},
+			prIdx:      0,
+			wantCmdNil: false,
+		},
+		{
+			name:       "g in viewWorktrees is a no-op (returns nil Cmd)",
+			view:       viewWorktrees,
+			wantCmdNil: true,
+		},
+		{
+			name:       "g in viewIssues with empty issues list returns nil Cmd",
+			view:       viewIssues,
+			issues:     []domain.Issue{},
+			issueIdx:   0,
+			wantCmdNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = tt.view
+			if tt.issues != nil {
+				model.issues = tt.issues
+			}
+			if tt.prs != nil {
+				model.prs = tt.prs
+			}
+			model.selectedIssueIdx = tt.issueIdx
+			model.selectedPRIdx = tt.prIdx
+
+			_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+
+			if tt.wantCmdNil {
+				assert.Nil(t, cmd, "expected nil Cmd (no-op) but got non-nil")
+			} else {
+				assert.NotNil(t, cmd, "expected non-nil Cmd to open in browser")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End Phase 2 RED tests (app_test.go)
+// ---------------------------------------------------------------------------
+
 func TestModel_WindowSizeMsg_StoresTerminalWidth(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -611,7 +611,7 @@ func TestModel_SyncTickMsg_TriggersSyncCmd(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 2: Issues & PRs View — RED tests (features not yet implemented)
+// Phase 2: Issues & PRs View tests
 // ---------------------------------------------------------------------------
 
 // TestModel_ViewSwitching verifies that pressing W/I/P (upper- and lower-case)
@@ -863,8 +863,99 @@ func TestModel_G_Key_OpensInBrowser(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// End Phase 2 RED tests (app_test.go)
+// End Phase 2 tests (app_test.go)
 // ---------------------------------------------------------------------------
+
+// TestModel_GithubSync_ClampsIssueAndPRIdx verifies that after a successful sync
+// that returns fewer items, selectedIssueIdx and selectedPRIdx are clamped to
+// the new list bounds so openInBrowserCmd never panics.
+func TestModel_GithubSync_ClampsIssueAndPRIdx(t *testing.T) {
+	tests := []struct {
+		name             string
+		initialIssueIdx  int
+		initialPRIdx     int
+		syncIssues       []domain.Issue
+		syncPRs          []domain.PullRequest
+		wantIssueIdx     int
+		wantPRIdx        int
+	}{
+		{
+			name:            "issue idx clamped when sync shrinks list",
+			initialIssueIdx: 4,
+			initialPRIdx:    0,
+			syncIssues:      []domain.Issue{{Number: 1, Title: "Only Issue"}},
+			syncPRs:         []domain.PullRequest{{Number: 10, Title: "PR", Branch: "main", Author: "dev", State: "OPEN"}},
+			wantIssueIdx:    0,
+			wantPRIdx:       0,
+		},
+		{
+			name:            "pr idx clamped when sync shrinks list",
+			initialIssueIdx: 0,
+			initialPRIdx:    5,
+			syncIssues:      []domain.Issue{{Number: 1, Title: "Issue"}},
+			syncPRs:         []domain.PullRequest{{Number: 10, Title: "PR", Branch: "main", Author: "dev", State: "OPEN"}},
+			wantIssueIdx:    0,
+			wantPRIdx:       0,
+		},
+		{
+			name:            "idx within bounds is preserved after sync",
+			initialIssueIdx: 0,
+			initialPRIdx:    0,
+			syncIssues:      []domain.Issue{{Number: 1, Title: "A"}, {Number: 2, Title: "B"}},
+			syncPRs:         []domain.PullRequest{{Number: 10, Title: "PR", Branch: "main", Author: "dev", State: "OPEN"}},
+			wantIssueIdx:    0,
+			wantPRIdx:       0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.selectedIssueIdx = tt.initialIssueIdx
+			model.selectedPRIdx = tt.initialPRIdx
+
+			msg := githubSyncedMsg{
+				issues:   tt.syncIssues,
+				prs:      tt.syncPRs,
+				syncedAt: time.Now(),
+			}
+			updated, _ := model.Update(msg)
+			m, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.wantIssueIdx, m.selectedIssueIdx, "issue idx must be clamped")
+			assert.Equal(t, tt.wantPRIdx, m.selectedPRIdx, "pr idx must be clamped")
+		})
+	}
+}
+
+// TestModel_BrowserOpenErrMsg_SetsError verifies that a browserOpenErrMsg with
+// a non-nil error sets m.Error so the user sees feedback.
+func TestModel_BrowserOpenErrMsg_SetsError(t *testing.T) {
+	model := NewModel()
+	require.NotNil(t, model)
+
+	updated, _ := model.Update(browserOpenErrMsg{err: errors.New("gh: not found")})
+	m, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Contains(t, m.Error, "Failed to open in browser")
+	assert.Contains(t, m.Error, "gh: not found")
+}
+
+// TestModel_BrowserOpenErrMsg_NilErrorNoChange verifies that a nil-error
+// browserOpenErrMsg does not set m.Error.
+func TestModel_BrowserOpenErrMsg_NilErrorNoChange(t *testing.T) {
+	model := NewModel()
+	require.NotNil(t, model)
+
+	updated, _ := model.Update(browserOpenErrMsg{err: nil})
+	m, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Empty(t, m.Error)
+}
 
 func TestModel_WindowSizeMsg_StoresTerminalWidth(t *testing.T) {
 	tests := []struct {

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -68,7 +68,7 @@ func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, t
 	}
 
 	header := renderHeader(repoPath, theme, headerInner)
-	nav := renderNavRail(theme, panelHeight, int(view))
+	nav := renderNavRail(theme, panelHeight, view)
 
 	var list string
 	switch view {
@@ -99,11 +99,11 @@ func renderHeader(repoPath string, theme styles.Theme, innerWidth int) string {
 	return theme.GetStyle("header").Width(innerWidth).Render(text)
 }
 
-func renderNavRail(theme styles.Theme, panelHeight, activeNav int) string {
+func renderNavRail(theme styles.Theme, panelHeight int, view activeView) string {
 	var b strings.Builder
 	for i, item := range navItems {
 		cursor := "  "
-		if i == activeNav {
+		if activeView(i) == view {
 			cursor = "> "
 		}
 		b.WriteString(fmt.Sprintf("%s%s: %s\n", cursor, item.key, item.label))
@@ -216,6 +216,7 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, theme styles.Theme,
 	for i, issue := range issues {
 		labels := strings.Join(issue.Labels, " ")
 		title := truncateStr(issue.Title, titleWidth)
+		// "Open" is hardcoded because gh issue list only returns open issues by default.
 		if i == selectedIdx {
 			row := fmt.Sprintf("%-6d %-*s %-8s %s", issue.Number, titleWidth, title, "Open", labels)
 			content.WriteString(theme.GetStyle("selected-row").Width(listInner).Render("> " + row))

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -45,7 +45,7 @@ var navItems = []navItem{
 // renderFull builds the complete 3-pane TUI layout.
 // termWidth is the terminal column count; 0 falls back to defaultTermWidth.
 // termHeight is the terminal row count; 0 disables explicit panel height.
-func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, themeIdx, activeNav, termWidth, termHeight int, syncing bool, lastSynced time.Time, syncErr error) string {
+func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, themeIdx int, view activeView, termWidth, termHeight int, syncing bool, lastSynced time.Time, syncErr error, issues []domain.Issue, selectedIssueIdx int, prs []domain.PullRequest, selectedPRIdx int) string {
 	if termWidth <= 0 {
 		termWidth = defaultTermWidth
 	}
@@ -68,9 +68,19 @@ func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, t
 	}
 
 	header := renderHeader(repoPath, theme, headerInner)
-	nav := renderNavRail(theme, panelHeight, activeNav)
-	list := renderWorktreePanel(worktrees, selectedIdx, theme, listInner, panelHeight)
-	ctx := renderContextPanel(worktrees, selectedIdx, theme, panelHeight)
+	nav := renderNavRail(theme, panelHeight, int(view))
+
+	var list string
+	switch view {
+	case viewIssues:
+		list = renderIssueList(issues, selectedIssueIdx, theme, listInner, panelHeight)
+	case viewPRs:
+		list = renderPRList(prs, selectedPRIdx, theme, listInner, panelHeight)
+	default:
+		list = renderWorktreePanel(worktrees, selectedIdx, theme, listInner, panelHeight)
+	}
+
+	ctx := renderContextPanel(view, worktrees, selectedIdx, issues, selectedIssueIdx, prs, selectedPRIdx, theme, panelHeight)
 	mainRow := lipgloss.JoinHorizontal(lipgloss.Top, nav, list, ctx)
 	footer := renderFooterBar(theme, time.Now().UTC().Format("2006-01-02"), termWidth, syncing, lastSynced, syncErr)
 	actionBar := renderActionBar(theme, termWidth)
@@ -149,22 +159,117 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 	return st.Render(strings.TrimRight(content.String(), "\n"))
 }
 
-func renderContextPanel(worktrees []domain.Worktree, selectedIdx int, theme styles.Theme, panelHeight int) string {
+func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeIdx int, issues []domain.Issue, issueIdx int, prs []domain.PullRequest, prIdx int, theme styles.Theme, panelHeight int) string {
 	var content string
-	if len(worktrees) == 0 || selectedIdx < 0 || selectedIdx >= len(worktrees) {
-		content = "No worktree selected.\nSelect a worktree to\nview context."
-	} else {
-		wt := worktrees[selectedIdx]
-		content = fmt.Sprintf(
-			"Context: %s\nBranch: %s\nStatus: %s\n\nAGENT COMMANDS:\n[a] Spawn Claude\n[c] Spawn Copilot",
-			filepath.Base(wt.Path), wt.Branch, worktreeStatus(wt),
-		)
+	switch view {
+	case viewIssues:
+		if len(issues) == 0 || issueIdx < 0 || issueIdx >= len(issues) {
+			content = "No issue selected.\nPress I to view issues."
+		} else {
+			iss := issues[issueIdx]
+			labelStrs := make([]string, len(iss.Labels))
+			for i, l := range iss.Labels {
+				labelStrs[i] = "[" + l + "]"
+			}
+			labelsStr := strings.Join(labelStrs, "")
+			content = fmt.Sprintf("Context: Issue #%d\n%s\n\nStatus: ● Open\nLabels: %s\n\n[g] Open in GitHub", iss.Number, iss.Title, labelsStr)
+		}
+	case viewPRs:
+		if len(prs) == 0 || prIdx < 0 || prIdx >= len(prs) {
+			content = "No PR selected.\nPress P to view PRs."
+		} else {
+			pr := prs[prIdx]
+			state := pr.State
+			if pr.IsDraft {
+				state = "DRAFT"
+			}
+			content = fmt.Sprintf("Context: PR #%d\n%s\n\nBranch: %s\nAuthor: @%s\nStatus: %s\n\n[g] Open in GitHub", pr.Number, pr.Title, pr.Branch, pr.Author, state)
+		}
+	default: // viewWorktrees
+		if len(worktrees) == 0 || worktreeIdx < 0 || worktreeIdx >= len(worktrees) {
+			content = "No worktree selected.\nSelect a worktree to\nview context."
+		} else {
+			wt := worktrees[worktreeIdx]
+			content = fmt.Sprintf(
+				"Context: %s\nBranch: %s\nStatus: %s\n\nAGENT COMMANDS:\n[a] Spawn Claude\n[c] Spawn Copilot",
+				filepath.Base(wt.Path), wt.Branch, worktreeStatus(wt),
+			)
+		}
 	}
 	st := theme.GetStyle("context-panel").Width(ctxPanelInner + panelPaddingOverhead)
 	if panelHeight > 0 {
 		st = st.Height(panelHeight)
 	}
 	return st.Render(content)
+}
+
+func renderIssueList(issues []domain.Issue, selectedIdx int, theme styles.Theme, listInner, panelHeight int) string {
+	var content strings.Builder
+	headerStyle := theme.GetStyle("table-header")
+	titleWidth := listInner - 30
+	if titleWidth < 10 {
+		titleWidth = 10
+	}
+	headerRow := fmt.Sprintf("  %-6s %-*s %-8s %s", "#", titleWidth, "TITLE", "STATUS", "LABELS")
+	content.WriteString(headerStyle.Render(headerRow))
+	content.WriteString("\n")
+	for i, issue := range issues {
+		labels := strings.Join(issue.Labels, " ")
+		title := truncateStr(issue.Title, titleWidth)
+		if i == selectedIdx {
+			row := fmt.Sprintf("%-6d %-*s %-8s %s", issue.Number, titleWidth, title, "Open", labels)
+			content.WriteString(theme.GetStyle("selected-row").Width(listInner).Render("> " + row))
+		} else {
+			row := fmt.Sprintf("  %-6d %-*s %-8s %s", issue.Number, titleWidth, title, "Open", labels)
+			content.WriteString(row)
+		}
+		content.WriteString("\n")
+	}
+	if len(issues) == 0 {
+		content.WriteString("  No issues found.\n")
+	}
+	st := theme.GetStyle("worktree-list").Width(listInner + panelPaddingOverhead)
+	if panelHeight > 0 {
+		st = st.Height(panelHeight)
+	}
+	return st.Render(strings.TrimRight(content.String(), "\n"))
+}
+
+func renderPRList(prs []domain.PullRequest, selectedIdx int, theme styles.Theme, listInner, panelHeight int) string {
+	var content strings.Builder
+	headerStyle := theme.GetStyle("table-header")
+	titleWidth := listInner - 50
+	if titleWidth < 10 {
+		titleWidth = 10
+	}
+	headerRow := fmt.Sprintf("  %-6s %-*s %-16s %-14s %s", "#", titleWidth, "TITLE", "BRANCH", "AUTHOR", "STATUS")
+	content.WriteString(headerStyle.Render(headerRow))
+	content.WriteString("\n")
+	for i, pr := range prs {
+		title := truncateStr(pr.Title, titleWidth)
+		branch := truncateStr(pr.Branch, 16)
+		author := truncateStr(pr.Author, 14)
+		state := pr.State
+		if pr.IsDraft {
+			state = "DRAFT"
+		}
+		if i == selectedIdx {
+			row := fmt.Sprintf("%-6d %-*s %-16s %-14s %s", pr.Number, titleWidth, title, branch, author, state)
+			content.WriteString(theme.GetStyle("selected-row").Width(listInner).Render("> " + row))
+		} else {
+			row := fmt.Sprintf("  %-6d %-*s %-16s %-14s %s", pr.Number, titleWidth, title, branch, author, state)
+			content.WriteString(row)
+		}
+		content.WriteString("\n")
+	}
+	if len(prs) == 0 {
+		content.WriteString("  No open PRs.\n")
+	}
+	st := theme.GetStyle("worktree-list").Width(listInner + panelPaddingOverhead)
+	if panelHeight > 0 {
+		st = st.Height(panelHeight)
+	}
+	return st.Render(strings.TrimRight(content.String(), "\n"))
 }
 
 func renderFooterBar(theme styles.Theme, date string, termWidth int, syncing bool, lastSynced time.Time, syncErr error) string {

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -213,8 +213,12 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, theme styles.Theme,
 	headerRow := fmt.Sprintf("  %-6s %-*s %-8s %s", "#", titleWidth, "TITLE", "STATUS", "LABELS")
 	content.WriteString(headerStyle.Render(headerRow))
 	content.WriteString("\n")
+	labelsWidth := listInner - titleWidth - 19 // remaining after "  <6#> <titleWidth> <8status> " prefix
+	if labelsWidth < 8 {
+		labelsWidth = 8
+	}
 	for i, issue := range issues {
-		labels := strings.Join(issue.Labels, " ")
+		labels := truncateStr(strings.Join(issue.Labels, " "), labelsWidth)
 		title := truncateStr(issue.Title, titleWidth)
 		// "Open" is hardcoded because gh issue list only returns open issues by default.
 		if i == selectedIdx {

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/m00nk0d3/nexus/internal/tui/styles"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -294,3 +295,380 @@ func TestRenderFooterBar_SyncStatus(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Phase 2: Issues & PRs View — RED tests (features not yet implemented)
+// ---------------------------------------------------------------------------
+
+// TestRenderIssueList_ContainsHeaders verifies that renderIssueList renders
+// the required column headers: #, TITLE, STATUS, LABELS.
+func TestRenderIssueList_ContainsHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		wantIn []string
+	}{
+		{
+			name:   "renders all required column headers",
+			wantIn: []string{"#", "TITLE", "STATUS", "LABELS"},
+		},
+	}
+
+	theme := styles.NewTheme("digital-noir")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderIssueList(nil, 0, theme, 80, 20)
+			for _, want := range tt.wantIn {
+				assert.Contains(t, result, want)
+			}
+		})
+	}
+}
+
+// TestRenderIssueList_ContainsIssueRows verifies that issue number, title, labels
+// are rendered, and that the selected row has a ">" cursor.
+func TestRenderIssueList_ContainsIssueRows(t *testing.T) {
+	issues := []domain.Issue{
+		{Number: 7, Title: "Fix the bug", Labels: []string{"bug", "p1"}},
+		{Number: 8, Title: "Add feature", Labels: []string{"enhancement"}},
+	}
+
+	tests := []struct {
+		name        string
+		selectedIdx int
+		wantIn      []string
+	}{
+		{
+			name:        "renders issue number and title for all issues",
+			selectedIdx: 0,
+			wantIn:      []string{"7", "Fix the bug", "8", "Add feature"},
+		},
+		{
+			name:        "renders issue labels",
+			selectedIdx: 0,
+			wantIn:      []string{"bug", "enhancement"},
+		},
+		{
+			name:        "selected issue (idx 0) has > cursor",
+			selectedIdx: 0,
+			wantIn:      []string{"> "},
+		},
+		{
+			name:        "selected issue (idx 1) has > cursor",
+			selectedIdx: 1,
+			wantIn:      []string{"> "},
+		},
+	}
+
+	theme := styles.NewTheme("digital-noir")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderIssueList(issues, tt.selectedIdx, theme, 80, 20)
+			for _, want := range tt.wantIn {
+				assert.Contains(t, result, want)
+			}
+		})
+	}
+}
+
+// TestRenderPRList_ContainsHeaders verifies that renderPRList renders
+// the required column headers: #, TITLE, BRANCH, AUTHOR, STATUS.
+func TestRenderPRList_ContainsHeaders(t *testing.T) {
+	tests := []struct {
+		name   string
+		wantIn []string
+	}{
+		{
+			name:   "renders all required column headers",
+			wantIn: []string{"#", "TITLE", "BRANCH", "AUTHOR", "STATUS"},
+		},
+	}
+
+	theme := styles.NewTheme("digital-noir")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderPRList(nil, 0, theme, 80, 20)
+			for _, want := range tt.wantIn {
+				assert.Contains(t, result, want)
+			}
+		})
+	}
+}
+
+// TestRenderPRList_ContainsPRRows verifies that PR number, title, branch, author
+// and state are rendered, and that the selected PR has a ">" cursor.
+func TestRenderPRList_ContainsPRRows(t *testing.T) {
+	prs := []domain.PullRequest{
+		{Number: 42, Title: "My PR", Branch: "feat/awesome", Author: "alice", State: "OPEN"},
+		{Number: 43, Title: "Fix PR", Branch: "fix/bug", Author: "bob", State: "OPEN"},
+	}
+
+	tests := []struct {
+		name        string
+		selectedIdx int
+		wantIn      []string
+	}{
+		{
+			name:        "renders PR number, title, branch, author, state",
+			selectedIdx: 0,
+			wantIn:      []string{"42", "My PR", "feat/awesome", "alice", "OPEN"},
+		},
+		{
+			name:        "selected PR (idx 0) has > cursor",
+			selectedIdx: 0,
+			wantIn:      []string{"> "},
+		},
+		{
+			name:        "second PR is also rendered",
+			selectedIdx: 0,
+			wantIn:      []string{"43", "Fix PR", "fix/bug", "bob"},
+		},
+	}
+
+	theme := styles.NewTheme("digital-noir")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderPRList(prs, tt.selectedIdx, theme, 80, 20)
+			for _, want := range tt.wantIn {
+				assert.Contains(t, result, want)
+			}
+		})
+	}
+}
+
+// TestRenderContextPanel_IssueContext verifies that when the active view is
+// viewIssues, the context panel shows the selected issue's number, title, labels,
+// and an "[g] Open in GitHub" hint.
+func TestRenderContextPanel_IssueContext(t *testing.T) {
+	tests := []struct {
+		name        string
+		issues      []domain.Issue
+		selectedIdx int
+		wantIn      []string
+	}{
+		{
+			name: "shows Issue context header with number and title",
+			issues: []domain.Issue{
+				{Number: 14, Title: "Implement Issues View", Labels: []string{"feature"}},
+			},
+			selectedIdx: 0,
+			wantIn:      []string{"Issue #14", "Implement Issues View"},
+		},
+		{
+			name: "shows labels in [label] bracket format",
+			issues: []domain.Issue{
+				{Number: 5, Title: "Bug Report", Labels: []string{"bug", "critical"}},
+			},
+			selectedIdx: 0,
+			wantIn:      []string{"[bug]", "[critical]"},
+		},
+		{
+			name: "shows [g] Open in GitHub hint",
+			issues: []domain.Issue{
+				{Number: 1, Title: "Some Issue", Labels: nil},
+			},
+			selectedIdx: 0,
+			wantIn:      []string{"[g] Open in GitHub"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = viewIssues
+			model.issues = tt.issues
+			model.selectedIssueIdx = tt.selectedIdx
+
+			view := model.View()
+
+			for _, want := range tt.wantIn {
+				assert.Contains(t, view, want)
+			}
+		})
+	}
+}
+
+// TestRenderContextPanel_PRContext verifies that when the active view is
+// viewPRs, the context panel shows the selected PR's number, title, branch,
+// author, state, and an "[g] Open in GitHub" hint.
+func TestRenderContextPanel_PRContext(t *testing.T) {
+	tests := []struct {
+		name      string
+		prs       []domain.PullRequest
+		prIdx     int
+		wantIn    []string
+	}{
+		{
+			name: "shows PR context header with number and title",
+			prs: []domain.PullRequest{
+				{Number: 42, Title: "Add search feature", Branch: "feat/search", Author: "alice", State: "OPEN"},
+			},
+			prIdx:  0,
+			wantIn: []string{"PR #42", "Add search feature"},
+		},
+		{
+			name: "shows branch and author in context panel",
+			prs: []domain.PullRequest{
+				{Number: 10, Title: "Fix bug", Branch: "fix/null-ptr", Author: "bob", State: "OPEN"},
+			},
+			prIdx:  0,
+			wantIn: []string{"fix/null-ptr", "bob"},
+		},
+		{
+			name: "shows PR state in context panel",
+			prs: []domain.PullRequest{
+				{Number: 55, Title: "Open PR", Branch: "feat/draft", Author: "carol", State: "OPEN"},
+			},
+			prIdx:  0,
+			wantIn: []string{"OPEN"},
+		},
+		{
+			name: "shows [g] Open in GitHub hint",
+			prs: []domain.PullRequest{
+				{Number: 1, Title: "Some PR", Branch: "main", Author: "dev", State: "OPEN"},
+			},
+			prIdx:  0,
+			wantIn: []string{"[g] Open in GitHub"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = viewPRs
+			model.prs = tt.prs
+			model.selectedPRIdx = tt.prIdx
+
+			view := model.View()
+
+			for _, want := range tt.wantIn {
+				assert.Contains(t, view, want)
+			}
+		})
+	}
+}
+
+// TestRenderFull_IssueViewShowsIssueList verifies that when view is viewIssues,
+// renderFull (via model.View()) shows issue data in the main list panel.
+func TestRenderFull_IssueViewShowsIssueList(t *testing.T) {
+	tests := []struct {
+		name   string
+		issues []domain.Issue
+		wantIn []string
+	}{
+		{
+			name: "issue view renders issue number and title",
+			issues: []domain.Issue{
+				{Number: 99, Title: "Test Issue"},
+			},
+			wantIn: []string{"99", "Test Issue"},
+		},
+		{
+			name: "issue view renders issue column headers",
+			issues: []domain.Issue{
+				{Number: 1, Title: "Any Issue"},
+			},
+			wantIn: []string{"TITLE", "STATUS"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = viewIssues
+			model.issues = tt.issues
+
+			view := model.View()
+
+			for _, want := range tt.wantIn {
+				assert.Contains(t, view, want)
+			}
+		})
+	}
+}
+
+// TestRenderFull_PRViewShowsPRList verifies that when view is viewPRs,
+// renderFull (via model.View()) shows PR data in the main list panel.
+func TestRenderFull_PRViewShowsPRList(t *testing.T) {
+	tests := []struct {
+		name   string
+		prs    []domain.PullRequest
+		wantIn []string
+	}{
+		{
+			name: "PR view renders PR number, title, and branch",
+			prs: []domain.PullRequest{
+				{Number: 88, Title: "Test PR", Branch: "feat/test", Author: "dev", State: "OPEN"},
+			},
+			wantIn: []string{"88", "Test PR", "feat/test"},
+		},
+		{
+			name: "PR view renders PR column headers",
+			prs: []domain.PullRequest{
+				{Number: 1, Title: "Any PR", Branch: "main", Author: "dev", State: "OPEN"},
+			},
+			wantIn: []string{"BRANCH", "AUTHOR"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = viewPRs
+			model.prs = tt.prs
+
+			view := model.View()
+
+			for _, want := range tt.wantIn {
+				assert.Contains(t, view, want)
+			}
+		})
+	}
+}
+
+// TestRenderFull_WorktreesViewStillWorks verifies that when view is viewWorktrees,
+// the existing worktree table still renders correctly.
+func TestRenderFull_WorktreesViewStillWorks(t *testing.T) {
+	tests := []struct {
+		name      string
+		worktrees []domain.Worktree
+		wantIn    []string
+	}{
+		{
+			name: "worktrees view shows worktree column headers",
+			worktrees: []domain.Worktree{
+				{Path: "/tmp/wt-main", Branch: "main", IsClean: true},
+			},
+			wantIn: []string{"NAME", "PATH", "STATUS"},
+		},
+		{
+			name: "worktrees view shows worktree name",
+			worktrees: []domain.Worktree{
+				{Path: "/tmp/wt-main", Branch: "main", IsClean: true},
+			},
+			wantIn: []string{"wt-main"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = viewWorktrees
+			model.Worktrees = tt.worktrees
+
+			view := model.View()
+
+			for _, want := range tt.wantIn {
+				assert.Contains(t, view, want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End Phase 2 RED tests (renderer_test.go)
+// ---------------------------------------------------------------------------

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -297,7 +297,7 @@ func TestRenderFooterBar_SyncStatus(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 2: Issues & PRs View — RED tests (features not yet implemented)
+// Phase 2: Issues & PRs View tests
 // ---------------------------------------------------------------------------
 
 // TestRenderIssueList_ContainsHeaders verifies that renderIssueList renders
@@ -670,5 +670,5 @@ func TestRenderFull_WorktreesViewStillWorks(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// End Phase 2 RED tests (renderer_test.go)
+// End Phase 2 tests (renderer_test.go)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #14

## What Changed
Implements the Issues (`I`) and PRs (`P`) view screens in the NAV RAIL middle panel, completing the `activeView` state machine for the TUI.

## Why
Only the Worktrees view (`W`) was previously implemented. This adds full Issues and PRs browsing with keyboard navigation and context panel integration.

## Changes
- `activeView` enum (`viewWorktrees`, `viewIssues`, `viewPRs`) replacing `activeNav int`
- `W`/`I`/`P` keys switch active view; per-view `↑`/`↓` navigation
- `[g]` key opens selected issue/PR in browser via `gh` CLI
- `renderIssueList()`: table with `#`, `TITLE`, `STATUS`, `LABELS`
- `renderPRList()`: table with `#`, `TITLE`, `BRANCH`, `AUTHOR`, `STATUS`
- `renderContextPanel()` dispatches on active view to show issue/PR context
- 12 new TDD tests; all 61 tests pass

## Testing
- `go test ./cmd/nexus/...` — all 61 tests pass
- Manual: press `I` → issues table, `P` → PRs table, `W` → worktrees, `[g]` → opens in browser