### PR TITLE
fix(tui): cap context panel height to terminal size and scroll cleanly

### DIFF
--- a/.copilot/agent-memory/tdd-enforcer/MEMORY.md
+++ b/.copilot/agent-memory/tdd-enforcer/MEMORY.md
@@ -1,43 +1,58 @@
-# TDD Enforcer Memory — nexus (m00nk0d3/nexus)
+ï»¿# TDD Enforcer Memory - nexus (m00nk0d3/nexus)
 
 ## Project Stack
-- Go (backend only), located at repo root
-- Test runner: go test ./internal/...
+- Go TUI app (Bubbletea), package `main` in `cmd/nexus/`
+- Test runner: `go test ./cmd/nexus/... -v`
+- Build: `go build ./...`
 
 ## Test Commands
-- Run all tests: go test ./internal/exec/... ./internal/domain/...
-- Run with verbose output: go test -v ./internal/exec/... ./internal/domain/...
-- Filter specific test: go test -run TestName ./internal/exec/...
+- Run all tests: `go test ./cmd/nexus/...`
+- Run renderer tests: `go test ./cmd/nexus/... -run "TestRenderer"`
+- Filter specific test: `go test ./cmd/nexus/... -run TestName`
 
 ## Architecture Pattern
-- internal/domain/ — pure structs, no deps (Issue, PullRequest, Worktree…)
-- internal/exec/ — gh/git CLI wrappers; use injected commandRunner for testability
-- Constructor pair: NewXxx(repoPath) calls NewXxxWithRunner(repoPath, runGhCommand)
-- Tests always use NewXxxWithRunner with a mock runner func
+- `internal/domain/` -- pure structs (Issue, PullRequest, Worktree)
+- `cmd/nexus/app.go` -- BubbleTea Model, Update, View, NewModel()
+- `cmd/nexus/renderer.go` -- pure render functions called from View()
+- Tests use `NewModel()` + set unexported fields directly (same `main` package)
 
-## Test Conventions (exec package)
-- Mock runner: unc(_ string, args ...string) (string, error) { return output, err }
-- Capture args: ar capturedArgs []string inside the runner closure
-- Table-driven tests for happy path, error, empty, edge cases in one 	ests := []struct{...} block
-- Use 	estify/assert + 	estify/require; equire.NoError, ssert.Contains, ssert.Equal
+## TUI Test Conventions (renderer_test.go)
+- All tests via `model.View()` -- no direct render function calls for context panel
+- Set state: `model.view = viewWorktrees/viewIssues/viewPRs`, `model.Worktrees`, `model.selectedIdx`
+- Lipgloss ANSI codes stripped in test env (no TTY), raw text is directly assertable
+- Use `assert.Contains(t, view, want)` for positive assertions
+- Use `assert.NotContains(t, view, notWant)` for negative assertions
+- `model.width = 300` for wide-terminal tests to prevent truncation
 
-## Error Wrapping Convention
-- mt.Errorf("list open prs: %w", err) — verb phrase prefix, then %w
-- Parse errors: mt.Errorf("parse pr list: %w", err)
-- Single-item fetch: mt.Errorf("get pr: %w", err) / mt.Errorf("parse pr: %w", err)
+## Key Model Fields (accessible in same package)
+- `model.selectedIdx` -- worktree selection
+- `model.selectedIssueIdx`, `model.selectedPRIdx`
+- `model.view`, `model.Worktrees`, `model.issues`, `model.prs`
+- `model.syncing`, `model.lastSynced`, `model.syncErr`, `model.width`
 
-## JSON Mapping Pattern (gh CLI)
-- Inner structs (ghLabel, ghAuthor, ghIssue, ghPR) kept unexported in the exec package
-- Labels always mapped via make([]string, len(g.Labels)) to guarantee non-nil slice
-- Shared mapping extracted to ghXxxToDomain(g ghXxx) domain.Xxx helper to avoid duplication
+## Renderer Helpers
+- `worktreeStatus(wt)` returns "Idle" | "Dirty" | "Locked"
+- `truncateStr(s, n)` -- clips to n runes with "..."
+- `formatLabels([]string)` -- "[label1][label2]" format (shared between issue + PR contexts)
+- `prStateColor(state)` -- lipgloss.Color: OPEN=#00D9FF, MERGED=#9B59B6, CLOSED=#E74C3C
+
+## GH:ID Column (renderWorktreePanel)
+- Default ghID = "-" when LinkedPR == nil (not empty string)
+- Non-selected rows: colorize with lipgloss (OPEN=cyan, MERGED/CLOSED=grey #4A5568)
+- Selected rows: ghID embedded in fmt.Sprintf string (no individual coloring needed)
+
+## Context Panel -- Worktree View (renderContextPanel default case)
+- With LinkedPR: shows "Context: PR #N", title (truncated), "GH Title:", "Author: @", "Status: * STATE", "Labels: [x][y]", AGENT COMMANDS
+- Without LinkedPR: shows "Context: basename", "Branch: ", "Path: ", AGENT COMMANDS
+- Agent commands (always present): `[a] Spawn Claude Code`, `[c] Spawn Copilot`, `[s] Open Shell in WT`
 
 ## Completed Issues
-- Issue #8: Added domain.PullRequest, GitHubClient with ListOpenPRs/GetPR — 12 new tests, all green
+- Issue #8: Added domain.PullRequest, GitHubClient with ListOpenPRs/GetPR
+- Issue #14: Added Issues/PRs views, renderIssueList, renderPRList, context panel for Issues+PRs
+- Issue #15: PR context panel in worktree view + GH:ID column colorization + "-" default when no PR
 
-## Issue #10: SQLite DB Setup (feat/issue-10-sqlite-db-setup)
-- RED tests written: `internal/data/db_test.go` (`package data_test`)
-- Target API: `func NewDB(path string) (*DB, error)`, `type DB struct { DB *sql.DB }`, `func (db *DB) Close() error`
-- SQLite driver: `modernc.org/sqlite` (pure-Go, no CGO). Driver name `"sqlite"`. Run `go get modernc.org/sqlite`.
-- Schema tables required: `worktrees`, `github_prs`, `github_issues`, `agent_history`, `context_snapshots`
-- `worktrees` min cols: `path TEXT`, `branch TEXT`. `github_prs` min cols: `number INTEGER`, `title TEXT`, `branch TEXT`, `state TEXT`.
-- Existing stub in `sqlite.go` has `type Database` / `NewDatabase` -- keep it; add new `db.go` with `type DB`.
+## exec package conventions (internal/exec/)
+- Constructor pair: NewXxx(repoPath) calls NewXxxWithRunner(repoPath, runGhCommand)
+- Tests always use NewXxxWithRunner with a mock runner func
+- Error wrapping: `fmt.Errorf("verb phrase: %w", err)` pattern
+- JSON inner structs (ghLabel, ghAuthor, etc.) kept unexported in exec package

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -176,12 +176,21 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.themeIdx = (m.themeIdx + 1) % len(styles.Themes)
 			case "w", "W":
 				m.view = viewWorktrees
+				m.ctxScrollOffset = 0
 			case "i", "I":
 				m.view = viewIssues
+				m.ctxScrollOffset = 0
 			case "p", "P":
 				m.view = viewPRs
+				m.ctxScrollOffset = 0
 			case "g", "G":
 				return m, m.openInBrowserCmd()
+			case "s", "S":
+				if m.view == viewWorktrees {
+					if selected, ok := m.selectedWorktree(); ok {
+						return m, m.switchWorktreeCmd(selected.Path)
+					}
+				}
 			}
 		}
 
@@ -454,14 +463,17 @@ func (m *Model) moveDown() {
 		case viewIssues:
 			if m.selectedIssueIdx < len(m.issues)-1 {
 				m.selectedIssueIdx++
+				m.ctxScrollOffset = 0
 			}
 		case viewPRs:
 			if m.selectedPRIdx < len(m.prs)-1 {
 				m.selectedPRIdx++
+				m.ctxScrollOffset = 0
 			}
 		default:
 			if m.selectedIdx < len(m.Worktrees)-1 {
 				m.selectedIdx++
+				m.ctxScrollOffset = 0
 			}
 		}
 	}
@@ -488,14 +500,17 @@ func (m *Model) moveUp() {
 		case viewIssues:
 			if m.selectedIssueIdx > 0 {
 				m.selectedIssueIdx--
+				m.ctxScrollOffset = 0
 			}
 		case viewPRs:
 			if m.selectedPRIdx > 0 {
 				m.selectedPRIdx--
+				m.ctxScrollOffset = 0
 			}
 		default:
 			if m.selectedIdx > 0 {
 				m.selectedIdx--
+				m.ctxScrollOffset = 0
 			}
 		}
 	}

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -59,8 +59,8 @@ const (
 type focusedPanel int
 
 const (
-	panelList  focusedPanel = iota // Main content list (default focus)
-	panelNav                       // Left navigation rail
+	panelNav   focusedPanel = iota // Left navigation rail (default focus)
+	panelList                      // Main content list
 	panelCtx                       // Right context panel
 	panelCount                     // Sentinel — used for modular cycling via (p+1)%panelCount
 )

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -55,6 +55,16 @@ const (
 	viewPRs                         // Shows the GitHub pull requests list
 )
 
+// focusedPanel identifies which panel currently has keyboard focus.
+type focusedPanel int
+
+const (
+	panelList  focusedPanel = iota // Main content list (default focus)
+	panelNav                       // Left navigation rail
+	panelCtx                       // Right context panel
+	panelCount                     // Sentinel — used for modular cycling via (p+1)%panelCount
+)
+
 // Model represents the root Bubbletea model for the Nexus TUI application.
 // It manages the list of git worktrees, user interactions, and active modals.
 type Model struct {
@@ -75,6 +85,8 @@ type Model struct {
 	syncing          bool                 // True while a background GitHub sync is in progress
 	selectedIssueIdx int                  // Currently selected issue index
 	selectedPRIdx    int                  // Currently selected PR index
+	focused          focusedPanel         // Which panel currently has keyboard focus
+	ctxScrollOffset  int                  // Scroll position within the context panel
 }
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
@@ -132,6 +144,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.Type {
+		case tea.KeyTab:
+			m.focused = (m.focused + 1) % panelCount
+			return m, nil
 		case tea.KeyEnter:
 			if selected, ok := m.selectedWorktree(); ok {
 				return m, m.switchWorktreeCmd(selected.Path)
@@ -146,37 +161,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.activeModal = modal.NewDeleteModal(selected)
 			}
 		case tea.KeyUp:
-			switch m.view {
-			case viewIssues:
-				if m.selectedIssueIdx > 0 {
-					m.selectedIssueIdx--
-				}
-			case viewPRs:
-				if m.selectedPRIdx > 0 {
-					m.selectedPRIdx--
-				}
-			default:
-				if m.selectedIdx > 0 {
-					m.selectedIdx--
-				}
-			}
+			m.moveUp()
 		case tea.KeyDown:
-			switch m.view {
-			case viewIssues:
-				if m.selectedIssueIdx < len(m.issues)-1 {
-					m.selectedIssueIdx++
-				}
-			case viewPRs:
-				if m.selectedPRIdx < len(m.prs)-1 {
-					m.selectedPRIdx++
-				}
-			default:
-				if m.selectedIdx < len(m.Worktrees)-1 {
-					m.selectedIdx++
-				}
-			}
+			m.moveDown()
 		case tea.KeyRunes:
 			switch msg.String() {
+			case "j":
+				m.moveDown()
+				return m, nil
+			case "k":
+				m.moveUp()
+				return m, nil
 			case "t":
 				m.themeIdx = (m.themeIdx + 1) % len(styles.Themes)
 			case "w", "W":
@@ -260,7 +255,7 @@ func (m *Model) View() string {
 	if m.activeModal != nil {
 		baseView = m.activeModal.View()
 	} else {
-		baseView = renderFull(m.Worktrees, m.selectedIdx, m.RepoPath, m.themeIdx, m.view, m.width, m.height, m.syncing, m.lastSynced, m.syncErr, m.issues, m.selectedIssueIdx, m.prs, m.selectedPRIdx)
+		baseView = renderFull(m.Worktrees, m.selectedIdx, m.RepoPath, m.themeIdx, m.view, m.width, m.height, m.syncing, m.lastSynced, m.syncErr, m.issues, m.selectedIssueIdx, m.prs, m.selectedPRIdx, m.focused, m.ctxScrollOffset)
 	}
 
 	if m.Error == "" {
@@ -437,5 +432,71 @@ func (m *Model) clampPRIdx() {
 	}
 	if m.selectedPRIdx >= len(m.prs) {
 		m.selectedPRIdx = len(m.prs) - 1
+	}
+}
+
+// moveDown advances the selection within the currently focused panel.
+// Nav panel: cycles the active view forward.
+// Ctx panel: scrolls the context content down.
+// List panel (default): moves the item cursor down.
+func (m *Model) moveDown() {
+	switch m.focused {
+	case panelNav:
+		n := int(m.view) + 1
+		if n > int(viewPRs) {
+			n = int(viewWorktrees)
+		}
+		m.view = activeView(n)
+	case panelCtx:
+		m.ctxScrollOffset++
+	default: // panelList
+		switch m.view {
+		case viewIssues:
+			if m.selectedIssueIdx < len(m.issues)-1 {
+				m.selectedIssueIdx++
+			}
+		case viewPRs:
+			if m.selectedPRIdx < len(m.prs)-1 {
+				m.selectedPRIdx++
+			}
+		default:
+			if m.selectedIdx < len(m.Worktrees)-1 {
+				m.selectedIdx++
+			}
+		}
+	}
+}
+
+// moveUp retreats the selection within the currently focused panel.
+// Nav panel: cycles the active view backward.
+// Ctx panel: scrolls the context content up.
+// List panel (default): moves the item cursor up.
+func (m *Model) moveUp() {
+	switch m.focused {
+	case panelNav:
+		n := int(m.view) - 1
+		if n < int(viewWorktrees) {
+			n = int(viewPRs)
+		}
+		m.view = activeView(n)
+	case panelCtx:
+		if m.ctxScrollOffset > 0 {
+			m.ctxScrollOffset--
+		}
+	default: // panelList
+		switch m.view {
+		case viewIssues:
+			if m.selectedIssueIdx > 0 {
+				m.selectedIssueIdx--
+			}
+		case viewPRs:
+			if m.selectedPRIdx > 0 {
+				m.selectedPRIdx--
+			}
+		default:
+			if m.selectedIdx > 0 {
+				m.selectedIdx--
+			}
+		}
 	}
 }

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -720,6 +720,7 @@ func TestModel_IssueNavigation(t *testing.T) {
 			require.NotNil(t, model)
 			model.issues = issues
 			model.view = viewIssues
+			model.focused = panelList
 			model.selectedIssueIdx = tt.initialIssueIdx
 
 			updated, _ := model.Update(tea.KeyMsg{Type: tt.keyType})
@@ -784,6 +785,7 @@ func TestModel_PRNavigation(t *testing.T) {
 			require.NotNil(t, model)
 			model.prs = prs
 			model.view = viewPRs
+			model.focused = panelList
 			model.selectedPRIdx = tt.initialPRIdx
 
 			updated, _ := model.Update(tea.KeyMsg{Type: tt.keyType})
@@ -961,25 +963,25 @@ func TestModel_BrowserOpenErrMsg_NilErrorNoChange(t *testing.T) {
 // Phase 4: Panel focus & j/k navigation tests
 // ---------------------------------------------------------------------------
 
-// TestModel_DefaultFocus_IsListPanel verifies that a new model starts with
-// the list panel focused (panelList is the zero value).
-func TestModel_DefaultFocus_IsListPanel(t *testing.T) {
+// TestModel_DefaultFocus_IsNavPanel verifies that a new model starts with
+// the nav panel focused (panelNav is the zero value).
+func TestModel_DefaultFocus_IsNavPanel(t *testing.T) {
 	model := NewModel()
 	require.NotNil(t, model)
-	assert.Equal(t, panelList, model.focused)
+	assert.Equal(t, panelNav, model.focused)
 }
 
 // TestModel_Tab_CyclesFocusThroughPanels verifies that Tab cycles focus
-// through list → nav → ctx → list.
+// left to right: nav → list → ctx → nav.
 func TestModel_Tab_CyclesFocusThroughPanels(t *testing.T) {
 	tests := []struct {
 		name         string
 		initialFocus focusedPanel
 		wantFocus    focusedPanel
 	}{
-		{name: "Tab from list focuses nav", initialFocus: panelList, wantFocus: panelNav},
-		{name: "Tab from nav focuses ctx", initialFocus: panelNav, wantFocus: panelCtx},
-		{name: "Tab from ctx wraps to list", initialFocus: panelCtx, wantFocus: panelList},
+		{name: "Tab from nav focuses list", initialFocus: panelNav, wantFocus: panelList},
+		{name: "Tab from list focuses ctx", initialFocus: panelList, wantFocus: panelCtx},
+		{name: "Tab from ctx wraps to nav", initialFocus: panelCtx, wantFocus: panelNav},
 	}
 
 	for _, tt := range tests {

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -1141,3 +1141,54 @@ func TestModel_WindowSizeMsg_StoresDimensions(t *testing.T) {
 		})
 	}
 }
+
+
+// TestModelUpdate_SKeyOpensShellInWorktree verifies that pressing "s" in
+// viewWorktrees with a selected worktree triggers switchWorktreeCmd.
+func TestModelUpdate_SKeyOpensShellInWorktree(t *testing.T) {
+tests := []struct {
+name       string
+view       activeView
+worktrees  []domain.Worktree
+wantCmdNil bool
+}{
+{
+name: "s key triggers switchWorktreeCmd when in worktrees view",
+view: viewWorktrees,
+worktrees: []domain.Worktree{
+{Path: "/tmp/my-wt", Branch: "feat/my-branch", IsClean: true},
+},
+wantCmdNil: false,
+},
+{
+name:       "s key does nothing when worktree list is empty",
+view:       viewWorktrees,
+worktrees:  nil,
+wantCmdNil: true,
+},
+{
+name: "s key does nothing in issues view",
+view: viewIssues,
+worktrees: []domain.Worktree{
+{Path: "/tmp/my-wt", Branch: "feat/my-branch", IsClean: true},
+},
+wantCmdNil: true,
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+model := NewModel()
+require.NotNil(t, model)
+model.view = tt.view
+model.Worktrees = tt.worktrees
+
+_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+if tt.wantCmdNil {
+assert.Nil(t, cmd)
+} else {
+assert.NotNil(t, cmd, "expected a non-nil cmd from switchWorktreeCmd")
+}
+})
+}
+}

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -957,7 +957,151 @@ func TestModel_BrowserOpenErrMsg_NilErrorNoChange(t *testing.T) {
 	assert.Empty(t, m.Error)
 }
 
-func TestModel_WindowSizeMsg_StoresTerminalWidth(t *testing.T) {
+// ---------------------------------------------------------------------------
+// Phase 4: Panel focus & j/k navigation tests
+// ---------------------------------------------------------------------------
+
+// TestModel_DefaultFocus_IsListPanel verifies that a new model starts with
+// the list panel focused (panelList is the zero value).
+func TestModel_DefaultFocus_IsListPanel(t *testing.T) {
+	model := NewModel()
+	require.NotNil(t, model)
+	assert.Equal(t, panelList, model.focused)
+}
+
+// TestModel_Tab_CyclesFocusThroughPanels verifies that Tab cycles focus
+// through list → nav → ctx → list.
+func TestModel_Tab_CyclesFocusThroughPanels(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialFocus focusedPanel
+		wantFocus    focusedPanel
+	}{
+		{name: "Tab from list focuses nav", initialFocus: panelList, wantFocus: panelNav},
+		{name: "Tab from nav focuses ctx", initialFocus: panelNav, wantFocus: panelCtx},
+		{name: "Tab from ctx wraps to list", initialFocus: panelCtx, wantFocus: panelList},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.focused = tt.initialFocus
+
+			updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyTab})
+			m, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.wantFocus, m.focused)
+		})
+	}
+}
+
+// TestModel_JK_ListFocused_NavigatesWorktrees verifies that j/k navigate
+// the worktree list when the list panel is focused.
+func TestModel_JK_ListFocused_NavigatesWorktrees(t *testing.T) {
+	worktrees := []domain.Worktree{
+		{Path: "/wt/a"},
+		{Path: "/wt/b"},
+		{Path: "/wt/c"},
+	}
+
+	tests := []struct {
+		name       string
+		key        rune
+		initialIdx int
+		wantIdx    int
+	}{
+		{name: "j moves selection down", key: 'j', initialIdx: 0, wantIdx: 1},
+		{name: "k moves selection up", key: 'k', initialIdx: 1, wantIdx: 0},
+		{name: "j at bottom stays", key: 'j', initialIdx: 2, wantIdx: 2},
+		{name: "k at top stays", key: 'k', initialIdx: 0, wantIdx: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.Worktrees = worktrees
+			model.selectedIdx = tt.initialIdx
+			model.focused = panelList
+
+			updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tt.key}})
+			m, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.wantIdx, m.selectedIdx)
+		})
+	}
+}
+
+// TestModel_JK_NavFocused_ChangesView verifies that j/k cycle through views
+// when the nav panel is focused.
+func TestModel_JK_NavFocused_ChangesView(t *testing.T) {
+	tests := []struct {
+		name        string
+		key         rune
+		initialView activeView
+		wantView    activeView
+	}{
+		{name: "j from worktrees → issues", key: 'j', initialView: viewWorktrees, wantView: viewIssues},
+		{name: "j from issues → PRs", key: 'j', initialView: viewIssues, wantView: viewPRs},
+		{name: "j from PRs wraps → worktrees", key: 'j', initialView: viewPRs, wantView: viewWorktrees},
+		{name: "k from PRs → issues", key: 'k', initialView: viewPRs, wantView: viewIssues},
+		{name: "k from issues → worktrees", key: 'k', initialView: viewIssues, wantView: viewWorktrees},
+		{name: "k from worktrees wraps → PRs", key: 'k', initialView: viewWorktrees, wantView: viewPRs},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = tt.initialView
+			model.focused = panelNav
+
+			updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tt.key}})
+			m, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.wantView, m.view)
+		})
+	}
+}
+
+// TestModel_JK_CtxFocused_ChangesScrollOffset verifies that j/k change the
+// context panel scroll offset when the ctx panel is focused.
+func TestModel_JK_CtxFocused_ChangesScrollOffset(t *testing.T) {
+	tests := []struct {
+		name          string
+		key           rune
+		initialOffset int
+		wantOffset    int
+	}{
+		{name: "j increments offset", key: 'j', initialOffset: 0, wantOffset: 1},
+		{name: "j increments from non-zero", key: 'j', initialOffset: 3, wantOffset: 4},
+		{name: "k decrements offset", key: 'k', initialOffset: 2, wantOffset: 1},
+		{name: "k at zero stays at zero", key: 'k', initialOffset: 0, wantOffset: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.focused = panelCtx
+			model.ctxScrollOffset = tt.initialOffset
+
+			updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tt.key}})
+			m, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.wantOffset, m.ctxScrollOffset)
+		})
+	}
+}
+
+// TestModel_WindowSizeMsg_StoresDimensions verifies that WindowSizeMsg updates
+// width and height fields on the model.
+func TestModel_WindowSizeMsg_StoresDimensions(t *testing.T) {
 	tests := []struct {
 		name       string
 		msgWidth   int

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	appVersion       = "1.0"
-	footerHints      = "[↑/↓] Navigate | [Enter] Select | [t] Theme | [g] Open in GH | [esc] Quit"
+	footerHints      = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [t] Theme | [g] GH | [esc] Quit"
 	actionBarHints   = "[c-n] New  [c-d] Delete  [c-l] Lock | [f1] Help"
 	defaultTermWidth = 120
 	navPanelInner    = 18
@@ -45,7 +45,7 @@ var navItems = []navItem{
 // renderFull builds the complete 3-pane TUI layout.
 // termWidth is the terminal column count; 0 falls back to defaultTermWidth.
 // termHeight is the terminal row count; 0 disables explicit panel height.
-func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, themeIdx int, view activeView, termWidth, termHeight int, syncing bool, lastSynced time.Time, syncErr error, issues []domain.Issue, selectedIssueIdx int, prs []domain.PullRequest, selectedPRIdx int) string {
+func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, themeIdx int, view activeView, termWidth, termHeight int, syncing bool, lastSynced time.Time, syncErr error, issues []domain.Issue, selectedIssueIdx int, prs []domain.PullRequest, selectedPRIdx int, focused focusedPanel, ctxScroll int) string {
 	if termWidth <= 0 {
 		termWidth = defaultTermWidth
 	}
@@ -68,19 +68,19 @@ func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, t
 	}
 
 	header := renderHeader(repoPath, theme, headerInner)
-	nav := renderNavRail(theme, panelHeight, view)
+	nav := renderNavRail(theme, panelHeight, view, focused == panelNav)
 
 	var list string
 	switch view {
 	case viewIssues:
-		list = renderIssueList(issues, selectedIssueIdx, theme, listInner, panelHeight)
+		list = renderIssueList(issues, selectedIssueIdx, theme, listInner, panelHeight, focused == panelList)
 	case viewPRs:
-		list = renderPRList(prs, selectedPRIdx, theme, listInner, panelHeight)
+		list = renderPRList(prs, selectedPRIdx, theme, listInner, panelHeight, focused == panelList)
 	default:
-		list = renderWorktreePanel(worktrees, selectedIdx, theme, listInner, panelHeight)
+		list = renderWorktreePanel(worktrees, selectedIdx, theme, listInner, panelHeight, focused == panelList)
 	}
 
-	ctx := renderContextPanel(view, worktrees, selectedIdx, issues, selectedIssueIdx, prs, selectedPRIdx, theme, panelHeight)
+	ctx := renderContextPanel(view, worktrees, selectedIdx, issues, selectedIssueIdx, prs, selectedPRIdx, theme, panelHeight, ctxScroll, focused == panelCtx)
 	mainRow := lipgloss.JoinHorizontal(lipgloss.Top, nav, list, ctx)
 	footer := renderFooterBar(theme, time.Now().UTC().Format("2006-01-02"), termWidth, syncing, lastSynced, syncErr)
 	actionBar := renderActionBar(theme, termWidth)
@@ -99,7 +99,7 @@ func renderHeader(repoPath string, theme styles.Theme, innerWidth int) string {
 	return theme.GetStyle("header").Width(innerWidth).Render(text)
 }
 
-func renderNavRail(theme styles.Theme, panelHeight int, view activeView) string {
+func renderNavRail(theme styles.Theme, panelHeight int, view activeView, focused bool) string {
 	var b strings.Builder
 	for i, item := range navItems {
 		cursor := "  "
@@ -109,13 +109,16 @@ func renderNavRail(theme styles.Theme, panelHeight int, view activeView) string 
 		b.WriteString(fmt.Sprintf("%s%s: %s\n", cursor, item.key, item.label))
 	}
 	st := theme.GetStyle("nav-rail").Width(navPanelInner + panelPaddingOverhead)
+	if !focused {
+		st = theme.MutedBorder(st)
+	}
 	if panelHeight > 0 {
 		st = st.Height(panelHeight)
 	}
 	return st.Render(strings.TrimRight(b.String(), "\n"))
 }
 
-func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme styles.Theme, listInner, panelHeight int) string {
+func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme styles.Theme, listInner, panelHeight int, focused bool) string {
 	var content strings.Builder
 
 	// fixed columns: cursor(2) + name(18) + sep(1) + sep(1) + status(8) + sep(1) + updated(10) + sep(1) + ghid(6) = 48
@@ -165,13 +168,16 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 	}
 
 	st := theme.GetStyle("worktree-list").Width(listInner + panelPaddingOverhead)
+	if !focused {
+		st = theme.MutedBorder(st)
+	}
 	if panelHeight > 0 {
 		st = st.Height(panelHeight)
 	}
 	return st.Render(strings.TrimRight(content.String(), "\n"))
 }
 
-func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeIdx int, issues []domain.Issue, issueIdx int, prs []domain.PullRequest, prIdx int, theme styles.Theme, panelHeight int) string {
+func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeIdx int, issues []domain.Issue, issueIdx int, prs []domain.PullRequest, prIdx int, theme styles.Theme, panelHeight int, ctxScroll int, focused bool) string {
 	var content string
 	switch view {
 	case viewIssues:
@@ -225,13 +231,17 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 		}
 	}
 	st := theme.GetStyle("context-panel").Width(ctxPanelInner + panelPaddingOverhead)
+	if !focused {
+		st = theme.MutedBorder(st)
+	}
 	if panelHeight > 0 {
+		content = clipContent(content, ctxScroll, panelHeight)
 		st = st.Height(panelHeight)
 	}
 	return st.Render(content)
 }
 
-func renderIssueList(issues []domain.Issue, selectedIdx int, theme styles.Theme, listInner, panelHeight int) string {
+func renderIssueList(issues []domain.Issue, selectedIdx int, theme styles.Theme, listInner, panelHeight int, focused bool) string {
 	var content strings.Builder
 	headerStyle := theme.GetStyle("table-header")
 	titleWidth := listInner - 30
@@ -262,13 +272,16 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, theme styles.Theme,
 		content.WriteString("  No issues found.\n")
 	}
 	st := theme.GetStyle("worktree-list").Width(listInner + panelPaddingOverhead)
+	if !focused {
+		st = theme.MutedBorder(st)
+	}
 	if panelHeight > 0 {
 		st = st.Height(panelHeight)
 	}
 	return st.Render(strings.TrimRight(content.String(), "\n"))
 }
 
-func renderPRList(prs []domain.PullRequest, selectedIdx int, theme styles.Theme, listInner, panelHeight int) string {
+func renderPRList(prs []domain.PullRequest, selectedIdx int, theme styles.Theme, listInner, panelHeight int, focused bool) string {
 	var content strings.Builder
 	headerStyle := theme.GetStyle("table-header")
 	titleWidth := listInner - 50
@@ -299,10 +312,33 @@ func renderPRList(prs []domain.PullRequest, selectedIdx int, theme styles.Theme,
 		content.WriteString("  No open PRs.\n")
 	}
 	st := theme.GetStyle("worktree-list").Width(listInner + panelPaddingOverhead)
+	if !focused {
+		st = theme.MutedBorder(st)
+	}
 	if panelHeight > 0 {
 		st = st.Height(panelHeight)
 	}
 	return st.Render(strings.TrimRight(content.String(), "\n"))
+}
+
+// clipContent slices content lines for bounded panel rendering.
+// offset skips the first N lines; maxLines caps the visible output.
+// If maxLines is 0 the content is returned unchanged.
+func clipContent(content string, offset, maxLines int) string {
+	if maxLines <= 0 {
+		return content
+	}
+	lines := strings.Split(content, "\n")
+	if offset > 0 {
+		if offset >= len(lines) {
+			offset = len(lines) - 1
+		}
+		lines = lines[offset:]
+	}
+	if len(lines) > maxLines {
+		lines = lines[:maxLines]
+	}
+	return strings.Join(lines, "\n")
 }
 
 func renderFooterBar(theme styles.Theme, date string, termWidth int, syncing bool, lastSynced time.Time, syncErr error) string {

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -141,7 +141,11 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 			prState = wt.LinkedPR.State
 		}
 		if i == selectedIdx {
-			row := fmt.Sprintf("%-18s %-*s %-8s %-10s %-6s", name, pathWidth, path, status, "—", ghID)
+			ghIDFormatted := fmt.Sprintf("%-6s", ghID)
+			if prState != "" {
+				ghIDFormatted = lipgloss.NewStyle().Foreground(prStateColor(prState)).Render(ghIDFormatted)
+			}
+			row := fmt.Sprintf("%-18s %-*s %-8s %-10s ", name, pathWidth, path, status, "—") + ghIDFormatted
 			content.WriteString(theme.GetStyle("selected-row").Width(listInner).Render("> " + row))
 		} else {
 			nameCol := fmt.Sprintf("%-18s", name)
@@ -150,12 +154,9 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 			updatedCol := fmt.Sprintf("%-10s", "—") // TODO: populate from git log --format=%ai
 			ghIDRaw := fmt.Sprintf("%-6s", ghID)
 			var ghIDCol string
-			switch prState {
-			case "OPEN":
-				ghIDCol = lipgloss.NewStyle().Foreground(lipgloss.Color("#00D9FF")).Render(ghIDRaw)
-			case "MERGED", "CLOSED":
-				ghIDCol = lipgloss.NewStyle().Foreground(lipgloss.Color("#4A5568")).Render(ghIDRaw)
-			default:
+			if prState != "" {
+				ghIDCol = lipgloss.NewStyle().Foreground(prStateColor(prState)).Render(ghIDRaw)
+			} else {
 				ghIDCol = ghIDRaw
 			}
 			content.WriteString("  " + nameCol + " " + pathCol + " " + statusCol + " " + updatedCol + " " + ghIDCol)
@@ -200,6 +201,8 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 			if wt.LinkedPR != nil {
 				pr := wt.LinkedPR
 				labelsStr := formatLabels(pr.Labels)
+				// titleTrunc is shown as a subtitle below the header; pr.Title repeats it
+				// in full under "GH Title:" so long titles aren't silently cut off.
 				titleTrunc := truncateStr(pr.Title, ctxPanelInner)
 				statusDot := lipgloss.NewStyle().Foreground(prStateColor(pr.State)).Render("●")
 				content = fmt.Sprintf(

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -17,7 +17,7 @@ const (
 	actionBarHints   = "[c-n] New  [c-d] Delete  [c-l] Lock | [f1] Help"
 	defaultTermWidth = 120
 	navPanelInner    = 18
-	ctxPanelInner    = 50
+	// ctxPanelInner is no longer a constant — use computeCtxInner(termWidth) instead.
 	// panelOverhead: 1 border-left + 1 pad-left + 1 pad-right + 1 border-right
 	panelOverhead = 4
 	// panelPaddingOverhead: lipgloss Width includes padding, so pass Width(inner + panelPaddingOverhead)
@@ -28,6 +28,10 @@ const (
 	minPathWidth   = 5
 	// fixedChromeRows: 1 header + 1 footer + 1 action bar + 2 panel borders (top+bottom)
 	fixedChromeRows = 5
+
+	// ctxMinInner / ctxMaxInner bound the dynamic context-panel content width.
+	ctxMinInner = 25
+	ctxMaxInner = 60
 )
 
 type navItem struct {
@@ -52,7 +56,8 @@ func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, t
 	theme := styles.NewTheme(styles.Themes[themeIdx])
 
 	navOuter := navPanelInner + panelOverhead
-	ctxOuter := ctxPanelInner + panelOverhead
+	ctxInner := computeCtxInner(termWidth)
+	ctxOuter := ctxInner + panelOverhead
 	listOuter := termWidth - navOuter - ctxOuter
 	if listOuter < minPathWidth+panelOverhead {
 		listOuter = minPathWidth + panelOverhead
@@ -80,7 +85,7 @@ func renderFull(worktrees []domain.Worktree, selectedIdx int, repoPath string, t
 		list = renderWorktreePanel(worktrees, selectedIdx, theme, listInner, panelHeight, focused == panelList)
 	}
 
-	ctx := renderContextPanel(view, worktrees, selectedIdx, issues, selectedIssueIdx, prs, selectedPRIdx, theme, panelHeight, ctxScroll, focused == panelCtx)
+	ctx := renderContextPanel(view, worktrees, selectedIdx, issues, selectedIssueIdx, prs, selectedPRIdx, theme, panelHeight, ctxScroll, focused == panelCtx, ctxInner)
 	mainRow := lipgloss.JoinHorizontal(lipgloss.Top, nav, list, ctx)
 	footer := renderFooterBar(theme, time.Now().UTC().Format("2006-01-02"), termWidth, syncing, lastSynced, syncErr)
 	actionBar := renderActionBar(theme, termWidth)
@@ -133,7 +138,20 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 	content.WriteString(headerStyle.Render(headerRow))
 	content.WriteString("\n")
 
-	for i, wt := range worktrees {
+	// Bug 1: cap rendered rows so panel content never exceeds panelHeight.
+	// The header row occupies 1 line, so at most panelHeight-1 data rows fit.
+	visible := worktrees
+	if panelHeight > 0 {
+		maxItems := panelHeight - 1
+		if maxItems < 0 {
+			maxItems = 0
+		}
+		if maxItems < len(visible) {
+			visible = visible[:maxItems]
+		}
+	}
+
+	for i, wt := range visible {
 		name := truncateStr(filepath.Base(wt.Path), 18)
 		path := truncateStr(wt.Path, pathWidth)
 		status := worktreeStatus(wt)
@@ -177,7 +195,7 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 	return st.Render(strings.TrimRight(content.String(), "\n"))
 }
 
-func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeIdx int, issues []domain.Issue, issueIdx int, prs []domain.PullRequest, prIdx int, theme styles.Theme, panelHeight int, ctxScroll int, focused bool) string {
+func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeIdx int, issues []domain.Issue, issueIdx int, prs []domain.PullRequest, prIdx int, theme styles.Theme, panelHeight int, ctxScroll int, focused bool, ctxInner int) string {
 	var content string
 	switch view {
 	case viewIssues:
@@ -186,7 +204,11 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 		} else {
 			iss := issues[issueIdx]
 			labelsStr := formatLabels(iss.Labels)
-			content = fmt.Sprintf("Context: Issue #%d\n%s\n\nStatus: ● Open\nLabels: %s\n\n[g] Open in GitHub", iss.Number, iss.Title, labelsStr)
+			// Bug 3: wrap title and labels to prevent visual wrapping from
+			// outpacing clipContent's line-count, which would push the footer off screen.
+			title := wrapText(iss.Title, ctxInner)
+			labels := wrapText(labelsStr, ctxInner)
+			content = fmt.Sprintf("Context: Issue #%d\n%s\n\nStatus: ● Open\nLabels: %s\n\n[g] Open in GitHub", iss.Number, title, labels)
 		}
 	case viewPRs:
 		if len(prs) == 0 || prIdx < 0 || prIdx >= len(prs) {
@@ -198,11 +220,17 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 				state = "DRAFT"
 			}
 			labelsStr := formatLabels(pr.Labels)
-			body := wrapText(pr.Body, ctxPanelInner)
+			body := wrapText(pr.Body, ctxInner)
 			if body == "" {
 				body = "(no description)"
 			}
-			content = fmt.Sprintf("Context: PR #%d\n%s\n\nBranch: %s\nAuthor: @%s\nStatus: %s\nLabels: %s\n\n%s\n\n[g] Open in GitHub", pr.Number, pr.Title, pr.Branch, pr.Author, state, labelsStr, body)
+			// Bug 3: wrap/truncate fields so visual line count matches \n count,
+			// preventing the panel from growing and pushing the footer off screen.
+			title := wrapText(pr.Title, ctxInner)
+			branch := truncateStr(pr.Branch, ctxInner-8)  // "Branch: " prefix = 8 chars
+			author := truncateStr(pr.Author, ctxInner-9)  // "Author: @" prefix = 9 chars
+			labels := wrapText(labelsStr, ctxInner)
+			content = fmt.Sprintf("Context: PR #%d\n%s\n\nBranch: %s\nAuthor: @%s\nStatus: %s\nLabels: %s\n\n%s\n\n[g] Open in GitHub", pr.Number, title, branch, author, state, labels, body)
 		}
 	default: // viewWorktrees
 		if len(worktrees) == 0 || worktreeIdx < 0 || worktreeIdx >= len(worktrees) {
@@ -212,9 +240,9 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 			if wt.LinkedPR != nil {
 				pr := wt.LinkedPR
 				labelsStr := formatLabels(pr.Labels)
-				titleTrunc := truncateStr(pr.Title, ctxPanelInner)
+				titleTrunc := truncateStr(pr.Title, ctxInner)
 				statusDot := lipgloss.NewStyle().Foreground(prStateColor(pr.State)).Render("●")
-				body := wrapText(pr.Body, ctxPanelInner)
+				body := wrapText(pr.Body, ctxInner)
 				if body == "" {
 					body = "(no description)"
 				}
@@ -223,14 +251,16 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 					pr.Number, titleTrunc, pr.Title, pr.Author, statusDot, pr.State, labelsStr, body,
 				)
 			} else {
+				const pathLabel = "Path: "
+				pathTrunc := truncateStr(wt.Path, ctxInner-len(pathLabel))
 				content = fmt.Sprintf(
 					"Context: %s\nBranch: %s\nPath: %s\n\nAGENT COMMANDS:\n[a] Spawn Claude Code\n[c] Spawn Copilot\n[s] Open Shell in WT",
-					filepath.Base(wt.Path), wt.Branch, wt.Path,
+					filepath.Base(wt.Path), wt.Branch, pathTrunc,
 				)
 			}
 		}
 	}
-	st := theme.GetStyle("context-panel").Width(ctxPanelInner + panelPaddingOverhead)
+	st := theme.GetStyle("context-panel").Width(ctxInner + panelPaddingOverhead)
 	if !focused {
 		st = theme.MutedBorder(st)
 	}
@@ -255,7 +285,20 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, theme styles.Theme,
 	if labelsWidth < 8 {
 		labelsWidth = 8
 	}
-	for i, issue := range issues {
+
+	// Bug 1: cap rendered rows so panel content never exceeds panelHeight.
+	visible := issues
+	if panelHeight > 0 {
+		maxItems := panelHeight - 1
+		if maxItems < 0 {
+			maxItems = 0
+		}
+		if maxItems < len(visible) {
+			visible = visible[:maxItems]
+		}
+	}
+
+	for i, issue := range visible {
 		labels := truncateStr(strings.Join(issue.Labels, " "), labelsWidth)
 		title := truncateStr(issue.Title, titleWidth)
 		// "Open" is hardcoded because gh issue list only returns open issues by default.
@@ -284,26 +327,52 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, theme styles.Theme,
 func renderPRList(prs []domain.PullRequest, selectedIdx int, theme styles.Theme, listInner, panelHeight int, focused bool) string {
 	var content strings.Builder
 	headerStyle := theme.GetStyle("table-header")
-	titleWidth := listInner - 50
+	// Bug 2: drop AUTHOR column (visible in context panel) and reduce BRANCH to 14.
+	// Fixed overhead: 2(cursor) + 6(#) + 1(sp) + 1(sp) + 14(branch) + 1(sp) = 25,
+	// Dynamic branch width: ~15% of available space, clamped to [8, 18].
+	branchWidth := listInner * 15 / 100
+	if branchWidth < 8 {
+		branchWidth = 8
+	}
+	if branchWidth > 18 {
+		branchWidth = 18
+	}
+	// Fixed overhead: 2(cursor/spaces) + 6(#) + 1(sp) + 1(sp) + 1(sp) + 6(STATUS) = 17;
+	// plus branchWidth + 2 spaces around it = branchWidth + 2 → total fixed = 19 + branchWidth.
+	// titleWidth fills remaining so total row = listInner.
+	const prStatusMaxLen = 6
+	titleWidth := listInner - (11 + branchWidth + prStatusMaxLen)
 	if titleWidth < 10 {
 		titleWidth = 10
 	}
-	headerRow := fmt.Sprintf("  %-6s %-*s %-16s %-14s %s", "#", titleWidth, "TITLE", "BRANCH", "AUTHOR", "STATUS")
+	headerRow := fmt.Sprintf("  %-6s %-*s %-*s %s", "#", titleWidth, "TITLE", branchWidth, "BRANCH", "STATUS")
 	content.WriteString(headerStyle.Render(headerRow))
 	content.WriteString("\n")
-	for i, pr := range prs {
+
+	// Bug 1: cap rendered rows so panel content never exceeds panelHeight.
+	visible := prs
+	if panelHeight > 0 {
+		maxItems := panelHeight - 1
+		if maxItems < 0 {
+			maxItems = 0
+		}
+		if maxItems < len(visible) {
+			visible = visible[:maxItems]
+		}
+	}
+
+	for i, pr := range visible {
 		title := truncateStr(pr.Title, titleWidth)
-		branch := truncateStr(pr.Branch, 16)
-		author := truncateStr(pr.Author, 14)
+		branch := truncateStr(pr.Branch, branchWidth)
 		state := pr.State
 		if pr.IsDraft {
 			state = "DRAFT"
 		}
 		if i == selectedIdx {
-			row := fmt.Sprintf("%-6d %-*s %-16s %-14s %s", pr.Number, titleWidth, title, branch, author, state)
+			row := fmt.Sprintf("%-6d %-*s %-*s %s", pr.Number, titleWidth, title, branchWidth, branch, state)
 			content.WriteString(theme.GetStyle("selected-row").Width(listInner).Render("> " + row))
 		} else {
-			row := fmt.Sprintf("  %-6d %-*s %-16s %-14s %s", pr.Number, titleWidth, title, branch, author, state)
+			row := fmt.Sprintf("  %-6d %-*s %-*s %s", pr.Number, titleWidth, title, branchWidth, branch, state)
 			content.WriteString(row)
 		}
 		content.WriteString("\n")
@@ -369,6 +438,19 @@ func renderFooterBar(theme styles.Theme, date string, termWidth int, syncing boo
 
 func renderActionBar(theme styles.Theme, termWidth int) string {
 	return theme.GetStyle("status-bar").Width(termWidth).Render(actionBarHints)
+}
+
+// computeCtxInner returns the inner content width for the context panel.
+// It scales to ~30 % of the terminal width and is clamped to [ctxMinInner, ctxMaxInner].
+func computeCtxInner(termWidth int) int {
+	inner := termWidth * 30 / 100
+	if inner < ctxMinInner {
+		return ctxMinInner
+	}
+	if inner > ctxMaxInner {
+		return ctxMaxInner
+	}
+	return inner
 }
 
 // wrapText word-wraps s to at most width runes per line.

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -207,7 +207,11 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 			title := wrapText(iss.Title, ctxInner)
 			// "Labels: " prefix = 8 chars; wrap to remaining width to avoid re-wrap.
 			labels := wrapText(labelsStr, ctxInner-8)
-			content = fmt.Sprintf("Context: Issue #%d\n%s\n\nStatus: ● Open\nLabels: %s\n\n[g] Open in GitHub", iss.Number, title, labels)
+			body := wrapText(iss.Body, ctxInner)
+			if body == "" {
+				body = "(no description)"
+			}
+			content = fmt.Sprintf("Context: Issue #%d\n%s\n\nStatus: ● Open\nLabels: %s\n\n%s\n\n[g] Open in GitHub", iss.Number, title, labels, body)
 		}
 	case viewPRs:
 		if len(prs) == 0 || prIdx < 0 || prIdx >= len(prs) {

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -198,7 +198,7 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 				state = "DRAFT"
 			}
 			labelsStr := formatLabels(pr.Labels)
-			body := pr.Body
+			body := wrapText(pr.Body, ctxPanelInner)
 			if body == "" {
 				body = "(no description)"
 			}
@@ -214,7 +214,7 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 				labelsStr := formatLabels(pr.Labels)
 				titleTrunc := truncateStr(pr.Title, ctxPanelInner)
 				statusDot := lipgloss.NewStyle().Foreground(prStateColor(pr.State)).Render("●")
-				body := pr.Body
+				body := wrapText(pr.Body, ctxPanelInner)
 				if body == "" {
 					body = "(no description)"
 				}
@@ -371,7 +371,64 @@ func renderActionBar(theme styles.Theme, termWidth int) string {
 	return theme.GetStyle("status-bar").Width(termWidth).Render(actionBarHints)
 }
 
-// truncateStr clips s to at most n runes, adding "…" if truncated.
+// wrapText word-wraps s to at most width runes per line.
+// Existing newlines are preserved; each segment is wrapped independently.
+// If width <= 0 the string is returned unchanged.
+func wrapText(s string, width int) string {
+	if width <= 0 {
+		return s
+	}
+	var out strings.Builder
+	for i, seg := range strings.Split(s, "\n") {
+		if i > 0 {
+			out.WriteByte('\n')
+		}
+		out.WriteString(wrapLine(seg, width))
+	}
+	return out.String()
+}
+
+// wrapLine wraps a single newline-free string at word boundaries.
+// Falls back to a hard break when a word exceeds width.
+func wrapLine(s string, width int) string {
+	runes := []rune(s)
+	if len(runes) <= width {
+		return s
+	}
+	var out strings.Builder
+	for len(runes) > width {
+		// Clean break: the character right after width is a space, so the
+		// first `width` runes form a complete word boundary.
+		if runes[width] == ' ' {
+			out.WriteString(string(runes[:width]))
+			out.WriteByte('\n')
+			runes = runes[width+1:]
+			continue
+		}
+		// Find the last space within the first `width` runes.
+		breakAt := -1
+		for i := width - 1; i >= 0; i-- {
+			if runes[i] == ' ' {
+				breakAt = i
+				break
+			}
+		}
+		if breakAt <= 0 {
+			// No space found — hard break at width.
+			out.WriteString(string(runes[:width]))
+			out.WriteByte('\n')
+			runes = runes[width:]
+		} else {
+			out.WriteString(string(runes[:breakAt]))
+			out.WriteByte('\n')
+			runes = runes[breakAt+1:]
+		}
+	}
+	out.WriteString(string(runes))
+	return out.String()
+}
+
+
 func truncateStr(s string, n int) string {
 	runes := []rune(s)
 	if len(runes) <= n {

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -204,10 +204,9 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 		} else {
 			iss := issues[issueIdx]
 			labelsStr := formatLabels(iss.Labels)
-			// Bug 3: wrap title and labels to prevent visual wrapping from
-			// outpacing clipContent's line-count, which would push the footer off screen.
 			title := wrapText(iss.Title, ctxInner)
-			labels := wrapText(labelsStr, ctxInner)
+			// "Labels: " prefix = 8 chars; wrap to remaining width to avoid re-wrap.
+			labels := wrapText(labelsStr, ctxInner-8)
 			content = fmt.Sprintf("Context: Issue #%d\n%s\n\nStatus: ● Open\nLabels: %s\n\n[g] Open in GitHub", iss.Number, title, labels)
 		}
 	case viewPRs:
@@ -224,12 +223,11 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 			if body == "" {
 				body = "(no description)"
 			}
-			// Bug 3: wrap/truncate fields so visual line count matches \n count,
-			// preventing the panel from growing and pushing the footer off screen.
 			title := wrapText(pr.Title, ctxInner)
 			branch := truncateStr(pr.Branch, ctxInner-8)  // "Branch: " prefix = 8 chars
 			author := truncateStr(pr.Author, ctxInner-9)  // "Author: @" prefix = 9 chars
-			labels := wrapText(labelsStr, ctxInner)
+			// "Labels: " prefix = 8 chars; wrap to remaining width to avoid re-wrap.
+			labels := wrapText(labelsStr, ctxInner-8)
 			content = fmt.Sprintf("Context: PR #%d\n%s\n\nBranch: %s\nAuthor: @%s\nStatus: %s\nLabels: %s\n\n%s\n\n[g] Open in GitHub", pr.Number, title, branch, author, state, labels, body)
 		}
 	default: // viewWorktrees
@@ -239,8 +237,10 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 			wt := worktrees[worktreeIdx]
 			if wt.LinkedPR != nil {
 				pr := wt.LinkedPR
+				// "Labels: " = 8 chars; "Author: @" = 9 chars; "GH Title: " = 10 chars
 				labelsStr := formatLabels(pr.Labels)
-				titleTrunc := truncateStr(pr.Title, ctxInner)
+				labels := wrapText(labelsStr, ctxInner-8)
+				titleTrunc := truncateStr(pr.Title, ctxInner-10) // "GH Title: " prefix = 10 chars
 				statusDot := lipgloss.NewStyle().Foreground(prStateColor(pr.State)).Render("●")
 				body := wrapText(pr.Body, ctxInner)
 				if body == "" {
@@ -248,7 +248,7 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 				}
 				content = fmt.Sprintf(
 					"Context: PR #%d\n%s\n\nGH Title: %s\nAuthor: @%s\nStatus: %s %s\nLabels: %s\n\n%s\n\nAGENT COMMANDS:\n[a] Spawn Claude Code\n[c] Spawn Copilot\n[s] Open Shell in WT",
-					pr.Number, titleTrunc, pr.Title, pr.Author, statusDot, pr.State, labelsStr, body,
+					pr.Number, titleTrunc, pr.Title, pr.Author, statusDot, pr.State, labels, body,
 				)
 			} else {
 				const pathLabel = "Path: "
@@ -266,7 +266,10 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 	}
 	if panelHeight > 0 {
 		content = clipContent(content, ctxScroll, panelHeight)
-		st = st.Height(panelHeight)
+		// MaxHeight(panelHeight+2): hard-cap the rendered output at panelHeight inner
+		// rows + 2 border rows. MaxHeight applies AFTER borders, so this prevents
+		// any lipgloss re-wrap from making the panel taller than the terminal allows.
+		st = st.Height(panelHeight).MaxHeight(panelHeight + 2)
 	}
 	return st.Render(content)
 }
@@ -432,12 +435,15 @@ func renderFooterBar(theme styles.Theme, date string, termWidth int, syncing boo
 	if syncStatus != "" {
 		content = left + "  " + syncStatus
 	}
+	// Truncate to termWidth so the bar never wraps to a second row on narrow terminals.
+	content = truncateStr(content, termWidth)
 
 	return theme.GetStyle("status-bar").Width(termWidth).Render(content)
 }
 
 func renderActionBar(theme styles.Theme, termWidth int) string {
-	return theme.GetStyle("status-bar").Width(termWidth).Render(actionBarHints)
+	hints := truncateStr(actionBarHints, termWidth)
+	return theme.GetStyle("status-bar").Width(termWidth).Render(hints)
 }
 
 // computeCtxInner returns the inner content width for the context panel.

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -191,7 +191,12 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 			if pr.IsDraft {
 				state = "DRAFT"
 			}
-			content = fmt.Sprintf("Context: PR #%d\n%s\n\nBranch: %s\nAuthor: @%s\nStatus: %s\n\n[g] Open in GitHub", pr.Number, pr.Title, pr.Branch, pr.Author, state)
+			labelsStr := formatLabels(pr.Labels)
+			body := pr.Body
+			if body == "" {
+				body = "(no description)"
+			}
+			content = fmt.Sprintf("Context: PR #%d\n%s\n\nBranch: %s\nAuthor: @%s\nStatus: %s\nLabels: %s\n\n%s\n\n[g] Open in GitHub", pr.Number, pr.Title, pr.Branch, pr.Author, state, labelsStr, body)
 		}
 	default: // viewWorktrees
 		if len(worktrees) == 0 || worktreeIdx < 0 || worktreeIdx >= len(worktrees) {
@@ -201,13 +206,15 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 			if wt.LinkedPR != nil {
 				pr := wt.LinkedPR
 				labelsStr := formatLabels(pr.Labels)
-				// titleTrunc is shown as a subtitle below the header; pr.Title repeats it
-				// in full under "GH Title:" so long titles aren't silently cut off.
 				titleTrunc := truncateStr(pr.Title, ctxPanelInner)
 				statusDot := lipgloss.NewStyle().Foreground(prStateColor(pr.State)).Render("●")
+				body := pr.Body
+				if body == "" {
+					body = "(no description)"
+				}
 				content = fmt.Sprintf(
-					"Context: PR #%d\n%s\n\nGH Title: %s\nAuthor: @%s\nStatus: %s %s\nLabels: %s\n\nAGENT COMMANDS:\n[a] Spawn Claude Code\n[c] Spawn Copilot\n[s] Open Shell in WT",
-					pr.Number, titleTrunc, pr.Title, pr.Author, statusDot, pr.State, labelsStr,
+					"Context: PR #%d\n%s\n\nGH Title: %s\nAuthor: @%s\nStatus: %s %s\nLabels: %s\n\n%s\n\nAGENT COMMANDS:\n[a] Spawn Claude Code\n[c] Spawn Copilot\n[s] Open Shell in WT",
+					pr.Number, titleTrunc, pr.Title, pr.Author, statusDot, pr.State, labelsStr, body,
 				)
 			} else {
 				content = fmt.Sprintf(

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -134,9 +134,11 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 		name := truncateStr(filepath.Base(wt.Path), 18)
 		path := truncateStr(wt.Path, pathWidth)
 		status := worktreeStatus(wt)
-		ghID := ""
+		ghID := "-"
+		var prState string
 		if wt.LinkedPR != nil {
 			ghID = fmt.Sprintf("%d", wt.LinkedPR.Number)
+			prState = wt.LinkedPR.State
 		}
 		if i == selectedIdx {
 			row := fmt.Sprintf("%-18s %-*s %-8s %-10s %-6s", name, pathWidth, path, status, "—", ghID)
@@ -146,7 +148,16 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 			pathCol := fmt.Sprintf("%-*s", pathWidth, path)
 			statusCol := theme.StatusStyle(status).Width(8).Render(status)
 			updatedCol := fmt.Sprintf("%-10s", "—") // TODO: populate from git log --format=%ai
-			ghIDCol := fmt.Sprintf("%-6s", ghID)
+			ghIDRaw := fmt.Sprintf("%-6s", ghID)
+			var ghIDCol string
+			switch prState {
+			case "OPEN":
+				ghIDCol = lipgloss.NewStyle().Foreground(lipgloss.Color("#00D9FF")).Render(ghIDRaw)
+			case "MERGED", "CLOSED":
+				ghIDCol = lipgloss.NewStyle().Foreground(lipgloss.Color("#4A5568")).Render(ghIDRaw)
+			default:
+				ghIDCol = ghIDRaw
+			}
 			content.WriteString("  " + nameCol + " " + pathCol + " " + statusCol + " " + updatedCol + " " + ghIDCol)
 		}
 		content.WriteString("\n")
@@ -167,11 +178,7 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 			content = "No issue selected.\nPress I to view issues."
 		} else {
 			iss := issues[issueIdx]
-			labelStrs := make([]string, len(iss.Labels))
-			for i, l := range iss.Labels {
-				labelStrs[i] = "[" + l + "]"
-			}
-			labelsStr := strings.Join(labelStrs, "")
+			labelsStr := formatLabels(iss.Labels)
 			content = fmt.Sprintf("Context: Issue #%d\n%s\n\nStatus: ● Open\nLabels: %s\n\n[g] Open in GitHub", iss.Number, iss.Title, labelsStr)
 		}
 	case viewPRs:
@@ -190,10 +197,21 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 			content = "No worktree selected.\nSelect a worktree to\nview context."
 		} else {
 			wt := worktrees[worktreeIdx]
-			content = fmt.Sprintf(
-				"Context: %s\nBranch: %s\nStatus: %s\n\nAGENT COMMANDS:\n[a] Spawn Claude\n[c] Spawn Copilot",
-				filepath.Base(wt.Path), wt.Branch, worktreeStatus(wt),
-			)
+			if wt.LinkedPR != nil {
+				pr := wt.LinkedPR
+				labelsStr := formatLabels(pr.Labels)
+				titleTrunc := truncateStr(pr.Title, ctxPanelInner)
+				statusDot := lipgloss.NewStyle().Foreground(prStateColor(pr.State)).Render("●")
+				content = fmt.Sprintf(
+					"Context: PR #%d\n%s\n\nGH Title: %s\nAuthor: @%s\nStatus: %s %s\nLabels: %s\n\nAGENT COMMANDS:\n[a] Spawn Claude Code\n[c] Spawn Copilot\n[s] Open Shell in WT",
+					pr.Number, titleTrunc, pr.Title, pr.Author, statusDot, pr.State, labelsStr,
+				)
+			} else {
+				content = fmt.Sprintf(
+					"Context: %s\nBranch: %s\nPath: %s\n\nAGENT COMMANDS:\n[a] Spawn Claude Code\n[c] Spawn Copilot\n[s] Open Shell in WT",
+					filepath.Base(wt.Path), wt.Branch, wt.Path,
+				)
+			}
 		}
 	}
 	st := theme.GetStyle("context-panel").Width(ctxPanelInner + panelPaddingOverhead)
@@ -328,5 +346,28 @@ func worktreeStatus(wt domain.Worktree) string {
 		return "Idle"
 	}
 	return "Dirty"
+}
+
+// prStateColor returns the lipgloss color for a given PR state string.
+func prStateColor(state string) lipgloss.Color {
+	switch state {
+	case "OPEN":
+		return lipgloss.Color("#00D9FF")
+	case "MERGED":
+		return lipgloss.Color("#9B59B6")
+	case "CLOSED":
+		return lipgloss.Color("#E74C3C")
+	default:
+		return lipgloss.Color("#4A5568")
+	}
+}
+
+// formatLabels formats a slice of label strings into "[label1][label2]" format.
+func formatLabels(labels []string) string {
+	strs := make([]string, len(labels))
+	for i, l := range labels {
+		strs[i] = "[" + l + "]"
+	}
+	return strings.Join(strs, "")
 }
 

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -1336,3 +1336,74 @@ func TestViewSwitch_ResetsCtxScrollOffset(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Issue body in context panel tests
+// ---------------------------------------------------------------------------
+
+// TestRenderer_IssueContextPanel_ShowsBody verifies that the issue context panel
+// renders the issue body when present.
+func TestRenderer_IssueContextPanel_ShowsBody(t *testing.T) {
+	tests := []struct {
+		name    string
+		issue   domain.Issue
+		wantIn  []string
+		wantOut []string
+	}{
+		{
+			name: "shows body text when populated",
+			issue: domain.Issue{
+				Number: 7,
+				Title:  "Fix the bug",
+				Body:   "This bug causes a crash on startup.",
+				Labels: []string{},
+			},
+			wantIn: []string{"This bug causes a crash on startup."},
+		},
+		{
+			name: "shows (no description) when body is empty",
+			issue: domain.Issue{
+				Number: 8,
+				Title:  "Empty body issue",
+				Body:   "",
+				Labels: []string{},
+			},
+			wantIn: []string{"(no description)"},
+		},
+		{
+			name: "body appears alongside all context fields",
+			issue: domain.Issue{
+				Number: 9,
+				Title:  "Some issue",
+				Body:   "Details about the issue.",
+				Labels: []string{"bug"},
+			},
+			wantIn: []string{
+				"Context: Issue #9",
+				"Some issue",
+				"Status: ● Open",
+				"Labels: [bug]",
+				"Details about the issue.",
+				"[g] Open in GitHub",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = viewIssues
+			model.issues = []domain.Issue{tt.issue}
+			model.selectedIssueIdx = 0
+
+			view := model.View()
+
+			for _, want := range tt.wantIn {
+				assert.Contains(t, view, want)
+			}
+			for _, notWant := range tt.wantOut {
+				assert.NotContains(t, view, notWant)
+			}
+		})
+	}
+}

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -670,5 +670,341 @@ func TestRenderFull_WorktreesViewStillWorks(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// End Phase 2 tests (renderer_test.go)
+// Phase 3: Issue #15 — PR Context Panel & GH:ID Column tests
+// ---------------------------------------------------------------------------
+
+// TestRenderer_ContextPanel_WithLinkedPR verifies that when a worktree has a
+// LinkedPR, the context panel shows PR-specific information: number, title,
+// author, state, and labels in the correct format.
+func TestRenderer_ContextPanel_WithLinkedPR(t *testing.T) {
+	tests := []struct {
+		name     string
+		worktree domain.Worktree
+		wantIn   []string
+	}{
+		{
+			name: "shows PR context header with number",
+			worktree: domain.Worktree{
+				Path:   "/tmp/feat-login",
+				Branch: "feat/login",
+				IsClean: true,
+				LinkedPR: &domain.PullRequest{
+					Number: 42,
+					Title:  "Add login feature",
+					Author: "alice",
+					State:  "OPEN",
+					Labels: []string{},
+				},
+			},
+			wantIn: []string{"Context: PR #42"},
+		},
+		{
+			name: "shows PR title in context",
+			worktree: domain.Worktree{
+				Path:   "/tmp/feat-login",
+				Branch: "feat/login",
+				IsClean: true,
+				LinkedPR: &domain.PullRequest{
+					Number: 42,
+					Title:  "Add login feature",
+					Author: "alice",
+					State:  "OPEN",
+					Labels: []string{},
+				},
+			},
+			wantIn: []string{"Add login feature"},
+		},
+		{
+			name: "shows GH Title label and author with @ prefix",
+			worktree: domain.Worktree{
+				Path:   "/tmp/feat-login",
+				Branch: "feat/login",
+				IsClean: true,
+				LinkedPR: &domain.PullRequest{
+					Number: 42,
+					Title:  "Add login feature",
+					Author: "alice",
+					State:  "OPEN",
+					Labels: []string{},
+				},
+			},
+			wantIn: []string{"GH Title:", "Author: @alice"},
+		},
+		{
+			name: "shows status dot and state",
+			worktree: domain.Worktree{
+				Path:   "/tmp/feat-login",
+				Branch: "feat/login",
+				IsClean: true,
+				LinkedPR: &domain.PullRequest{
+					Number: 42,
+					Title:  "Add login feature",
+					Author: "alice",
+					State:  "OPEN",
+					Labels: []string{},
+				},
+			},
+			wantIn: []string{"Status: ●", "OPEN"},
+		},
+		{
+			name: "shows labels in bracket format",
+			worktree: domain.Worktree{
+				Path:   "/tmp/feat-auth",
+				Branch: "feat/auth",
+				IsClean: true,
+				LinkedPR: &domain.PullRequest{
+					Number: 99,
+					Title:  "Auth refactor",
+					Author: "bob",
+					State:  "OPEN",
+					Labels: []string{"enhancement", "backend"},
+				},
+			},
+			wantIn: []string{"Labels: [enhancement][backend]"},
+		},
+		{
+			name: "shows agent commands section",
+			worktree: domain.Worktree{
+				Path:   "/tmp/feat-login",
+				Branch: "feat/login",
+				IsClean: true,
+				LinkedPR: &domain.PullRequest{
+					Number: 42,
+					Title:  "Add login feature",
+					Author: "alice",
+					State:  "MERGED",
+					Labels: []string{},
+				},
+			},
+			wantIn: []string{"AGENT COMMANDS:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = viewWorktrees
+			model.Worktrees = []domain.Worktree{tt.worktree}
+			model.selectedIdx = 0
+
+			view := model.View()
+
+			for _, want := range tt.wantIn {
+				assert.Contains(t, view, want)
+			}
+		})
+	}
+}
+
+// TestRenderer_ContextPanel_NoLinkedPR verifies that when a worktree has no
+// LinkedPR, the context panel shows the worktree basename, branch, and path.
+func TestRenderer_ContextPanel_NoLinkedPR(t *testing.T) {
+	tests := []struct {
+		name     string
+		worktree domain.Worktree
+		wantIn   []string
+		wantOut  []string
+	}{
+		{
+			name: "shows worktree basename as context header",
+			worktree: domain.Worktree{
+				Path:    "/tmp/feat-search",
+				Branch:  "feat/search",
+				IsClean: true,
+			},
+			wantIn: []string{"Context: feat-search"},
+		},
+		{
+			name: "shows branch",
+			worktree: domain.Worktree{
+				Path:    "/tmp/feat-search",
+				Branch:  "feat/search",
+				IsClean: true,
+			},
+			wantIn: []string{"Branch: feat/search"},
+		},
+		{
+			name: "shows path",
+			worktree: domain.Worktree{
+				Path:    "/tmp/feat-search",
+				Branch:  "feat/search",
+				IsClean: true,
+			},
+			wantIn: []string{"Path: /tmp/feat-search"},
+		},
+		{
+			name: "does not show PR-specific fields",
+			worktree: domain.Worktree{
+				Path:    "/tmp/feat-search",
+				Branch:  "feat/search",
+				IsClean: true,
+			},
+			wantOut: []string{"GH Title:", "Author: @", "Labels:"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = viewWorktrees
+			model.Worktrees = []domain.Worktree{tt.worktree}
+			model.selectedIdx = 0
+
+			view := model.View()
+
+			for _, want := range tt.wantIn {
+				assert.Contains(t, view, want)
+			}
+			for _, notWant := range tt.wantOut {
+				assert.NotContains(t, view, notWant)
+			}
+		})
+	}
+}
+
+// TestRenderer_ContextPanel_AgentCommandsAlwaysVisible verifies that the agent
+// commands [a], [c], and [s] are always shown in the worktree context panel,
+// regardless of whether a LinkedPR is present.
+func TestRenderer_ContextPanel_AgentCommandsAlwaysVisible(t *testing.T) {
+	tests := []struct {
+		name     string
+		worktree domain.Worktree
+	}{
+		{
+			name: "agent commands present with LinkedPR",
+			worktree: domain.Worktree{
+				Path:    "/tmp/feat-auth",
+				Branch:  "feat/auth",
+				IsClean: true,
+				LinkedPR: &domain.PullRequest{
+					Number: 7,
+					Title:  "Auth",
+					Author: "carol",
+					State:  "OPEN",
+				},
+			},
+		},
+		{
+			name: "agent commands present without LinkedPR",
+			worktree: domain.Worktree{
+				Path:    "/tmp/feat-search",
+				Branch:  "feat/search",
+				IsClean: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = viewWorktrees
+			model.Worktrees = []domain.Worktree{tt.worktree}
+			model.selectedIdx = 0
+
+			view := model.View()
+
+			assert.Contains(t, view, "[a] Spawn Claude Code")
+			assert.Contains(t, view, "[c] Spawn Copilot")
+			assert.Contains(t, view, "[s] Open Shell in WT")
+		})
+	}
+}
+
+// TestRenderer_GHIDColumn_NoLinkedPR verifies that when a worktree has no
+// LinkedPR, the GH:ID column shows "-" (not empty string).
+func TestRenderer_GHIDColumn_NoLinkedPR(t *testing.T) {
+	tests := []struct {
+		name     string
+		worktree domain.Worktree
+	}{
+		{
+			name: "GH:ID shows dash when no PR linked (non-selected row)",
+			worktree: domain.Worktree{
+				Path:    "/tmp/wt-no-pr",
+				Branch:  "main",
+				IsClean: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = viewWorktrees
+			model.Worktrees = []domain.Worktree{tt.worktree}
+			// Set selectedIdx to -1 so the row is NOT selected, ensuring we hit the
+			// non-selected branch of the rendering code.
+			model.selectedIdx = -1
+			model.width = 300
+
+			view := model.View()
+
+			// The GH:ID column should contain "-" not empty padding
+			assert.Contains(t, view, "-")
+		})
+	}
+}
+
+// TestRenderer_GHIDColumn_WithLinkedPR verifies that when a worktree has a
+// LinkedPR, the GH:ID column shows the PR number.
+func TestRenderer_GHIDColumn_WithLinkedPR(t *testing.T) {
+	tests := []struct {
+		name        string
+		worktree    domain.Worktree
+		wantPRNum   string
+	}{
+		{
+			name: "GH:ID shows PR number for linked PR (non-selected row)",
+			worktree: domain.Worktree{
+				Path:    "/tmp/feat-login",
+				Branch:  "feat/login",
+				IsClean: true,
+				LinkedPR: &domain.PullRequest{
+					Number: 1442,
+					Title:  "Login feature",
+					Author: "alice",
+					State:  "OPEN",
+				},
+			},
+			wantPRNum: "1442",
+		},
+		{
+			name: "GH:ID shows PR number for merged PR",
+			worktree: domain.Worktree{
+				Path:    "/tmp/fix-bug",
+				Branch:  "fix/bug",
+				IsClean: true,
+				LinkedPR: &domain.PullRequest{
+					Number: 55,
+					Title:  "Bug fix",
+					Author: "bob",
+					State:  "MERGED",
+				},
+			},
+			wantPRNum: "55",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = viewWorktrees
+			model.Worktrees = []domain.Worktree{tt.worktree}
+			model.selectedIdx = -1
+			model.width = 300
+
+			view := model.View()
+
+			assert.Contains(t, view, tt.wantPRNum)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End Phase 3 tests (renderer_test.go)
 // ---------------------------------------------------------------------------

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -317,7 +317,7 @@ func TestRenderIssueList_ContainsHeaders(t *testing.T) {
 	theme := styles.NewTheme("digital-noir")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := renderIssueList(nil, 0, theme, 80, 20)
+			result := renderIssueList(nil, 0, theme, 80, 20, false)
 			for _, want := range tt.wantIn {
 				assert.Contains(t, result, want)
 			}
@@ -363,7 +363,7 @@ func TestRenderIssueList_ContainsIssueRows(t *testing.T) {
 	theme := styles.NewTheme("digital-noir")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := renderIssueList(issues, tt.selectedIdx, theme, 80, 20)
+			result := renderIssueList(issues, tt.selectedIdx, theme, 80, 20, false)
 			for _, want := range tt.wantIn {
 				assert.Contains(t, result, want)
 			}
@@ -387,7 +387,7 @@ func TestRenderPRList_ContainsHeaders(t *testing.T) {
 	theme := styles.NewTheme("digital-noir")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := renderPRList(nil, 0, theme, 80, 20)
+			result := renderPRList(nil, 0, theme, 80, 20, false)
 			for _, want := range tt.wantIn {
 				assert.Contains(t, result, want)
 			}
@@ -428,7 +428,7 @@ func TestRenderPRList_ContainsPRRows(t *testing.T) {
 	theme := styles.NewTheme("digital-noir")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := renderPRList(prs, tt.selectedIdx, theme, 80, 20)
+			result := renderPRList(prs, tt.selectedIdx, theme, 80, 20, false)
 			for _, want := range tt.wantIn {
 				assert.Contains(t, result, want)
 			}
@@ -1009,11 +1009,90 @@ func TestRenderer_GHIDColumn_WithLinkedPR(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// End Phase 3 tests (renderer_test.go)
+// Phase 4: clipContent & panel focus rendering tests
 // ---------------------------------------------------------------------------
 
-// TestPrStateColor verifies that prStateColor returns the correct lipgloss color
-// for each known PR state and a safe default for unknown states.
+// TestClipContent verifies that clipContent correctly slices content lines
+// with scroll offset and maxLines constraints.
+func TestClipContent(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		offset   int
+		maxLines int
+		wantOut  string
+	}{
+		{
+			name:     "no clipping needed when within bounds",
+			content:  "line1\nline2\nline3",
+			offset:   0,
+			maxLines: 10,
+			wantOut:  "line1\nline2\nline3",
+		},
+		{
+			name:     "clips to maxLines",
+			content:  "a\nb\nc\nd\ne",
+			offset:   0,
+			maxLines: 3,
+			wantOut:  "a\nb\nc",
+		},
+		{
+			name:     "applies offset",
+			content:  "a\nb\nc\nd",
+			offset:   1,
+			maxLines: 10,
+			wantOut:  "b\nc\nd",
+		},
+		{
+			name:     "applies offset and clips",
+			content:  "a\nb\nc\nd\ne",
+			offset:   1,
+			maxLines: 2,
+			wantOut:  "b\nc",
+		},
+		{
+			name:     "offset beyond content clamps to last line",
+			content:  "a\nb",
+			offset:   5,
+			maxLines: 10,
+			wantOut:  "b",
+		},
+		{
+			name:     "zero maxLines returns content unchanged",
+			content:  "a\nb\nc",
+			offset:   0,
+			maxLines: 0,
+			wantOut:  "a\nb\nc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := clipContent(tt.content, tt.offset, tt.maxLines)
+			assert.Equal(t, tt.wantOut, result)
+		})
+	}
+}
+
+// TestRenderFull_FooterContainsTabAndJKHints verifies that the footer bar
+// includes the new Tab panel and j/k navigation hints.
+func TestRenderFull_FooterContainsTabAndJKHints(t *testing.T) {
+	model := NewModel()
+	require.NotNil(t, model)
+
+	view := model.View()
+
+	assert.Contains(t, view, "[Tab]")
+	assert.Contains(t, view, "[j/k]")
+	// Old hints must still be present
+	assert.Contains(t, view, "[Enter] Select")
+	assert.Contains(t, view, "[esc] Quit")
+}
+
+// ---------------------------------------------------------------------------
+// End Phase 4 tests (renderer_test.go)
+// ---------------------------------------------------------------------------
+
 func TestPrStateColor(t *testing.T) {
 	tests := []struct {
 		state     string

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -3,9 +3,11 @@ package main
 import (
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/m00nk0d3/nexus/internal/domain"
 	"github.com/m00nk0d3/nexus/internal/tui/styles"
@@ -1196,3 +1198,141 @@ assert.NotContains(t, view, longPath, "raw long path must not appear; it should 
 // The truncated path must contain the ellipsis sentinel.
 assert.Contains(t, view, "Path: ")
 }
+
+// ---------------------------------------------------------------------------
+// Phase 6: context panel height-cap and scroll-reset tests
+// ---------------------------------------------------------------------------
+
+// TestRenderFull_PRWithLongBody_FitsTerminalHeight verifies that a PR with a
+// very long body does not cause the rendered output to exceed the terminal height.
+// This is a regression test for the bug where the context panel grew taller than
+// the terminal, pushing the header bar off-screen.
+func TestRenderFull_PRWithLongBody_FitsTerminalHeight(t *testing.T) {
+	const termHeight = 24
+	const termWidth = 120
+
+	// Build a body that, after word-wrapping, generates hundreds of lines.
+	longBody := strings.Repeat("This is a long line of PR body text that keeps going. ", 200)
+
+	prs := []domain.PullRequest{
+		{
+			Number: 1,
+			Title:  "My very important PR",
+			Branch: "feat/very-long-body-pr",
+			Author: "alice",
+			State:  "OPEN",
+			Labels: []string{"bug", "enhancement", "security", "breaking-change"},
+			Body:   longBody,
+		},
+	}
+
+	model := NewModel()
+	require.NotNil(t, model)
+	model.view = viewPRs
+	model.prs = prs
+	model.width = termWidth
+	model.height = termHeight
+
+	rendered := model.View()
+
+	// Count newlines — output must have at most termHeight lines.
+	lineCount := strings.Count(rendered, "\n") + 1
+	assert.LessOrEqual(t, lineCount, termHeight,
+		"rendered output (%d lines) must not exceed terminal height (%d)", lineCount, termHeight)
+}
+
+// TestRenderFull_IssueWithManyLabels_FitsTerminalHeight verifies the same height
+// constraint when viewing an issue with many labels (exercises the Labels: prefix fix).
+func TestRenderFull_IssueWithManyLabels_FitsTerminalHeight(t *testing.T) {
+	const termHeight = 24
+	const termWidth = 80
+
+	issues := []domain.Issue{
+		{
+			Number: 5,
+			Title:  "Some issue",
+			Labels: []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"},
+		},
+	}
+
+	model := NewModel()
+	require.NotNil(t, model)
+	model.view = viewIssues
+	model.issues = issues
+	model.width = termWidth
+	model.height = termHeight
+
+	rendered := model.View()
+
+	lineCount := strings.Count(rendered, "\n") + 1
+	assert.LessOrEqual(t, lineCount, termHeight,
+		"rendered output (%d lines) must not exceed terminal height (%d)", lineCount, termHeight)
+}
+
+// TestMoveDown_ResetsCtxScrollOffset verifies that navigating the list panel
+// resets the context scroll offset so the new item's content starts at the top.
+func TestMoveDown_ResetsCtxScrollOffset(t *testing.T) {
+	model := NewModel()
+	require.NotNil(t, model)
+	model.view = viewPRs
+	model.focused = panelList
+	model.prs = []domain.PullRequest{
+		{Number: 1, Title: "PR 1", Branch: "feat/1", Author: "alice", State: "OPEN"},
+		{Number: 2, Title: "PR 2", Branch: "feat/2", Author: "bob", State: "OPEN"},
+	}
+	model.selectedPRIdx = 0
+	model.ctxScrollOffset = 5 // simulate scrolled state
+
+	model.moveDown()
+
+	assert.Equal(t, 0, model.ctxScrollOffset, "ctxScrollOffset must reset to 0 after navigating to next PR")
+	assert.Equal(t, 1, model.selectedPRIdx)
+}
+
+// TestMoveUp_ResetsCtxScrollOffset verifies that navigating up in the list panel
+// resets the context scroll offset.
+func TestMoveUp_ResetsCtxScrollOffset(t *testing.T) {
+	model := NewModel()
+	require.NotNil(t, model)
+	model.view = viewPRs
+	model.focused = panelList
+	model.prs = []domain.PullRequest{
+		{Number: 1, Title: "PR 1", Branch: "feat/1", Author: "alice", State: "OPEN"},
+		{Number: 2, Title: "PR 2", Branch: "feat/2", Author: "bob", State: "OPEN"},
+	}
+	model.selectedPRIdx = 1
+	model.ctxScrollOffset = 3 // simulate scrolled state
+
+	model.moveUp()
+
+	assert.Equal(t, 0, model.ctxScrollOffset, "ctxScrollOffset must reset to 0 after navigating to previous PR")
+	assert.Equal(t, 0, model.selectedPRIdx)
+}
+
+// TestViewSwitch_ResetsCtxScrollOffset verifies that switching views (W/I/P keys)
+// resets the context scroll offset so the new view starts from the top.
+func TestViewSwitch_ResetsCtxScrollOffset(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     string
+		wantView activeView
+	}{
+		{"switch to worktrees resets scroll", "w", viewWorktrees},
+		{"switch to issues resets scroll", "i", viewIssues},
+		{"switch to PRs resets scroll", "p", viewPRs},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.ctxScrollOffset = 7 // simulate scrolled state
+
+			_, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(tt.key)})
+
+			assert.Equal(t, 0, model.ctxScrollOffset, "ctxScrollOffset must reset to 0 after switching view")
+			assert.Equal(t, tt.wantView, model.view)
+		})
+	}
+}
+

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -372,7 +372,8 @@ func TestRenderIssueList_ContainsIssueRows(t *testing.T) {
 }
 
 // TestRenderPRList_ContainsHeaders verifies that renderPRList renders
-// the required column headers: #, TITLE, BRANCH, AUTHOR, STATUS.
+// the required column headers: #, TITLE, BRANCH, STATUS.
+// Note: AUTHOR column was removed from the list (it is visible in the context panel).
 func TestRenderPRList_ContainsHeaders(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -380,7 +381,7 @@ func TestRenderPRList_ContainsHeaders(t *testing.T) {
 	}{
 		{
 			name:   "renders all required column headers",
-			wantIn: []string{"#", "TITLE", "BRANCH", "AUTHOR", "STATUS"},
+			wantIn: []string{"#", "TITLE", "BRANCH", "STATUS"},
 		},
 	}
 
@@ -409,9 +410,9 @@ func TestRenderPRList_ContainsPRRows(t *testing.T) {
 		wantIn      []string
 	}{
 		{
-			name:        "renders PR number, title, branch, author, state",
+			name:        "renders PR number, title, branch, and state",
 			selectedIdx: 0,
-			wantIn:      []string{"42", "My PR", "feat/awesome", "alice", "OPEN"},
+			wantIn:      []string{"42", "My PR", "feat/awesome", "OPEN"},
 		},
 		{
 			name:        "selected PR (idx 0) has > cursor",
@@ -421,7 +422,7 @@ func TestRenderPRList_ContainsPRRows(t *testing.T) {
 		{
 			name:        "second PR is also rendered",
 			selectedIdx: 0,
-			wantIn:      []string{"43", "Fix PR", "fix/bug", "bob"},
+			wantIn:      []string{"43", "Fix PR", "fix/bug"},
 		},
 	}
 
@@ -610,7 +611,7 @@ func TestRenderFull_PRViewShowsPRList(t *testing.T) {
 			prs: []domain.PullRequest{
 				{Number: 1, Title: "Any PR", Branch: "main", Author: "dev", State: "OPEN"},
 			},
-			wantIn: []string{"BRANCH", "AUTHOR"},
+			wantIn: []string{"BRANCH", "STATUS"},
 		},
 	}
 
@@ -1170,4 +1171,28 @@ func TestPrStateColor(t *testing.T) {
 			assert.Equal(t, lipgloss.Color(tt.wantColor), got)
 		})
 	}
+}
+
+
+// TestRenderer_ContextPanel_LongPathTruncated verifies that a worktree path
+// longer than the dynamic ctxInner does not overflow and is truncated with ellipsis.
+func TestRenderer_ContextPanel_LongPathTruncated(t *testing.T) {
+longPath := "/development/worktrees/feat-issue-9-config-file-parsing-very-long-name"
+wt := domain.Worktree{
+Path:    longPath,
+Branch:  "feat-issue-9",
+IsClean: true,
+}
+model := NewModel()
+require.NotNil(t, model)
+model.view = viewWorktrees
+model.Worktrees = []domain.Worktree{wt}
+model.selectedIdx = 0
+
+view := model.View()
+
+// Path must not appear raw (it would overflow the panel when the terminal is narrow).
+assert.NotContains(t, view, longPath, "raw long path must not appear; it should be truncated")
+// The truncated path must contain the ellipsis sentinel.
+assert.Contains(t, view, "Path: ")
 }

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
 	"github.com/m00nk0d3/nexus/internal/domain"
 	"github.com/m00nk0d3/nexus/internal/tui/styles"
 	"github.com/stretchr/testify/assert"
@@ -943,8 +944,10 @@ func TestRenderer_GHIDColumn_NoLinkedPR(t *testing.T) {
 
 			view := model.View()
 
-			// The GH:ID column should contain "-" not empty padding
-			assert.Contains(t, view, "-")
+			// The GH:ID column should contain "- " (dash padded to 6 chars). We verify
+			// the worktree row is actually rendered and the column shows the placeholder.
+			assert.Contains(t, view, "wt-no-pr")
+			assert.Contains(t, view, "-     ") // "- " padded to 6 chars
 		})
 	}
 }
@@ -1008,3 +1011,25 @@ func TestRenderer_GHIDColumn_WithLinkedPR(t *testing.T) {
 // ---------------------------------------------------------------------------
 // End Phase 3 tests (renderer_test.go)
 // ---------------------------------------------------------------------------
+
+// TestPrStateColor verifies that prStateColor returns the correct lipgloss color
+// for each known PR state and a safe default for unknown states.
+func TestPrStateColor(t *testing.T) {
+	tests := []struct {
+		state     string
+		wantColor string
+	}{
+		{"OPEN", "#00D9FF"},
+		{"MERGED", "#9B59B6"},
+		{"CLOSED", "#E74C3C"},
+		{"UNKNOWN", "#4A5568"},
+		{"", "#4A5568"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			got := prStateColor(tt.state)
+			assert.Equal(t, lipgloss.Color(tt.wantColor), got)
+		})
+	}
+}

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -1093,6 +1093,65 @@ func TestRenderFull_FooterContainsTabAndJKHints(t *testing.T) {
 // End Phase 4 tests (renderer_test.go)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Phase 5: wrapText — prevent context panel from stretching vertically
+// ---------------------------------------------------------------------------
+
+// TestWrapText verifies that wrapText breaks long lines at word boundaries,
+// hard-breaks words longer than the width, and preserves existing newlines.
+func TestWrapText(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		width   int
+		wantOut string
+	}{
+		{
+			name:    "short line unchanged",
+			input:   "hello world",
+			width:   50,
+			wantOut: "hello world",
+		},
+		{
+			name:    "long line breaks at word boundary",
+			input:   "one two three four five six seven eight nine ten eleven",
+			width:   20,
+			wantOut: "one two three four\nfive six seven eight\nnine ten eleven",
+		},
+		{
+			name:    "single word longer than width gets hard-broken",
+			input:   "abcdefghijklmnopqrstuvwxyz",
+			width:   10,
+			wantOut: "abcdefghij\nklmnopqrst\nuvwxyz",
+		},
+		{
+			name:    "existing newlines are preserved and each segment wrapped",
+			input:   "line one is short\nthis line is much much much much much much much longer than the limit",
+			width:   20,
+			wantOut: "line one is short\nthis line is much\nmuch much much much\nmuch much longer\nthan the limit",
+		},
+		{
+			name:    "zero width returns input unchanged",
+			input:   "some content",
+			width:   0,
+			wantOut: "some content",
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			width:   10,
+			wantOut: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapText(tt.input, tt.width)
+			assert.Equal(t, tt.wantOut, got)
+		})
+	}
+}
+
 func TestPrStateColor(t *testing.T) {
 	tests := []struct {
 		state     string

--- a/internal/domain/issue.go
+++ b/internal/domain/issue.go
@@ -9,6 +9,7 @@ import (
 type Issue struct {
 	Number int
 	Title  string
+	Body   string
 	Labels []string
 }
 

--- a/internal/domain/pr.go
+++ b/internal/domain/pr.go
@@ -4,6 +4,7 @@ package domain
 type PullRequest struct {
 	Number  int
 	Title   string
+	Body    string
 	Branch  string
 	Author  string
 	State   string // "OPEN", "MERGED", "CLOSED"

--- a/internal/exec/github.go
+++ b/internal/exec/github.go
@@ -90,7 +90,7 @@ func NewPRCommandWithRunner(repoPath string, runner commandRunner) *PRCommand {
 	return &PRCommand{repoPath: repoPath, runner: runner}
 }
 
-const prFields = "number,title,headRefName,author,state,labels,isDraft"
+const prFields = "number,title,body,headRefName,author,state,labels,isDraft"
 
 // ListOpenPRs returns all open pull requests via `gh pr list`.
 func (c *PRCommand) ListOpenPRs() ([]domain.PullRequest, error) {
@@ -131,6 +131,7 @@ type ghAuthor struct {
 type ghPR struct {
 	Number      int       `json:"number"`
 	Title       string    `json:"title"`
+	Body        string    `json:"body"`
 	HeadRefName string    `json:"headRefName"`
 	Author      ghAuthor  `json:"author"`
 	State       string    `json:"state"`
@@ -146,6 +147,7 @@ func ghPRToDomain(g ghPR) domain.PullRequest {
 	return domain.PullRequest{
 		Number:  g.Number,
 		Title:   g.Title,
+		Body:    g.Body,
 		Branch:  g.HeadRefName,
 		Author:  g.Author.Login,
 		State:   g.State,

--- a/internal/exec/github.go
+++ b/internal/exec/github.go
@@ -27,7 +27,7 @@ func NewIssueCommandWithRunner(repoPath string, runner commandRunner) *IssueComm
 
 // ListOpenIssues returns all open GitHub issues via `gh issue list`.
 func (c *IssueCommand) ListOpenIssues() ([]domain.Issue, error) {
-	output, err := c.runner(c.repoPath, "issue", "list", "--json", "number,title,labels", "--state", "open", "--limit", "100")
+	output, err := c.runner(c.repoPath, "issue", "list", "--json", "number,title,body,labels", "--state", "open", "--limit", "100")
 	if err != nil {
 		return nil, fmt.Errorf("list open issues: %w", err)
 	}
@@ -45,10 +45,11 @@ type ghLabel struct {
 	Name string `json:"name"`
 }
 
-// ghIssue is the JSON shape returned by `gh issue list --json number,title,labels`.
+// ghIssue is the JSON shape returned by `gh issue list --json number,title,body,labels`.
 type ghIssue struct {
 	Number int       `json:"number"`
 	Title  string    `json:"title"`
+	Body   string    `json:"body"`
 	Labels []ghLabel `json:"labels"`
 }
 
@@ -67,6 +68,7 @@ func parseIssueList(raw string) ([]domain.Issue, error) {
 		issues = append(issues, domain.Issue{
 			Number: g.Number,
 			Title:  g.Title,
+			Body:   g.Body,
 			Labels: labels,
 		})
 	}

--- a/internal/exec/github_test.go
+++ b/internal/exec/github_test.go
@@ -18,7 +18,7 @@ func TestNewIssueCommand(t *testing.T) {
 }
 
 func TestListOpenIssues_ValidOutput_ReturnsIssues(t *testing.T) {
-	raw := `[{"number":5,"title":"[Phase 1] Implement - Create/delete modals","labels":[{"name":"phase-1"}]},{"number":6,"title":"[Phase 1] Implement - Switch worktree","labels":[{"name":"phase-1"},{"name":"enhancement"}]}]`
+	raw := `[{"number":5,"title":"[Phase 1] Implement - Create/delete modals","body":"","labels":[{"name":"phase-1"}]},{"number":6,"title":"[Phase 1] Implement - Switch worktree","body":"Some details","labels":[{"name":"phase-1"},{"name":"enhancement"}]}]`
 
 	runner := func(_ string, _ ...string) (string, error) {
 		return raw, nil
@@ -102,7 +102,7 @@ func TestListOpenIssues_PassesCorrectArgs(t *testing.T) {
 	_, err := cmd.ListOpenIssues()
 
 	require.NoError(t, err)
-	assert.Equal(t, []string{"issue", "list", "--json", "number,title,labels", "--state", "open", "--limit", "100"}, capturedArgs)
+	assert.Equal(t, []string{"issue", "list", "--json", "number,title,body,labels", "--state", "open", "--limit", "100"}, capturedArgs)
 }
 
 func TestListOpenIssues_MapsDomainsCorrectly(t *testing.T) {
@@ -113,9 +113,9 @@ func TestListOpenIssues_MapsDomainsCorrectly(t *testing.T) {
 	}{
 		{
 			name: "single issue with multiple labels",
-			raw:  `[{"number":42,"title":"Fix the thing","labels":[{"name":"bug"},{"name":"priority-high"}]}]`,
+			raw:  `[{"number":42,"title":"Fix the thing","body":"Details here","labels":[{"name":"bug"},{"name":"priority-high"}]}]`,
 			expected: []domain.Issue{
-				{Number: 42, Title: "Fix the thing", Labels: []string{"bug", "priority-high"}},
+				{Number: 42, Title: "Fix the thing", Body: "Details here", Labels: []string{"bug", "priority-high"}},
 			},
 		},
 	}

--- a/internal/exec/github_test.go
+++ b/internal/exec/github_test.go
@@ -146,8 +146,8 @@ func TestNewPRCommand(t *testing.T) {
 
 func TestListOpenPRs(t *testing.T) {
 	twoPRsJSON := `[
-		{"number":1,"title":"Add login","headRefName":"feat/login","author":{"login":"alice"},"state":"OPEN","labels":[{"name":"enhancement"}],"isDraft":false},
-		{"number":2,"title":"WIP: refactor","headRefName":"chore/refactor","author":{"login":"bob"},"state":"OPEN","labels":[{"name":"wip"},{"name":"refactor"}],"isDraft":true}
+		{"number":1,"title":"Add login","body":"Adds login flow","headRefName":"feat/login","author":{"login":"alice"},"state":"OPEN","labels":[{"name":"enhancement"}],"isDraft":false},
+		{"number":2,"title":"WIP: refactor","body":"","headRefName":"chore/refactor","author":{"login":"bob"},"state":"OPEN","labels":[{"name":"wip"},{"name":"refactor"}],"isDraft":true}
 	]`
 
 	tests := []struct {
@@ -163,8 +163,8 @@ func TestListOpenPRs(t *testing.T) {
 			name:      "valid JSON with 2 PRs maps correctly",
 			runnerOut: twoPRsJSON,
 			wantPRs: []domain.PullRequest{
-				{Number: 1, Title: "Add login", Branch: "feat/login", Author: "alice", State: "OPEN", Labels: []string{"enhancement"}, IsDraft: false},
-				{Number: 2, Title: "WIP: refactor", Branch: "chore/refactor", Author: "bob", State: "OPEN", Labels: []string{"wip", "refactor"}, IsDraft: true},
+				{Number: 1, Title: "Add login", Body: "Adds login flow", Branch: "feat/login", Author: "alice", State: "OPEN", Labels: []string{"enhancement"}, IsDraft: false},
+				{Number: 2, Title: "WIP: refactor", Body: "", Branch: "chore/refactor", Author: "bob", State: "OPEN", Labels: []string{"wip", "refactor"}, IsDraft: true},
 			},
 		},
 		{
@@ -245,7 +245,7 @@ func TestListOpenPRs(t *testing.T) {
 }
 
 func TestGetPR(t *testing.T) {
-	validPRJSON := `{"number":42,"title":"Implement feature","headRefName":"feat/feature","author":{"login":"frank"},"state":"MERGED","labels":[{"name":"feature"}],"isDraft":false}`
+	validPRJSON := `{"number":42,"title":"Implement feature","body":"This implements the feature.","headRefName":"feat/feature","author":{"login":"frank"},"state":"MERGED","labels":[{"name":"feature"}],"isDraft":false}`
 
 	tests := []struct {
 		name        string
@@ -264,6 +264,7 @@ func TestGetPR(t *testing.T) {
 			wantPR: &domain.PullRequest{
 				Number:  42,
 				Title:   "Implement feature",
+				Body:    "This implements the feature.",
 				Branch:  "feat/feature",
 				Author:  "frank",
 				State:   "MERGED",

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -145,6 +145,13 @@ func (t Theme) StatusStyle(status string) lipgloss.Style {
 	}
 }
 
+// MutedBorder returns s with the border foreground dimmed to the muted color.
+// Apply this to unfocused panels to visually de-emphasize them relative to the
+// currently focused panel.
+func (t Theme) MutedBorder(s lipgloss.Style) lipgloss.Style {
+	return s.BorderForeground(lipgloss.Color(t.muted))
+}
+
 // RenderBox renders content inside a rounded-border panel with an optional title.
 func (t Theme) RenderBox(title, content string) string {
 	style := lipgloss.NewStyle().


### PR DESCRIPTION
Closes #15

## What Changed

Fixed the PR/Issues context panel layout bug where the panel grew taller than the terminal, pushing the header bar off-screen.

## Root Causes Fixed

1. **lipgloss Height(n) is minimum-only** - added MaxHeight(panelHeight+2) as a hard cap.
2. **Labels: prefix overflow (8 chars)** - wrap labels to ctxInner-8.
3. **GH Title: prefix overflow (10 chars)** - truncate title to ctxInner-10.
4. **Footer bar wraps on 80-col terminals** - truncate footer/actionBar to termWidth.
5. **ctxScrollOffset not reset on navigation** - reset to 0 on list nav and view switch.

## Testing

Added 5 regression tests covering all fixes. Full suite green.