### PR TITLE
[Phase 3] feat(app): GitHub Copilot launcher (suspend + context pass)

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/m00nk0d3/nexus/internal/data"
 	"github.com/m00nk0d3/nexus/internal/domain"
@@ -45,6 +47,15 @@ type syncTickMsg struct{}
 
 // browserOpenErrMsg carries an error from opening an issue or PR in the browser.
 type browserOpenErrMsg struct{ err error }
+
+// agentDoneMsg is dispatched when an AI agent process exits.
+// It carries enough information to log the run and update UI state.
+type agentDoneMsg struct {
+	agentName string
+	prompt    string
+	exitCode  int
+	startedAt time.Time
+}
 
 // activeView represents the currently active main panel view.
 type activeView int
@@ -87,6 +98,13 @@ type Model struct {
 	selectedPRIdx    int                  // Currently selected PR index
 	focused          focusedPanel         // Which panel currently has keyboard focus
 	ctxScrollOffset  int                  // Scroll position within the context panel
+
+	// DB is optional; when non-nil, agent runs are logged to agent_history.
+	db *data.DB
+
+	// Copilot prompt state
+	copilotPromptActive bool           // true while the inline Copilot prompt is open
+	copilotPromptInput  textinput.Model // text input for entering the Copilot prompt
 }
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
@@ -141,6 +159,35 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// While the Copilot inline prompt is open, route key events to the textinput.
+	// Non-key messages (e.g. agentDoneMsg, tea.WindowSizeMsg) fall through to
+	// the main switch below so they are still handled correctly.
+	if m.copilotPromptActive {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			switch keyMsg.Type {
+			case tea.KeyEnter:
+				prompt := strings.TrimSpace(m.copilotPromptInput.Value())
+				if prompt == "" {
+					return m, nil
+				}
+				m.copilotPromptActive = false
+				if selected, ok := m.selectedWorktree(); ok {
+					return m, m.spawnCopilotCmd(selected.Path, prompt)
+				}
+				return m, nil
+			case tea.KeyEsc:
+				m.copilotPromptActive = false
+				m.copilotPromptInput.SetValue("")
+				return m, nil
+			default:
+				var cmd tea.Cmd
+				m.copilotPromptInput, cmd = m.copilotPromptInput.Update(keyMsg)
+				return m, cmd
+			}
+		}
+		// Non-key message: fall through to the main switch to handle it normally.
+	}
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.Type {
@@ -191,6 +238,21 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return m, m.switchWorktreeCmd(selected.Path)
 					}
 				}
+			case "c", "C":
+				if m.view == viewWorktrees && m.Config.AIAgents.CopilotEnabled {
+					if _, ok := m.selectedWorktree(); ok {
+						if _, err := exec.LookPath("gh"); err != nil {
+							m.Error = "gh not found on $PATH — install GitHub CLI to use Copilot"
+							return m, nil
+						}
+						ti := textinput.New()
+						ti.Placeholder = "Enter Copilot prompt…"
+						focusCmd := ti.Focus()
+						m.copilotPromptInput = ti
+						m.copilotPromptActive = true
+						return m, focusCmd
+					}
+				}
 			}
 		}
 
@@ -226,6 +288,22 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case browserOpenErrMsg:
 		if msg.err != nil {
 			m.Error = fmt.Sprintf("Failed to open in browser: %v", msg.err)
+		}
+
+	case agentDoneMsg:
+		m.copilotPromptActive = false
+		m.copilotPromptInput.SetValue("")
+		if m.db != nil {
+			entry := data.AgentHistoryEntry{
+				AgentName: msg.agentName,
+				Prompt:    msg.prompt,
+				ExitCode:  msg.exitCode,
+				StartedAt: msg.startedAt,
+				EndedAt:   time.Now(),
+			}
+			if err := data.LogAgentRun(m.db, entry); err != nil {
+				m.Error = fmt.Sprintf("failed to log agent run: %v", err)
+			}
 		}
 
 	case githubSyncedMsg:
@@ -265,6 +343,15 @@ func (m *Model) View() string {
 		baseView = m.activeModal.View()
 	} else {
 		baseView = renderFull(m.Worktrees, m.selectedIdx, m.RepoPath, m.themeIdx, m.view, m.width, m.height, m.syncing, m.lastSynced, m.syncErr, m.issues, m.selectedIssueIdx, m.prs, m.selectedPRIdx, m.focused, m.ctxScrollOffset)
+	}
+
+	// When the Copilot inline prompt is active, overlay it on top of the normal view.
+	if m.copilotPromptActive {
+		return fmt.Sprintf(
+			"Spawn Copilot\n> Enter prompt: %s\n\nEnter confirm  •  Esc cancel\n\n%s",
+			m.copilotPromptInput.View(),
+			baseView,
+		)
 	}
 
 	if m.Error == "" {
@@ -346,6 +433,35 @@ func (m *Model) switchWorktreeCmd(path string) tea.Cmd {
 	cmd := buildShellCmd(path)
 	return tea.ExecProcess(cmd, func(err error) tea.Msg {
 		return worktreeSwitchedMsg{err: err}
+	})
+}
+
+// buildCopilotCmd constructs the exec.Cmd for running gh copilot suggest
+// with the given prompt in the specified worktree directory.
+// It is extracted as a top-level function to keep it unit-testable.
+func buildCopilotCmd(worktreePath, prompt string) *exec.Cmd {
+	cmd := exec.Command("gh", "copilot", "suggest", prompt)
+	cmd.Dir = worktreePath
+	return cmd
+}
+
+// spawnCopilotCmd returns a Cmd that runs gh copilot suggest in the worktree
+// directory and dispatches agentDoneMsg when the process exits.
+func (m *Model) spawnCopilotCmd(worktreePath, prompt string) tea.Cmd {
+	startedAt := time.Now()
+	cmd := buildCopilotCmd(worktreePath, prompt)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		exitCode := 0
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+		return agentDoneMsg{
+			agentName: "copilot",
+			prompt:    prompt,
+			exitCode:  exitCode,
+			startedAt: startedAt,
+		}
 	})
 }
 

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -174,6 +174,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if selected, ok := m.selectedWorktree(); ok {
 					return m, m.spawnCopilotCmd(selected.Path, prompt)
 				}
+				m.copilotPromptInput.SetValue("")
 				return m, nil
 			case tea.KeyEsc:
 				m.copilotPromptActive = false
@@ -347,11 +348,12 @@ func (m *Model) View() string {
 
 	// When the Copilot inline prompt is active, overlay it on top of the normal view.
 	if m.copilotPromptActive {
-		return fmt.Sprintf(
-			"Spawn Copilot\n> Enter prompt: %s\n\nEnter confirm  •  Esc cancel\n\n%s",
-			m.copilotPromptInput.View(),
-			baseView,
+		theme := styles.NewTheme(styles.Themes[m.themeIdx])
+		prompt := theme.RenderBox(
+			"Spawn Copilot",
+			fmt.Sprintf("> %s\n\nEnter confirm  •  Esc cancel", m.copilotPromptInput.View()),
 		)
+		return fmt.Sprintf("%s\n\n%s", prompt, baseView)
 	}
 
 	if m.Error == "" {

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -1145,8 +1145,7 @@ func TestModel_WindowSizeMsg_StoresDimensions(t *testing.T) {
 }
 
 
-
-// TestModelUpdate_SKeyOpensShellInWorktree verifies that pressing "s" in
+// TestModelUpdate_SKeyOpensShellInWorktreeverifies that pressing "s" in
 // viewWorktrees with a selected worktree triggers switchWorktreeCmd.
 func TestModelUpdate_SKeyOpensShellInWorktree(t *testing.T) {
 tests := []struct {

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"errors"
+	"os/exec"
 	"testing"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/data"
 	"github.com/m00nk0d3/nexus/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1143,6 +1145,7 @@ func TestModel_WindowSizeMsg_StoresDimensions(t *testing.T) {
 }
 
 
+
 // TestModelUpdate_SKeyOpensShellInWorktree verifies that pressing "s" in
 // viewWorktrees with a selected worktree triggers switchWorktreeCmd.
 func TestModelUpdate_SKeyOpensShellInWorktree(t *testing.T) {
@@ -1192,3 +1195,262 @@ assert.NotNil(t, cmd, "expected a non-nil cmd from switchWorktreeCmd")
 })
 }
 }
+
+// ---------------------------------------------------------------------------
+// Phase 3: GitHub Copilot launcher tests
+// ---------------------------------------------------------------------------
+
+// newTestDB is a test helper that opens an in-memory SQLite DB for tests
+// that need to exercise the DB logging path on the Model.
+func newTestDB(t *testing.T) (*data.DB, error) {
+	t.Helper()
+	db, err := data.NewDB(":memory:")
+	if err != nil {
+		return nil, err
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db, nil
+}
+
+// TestModel_C_Key_TriggersCopilotPrompt verifies that pressing 'c' with
+// CopilotEnabled=true and a selected worktree activates the copilot prompt
+// input. When CopilotEnabled=false or no worktree exists, it is a no-op.
+func TestModel_C_Key_TriggersCopilotPrompt(t *testing.T) {
+	tests := []struct {
+		name             string
+		copilotEnabled   bool
+		hasWorktree      bool
+		wantPromptActive bool
+	}{
+		{
+			name:             "c key with disabled config does nothing",
+			copilotEnabled:   false,
+			hasWorktree:      true,
+			wantPromptActive: false,
+		},
+		{
+			name:             "c key with no worktree does nothing",
+			copilotEnabled:   true,
+			hasWorktree:      false,
+			wantPromptActive: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			model.Config.AIAgents.CopilotEnabled = tt.copilotEnabled
+			model.view = viewWorktrees
+			if tt.hasWorktree {
+				model.Worktrees = []domain.Worktree{
+					{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"},
+				}
+			}
+
+			updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+			updatedModel, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.False(t, updatedModel.copilotPromptActive,
+				"copilotPromptActive should be false")
+		})
+	}
+
+	// Separate sub-test for the "gh on PATH" happy path, skipped if gh is absent.
+	t.Run("c key with enabled config and selected worktree activates prompt", func(t *testing.T) {
+		if _, err := exec.LookPath("gh"); err != nil {
+			t.Skip("gh not on PATH; skipping test that requires gh CLI")
+		}
+
+		model := NewModel()
+		model.Config.AIAgents.CopilotEnabled = true
+		model.view = viewWorktrees
+		model.Worktrees = []domain.Worktree{
+			{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"},
+		}
+
+		updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+		updatedModel, ok := updated.(*Model)
+		require.True(t, ok)
+
+		assert.True(t, updatedModel.copilotPromptActive,
+			"copilotPromptActive should be true when gh is on PATH")
+		assert.NotNil(t, cmd, "textinput.Init() should return a non-nil cmd")
+	})
+
+	// Verify that 'c' in a non-worktree view does nothing even when enabled.
+	t.Run("c key in issues view does nothing even when enabled", func(t *testing.T) {
+		model := NewModel()
+		model.Config.AIAgents.CopilotEnabled = true
+		model.view = viewIssues
+		model.Worktrees = []domain.Worktree{
+			{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"},
+		}
+
+		updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+		updatedModel, ok := updated.(*Model)
+		require.True(t, ok)
+
+		assert.False(t, updatedModel.copilotPromptActive,
+			"copilotPromptActive should stay false when not in worktrees view")
+	})
+}
+
+// TestBuildCopilotCmd_BuildsCorrectCommand verifies that buildCopilotCmd
+// produces the right exec.Cmd args and working directory.
+func TestBuildCopilotCmd_BuildsCorrectCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		worktreePath string
+		prompt       string
+		wantArgs     []string
+		wantDir      string
+	}{
+		{
+			name:         "simple prompt",
+			worktreePath: "/tmp/my-worktree",
+			prompt:       "fix the null pointer",
+			wantArgs:     []string{"gh", "copilot", "suggest", "fix the null pointer"},
+			wantDir:      "/tmp/my-worktree",
+		},
+		{
+			name:         "multi-word prompt",
+			worktreePath: "/repo/feat-branch",
+			prompt:       "add unit tests for auth handler",
+			wantArgs:     []string{"gh", "copilot", "suggest", "add unit tests for auth handler"},
+			wantDir:      "/repo/feat-branch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := buildCopilotCmd(tt.worktreePath, tt.prompt)
+			require.NotNil(t, cmd)
+			assert.Equal(t, tt.wantArgs, cmd.Args)
+			assert.Equal(t, tt.wantDir, cmd.Dir)
+		})
+	}
+}
+
+// TestModel_CopilotPrompt_EscCancels verifies that pressing Esc while the
+// copilot prompt is active clears copilotPromptActive without spawning.
+func TestModel_CopilotPrompt_EscCancels(t *testing.T) {
+	model := NewModel()
+	model.copilotPromptActive = true
+	model.Worktrees = []domain.Worktree{{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"}}
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.False(t, updatedModel.copilotPromptActive,
+		"Esc should deactivate the copilot prompt")
+}
+
+// TestModel_CopilotPrompt_EscClearsInputValue verifies that Esc also resets
+// the text input value so it starts fresh on the next invocation.
+func TestModel_CopilotPrompt_EscClearsInputValue(t *testing.T) {
+	model := NewModel()
+	model.copilotPromptActive = true
+	model.copilotPromptInput.SetValue("some typed text")
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Equal(t, "", updatedModel.copilotPromptInput.Value(),
+		"Esc should clear the copilot prompt input value")
+}
+
+// TestModel_CopilotPrompt_EnterWithEmptyPrompt_DoesNotSpawn verifies that
+// pressing Enter with an empty (or whitespace-only) prompt is a no-op.
+func TestModel_CopilotPrompt_EnterWithEmptyPrompt_DoesNotSpawn(t *testing.T) {
+	model := NewModel()
+	model.copilotPromptActive = true
+	// Leave input value empty (default)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	// With an empty prompt, state should not change (prompt stays active)
+	// and no cmd should be spawned.
+	assert.True(t, updatedModel.copilotPromptActive,
+		"empty-prompt Enter should leave copilotPromptActive true")
+	assert.Nil(t, cmd, "empty-prompt Enter should not return a spawn Cmd")
+}
+
+// TestModel_AgentDoneMsg_ClearsPrompt verifies that receiving agentDoneMsg
+// clears the copilot prompt state regardless of exit code.
+func TestModel_AgentDoneMsg_ClearsPrompt(t *testing.T) {
+	tests := []struct {
+		name     string
+		exitCode int
+	}{
+		{name: "exit code 0 clears prompt", exitCode: 0},
+		{name: "non-zero exit code still clears prompt", exitCode: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			model.copilotPromptActive = true
+
+			updated, _ := model.Update(agentDoneMsg{
+				agentName: "copilot",
+				prompt:    "test prompt",
+				exitCode:  tt.exitCode,
+			})
+			updatedModel, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.False(t, updatedModel.copilotPromptActive,
+				"agentDoneMsg should clear copilotPromptActive")
+		})
+	}
+}
+
+// TestModel_AgentDoneMsg_LogsToDBWhenAvailable verifies that agentDoneMsg
+// triggers a DB log call when model.db is set (non-nil).
+func TestModel_AgentDoneMsg_LogsToDBWhenAvailable(t *testing.T) {
+	// We test the logging path by supplying a real in-memory DB.
+	db, err := newTestDB(t)
+	require.NoError(t, err)
+
+	model := NewModel()
+	model.copilotPromptActive = true
+	model.db = db
+
+	updated, _ := model.Update(agentDoneMsg{
+		agentName: "copilot",
+		prompt:    "fix bug",
+		exitCode:  0,
+	})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	// No error should be set on the model.
+	assert.Empty(t, updatedModel.Error, "DB log should not set an error on success")
+
+	// Verify the row was actually written.
+	var count int
+	require.NoError(t, db.Conn.QueryRow(
+		"SELECT COUNT(*) FROM agent_history WHERE agent_name = 'copilot'",
+	).Scan(&count))
+	assert.Equal(t, 1, count, "one agent_history row should have been inserted")
+}
+
+// TestModel_View_ShowsCopilotPromptWhenActive verifies that View() returns a
+// string containing the prompt UI when copilotPromptActive is true.
+func TestModel_View_ShowsCopilotPromptWhenActive(t *testing.T) {
+	model := NewModel()
+	model.copilotPromptActive = true
+
+	view := model.View()
+
+	assert.Contains(t, view, "Spawn Copilot",
+		"View should show the Copilot prompt header when active")
+	assert.Contains(t, view, "Esc cancel",
+		"View should show the cancel hint when copilot prompt is active")
+}
+

--- a/cmd/nexus/main.go
+++ b/cmd/nexus/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/data"
 )
 
 func run() error {
@@ -15,6 +17,16 @@ func run() error {
 
 	m := NewModel()
 	m.RepoPath = cwd
+
+	// Open DB best-effort: non-fatal if it fails (e.g. no write permission).
+	// When db is nil, agent runs are not logged but everything else works.
+	dbPath := data.DefaultDBPath()
+	// Ensure the parent directory exists before opening the DB.
+	_ = os.MkdirAll(filepath.Dir(dbPath), 0o755)
+	if db, err := data.NewDB(dbPath); err == nil {
+		m.db = db
+		defer db.Close()
+	}
 
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	_, err = p.Run()

--- a/internal/data/agent_history.go
+++ b/internal/data/agent_history.go
@@ -1,0 +1,36 @@
+package data
+
+import (
+	"fmt"
+	"time"
+)
+
+// AgentHistoryEntry holds the data for a single AI agent invocation to be
+// persisted in the agent_history table.
+type AgentHistoryEntry struct {
+	AgentName  string // Name of the agent, e.g. "copilot"
+	WorktreeID *int64 // Optional FK to worktrees.id; nil if not linked
+	Prompt     string // The prompt that was sent to the agent
+	ExitCode   int    // Process exit code (0 = success)
+	StartedAt  time.Time
+	EndedAt    time.Time
+}
+
+// LogAgentRun inserts an agent invocation record into the agent_history table.
+// Returns a wrapped error on failure so callers can detect "log agent run" context.
+func LogAgentRun(db *DB, entry AgentHistoryEntry) error {
+	_, err := db.Conn.Exec(
+		`INSERT INTO agent_history (agent_name, worktree_id, prompt, exit_code, started_at, ended_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		entry.AgentName,
+		entry.WorktreeID,
+		entry.Prompt,
+		entry.ExitCode,
+		entry.StartedAt,
+		entry.EndedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("log agent run: %w", err)
+	}
+	return nil
+}

--- a/internal/data/agent_history_test.go
+++ b/internal/data/agent_history_test.go
@@ -1,0 +1,126 @@
+package data_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m00nk0d3/nexus/internal/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLogAgentRun_Success verifies that LogAgentRun inserts a row into
+// agent_history and that the values can be read back from the database.
+func TestLogAgentRun_Success(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	now := time.Now().UTC().Truncate(time.Second)
+	entry := data.AgentHistoryEntry{
+		AgentName: "copilot",
+		Prompt:    "fix the null pointer dereference",
+		ExitCode:  0,
+		StartedAt: now,
+		EndedAt:   now.Add(5 * time.Second),
+	}
+
+	err = data.LogAgentRun(db, entry)
+	require.NoError(t, err, "LogAgentRun should insert without error")
+
+	// Verify the row was written and values match.
+	var gotAgent, gotPrompt string
+	var gotExit int
+	err = db.Conn.QueryRow(
+		"SELECT agent_name, prompt, exit_code FROM agent_history WHERE agent_name = ?",
+		"copilot",
+	).Scan(&gotAgent, &gotPrompt, &gotExit)
+	require.NoError(t, err, "inserted row should be queryable")
+
+	assert.Equal(t, "copilot", gotAgent)
+	assert.Equal(t, "fix the null pointer dereference", gotPrompt)
+	assert.Equal(t, 0, gotExit)
+}
+
+// TestLogAgentRun_WithWorktreeID verifies that LogAgentRun correctly stores
+// a non-nil WorktreeID foreign key.
+func TestLogAgentRun_WithWorktreeID(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Insert a worktree to satisfy the FK constraint.
+	res, err := db.Conn.Exec(
+		"INSERT INTO worktrees (path, branch) VALUES (?, ?)",
+		"/repo/feat", "feat/branch",
+	)
+	require.NoError(t, err)
+	id, err := res.LastInsertId()
+	require.NoError(t, err)
+
+	wtID := id
+	entry := data.AgentHistoryEntry{
+		AgentName:  "copilot",
+		WorktreeID: &wtID,
+		Prompt:     "add unit tests",
+		ExitCode:   0,
+		StartedAt:  time.Now(),
+		EndedAt:    time.Now(),
+	}
+
+	err = data.LogAgentRun(db, entry)
+	require.NoError(t, err)
+
+	// Verify worktree_id was stored.
+	var gotWorktreeID int64
+	err = db.Conn.QueryRow(
+		"SELECT worktree_id FROM agent_history WHERE agent_name = ?", "copilot",
+	).Scan(&gotWorktreeID)
+	require.NoError(t, err)
+	assert.Equal(t, wtID, gotWorktreeID)
+}
+
+// TestLogAgentRun_NonZeroExitCode verifies that a non-zero exit code is stored.
+func TestLogAgentRun_NonZeroExitCode(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	entry := data.AgentHistoryEntry{
+		AgentName: "copilot",
+		Prompt:    "suggest fix",
+		ExitCode:  1,
+		StartedAt: time.Now(),
+		EndedAt:   time.Now(),
+	}
+
+	require.NoError(t, data.LogAgentRun(db, entry))
+
+	var gotExit int
+	require.NoError(t, db.Conn.QueryRow(
+		"SELECT exit_code FROM agent_history WHERE agent_name = ?", "copilot",
+	).Scan(&gotExit))
+	assert.Equal(t, 1, gotExit)
+}
+
+// TestLogAgentRun_ClosedDB verifies that a closed DB returns a wrapped error
+// containing the "log agent run" context string.
+func TestLogAgentRun_ClosedDB(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	// Close immediately to make the connection invalid.
+	require.NoError(t, db.Close())
+
+	entry := data.AgentHistoryEntry{
+		AgentName: "copilot",
+		Prompt:    "test",
+		ExitCode:  0,
+		StartedAt: time.Now(),
+		EndedAt:   time.Now(),
+	}
+
+	err = data.LogAgentRun(db, entry)
+	require.Error(t, err, "LogAgentRun on a closed DB should return an error")
+	assert.Contains(t, err.Error(), "log agent run",
+		"error should include 'log agent run' context string")
+}

--- a/internal/data/db.go
+++ b/internal/data/db.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"embed"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	_ "modernc.org/sqlite"
 )
@@ -103,4 +105,15 @@ func (db *DB) applyMigration(name, content string) error {
 		return fmt.Errorf("commit migration %s: %w", name, err)
 	}
 	return nil
+}
+
+// DefaultDBPath returns the default path for the Nexus SQLite database,
+// located at ~/.nexus/nexus.db. Falls back to ./nexus.db if the home
+// directory cannot be determined.
+func DefaultDBPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "."
+	}
+	return filepath.Join(home, ".nexus", "nexus.db")
 }


### PR DESCRIPTION
Closes #16

## What Changed

Adds a GitHub Copilot launcher to the Nexus TUI worktree context panel. Pressing `c` while a worktree is selected suspends Nexus, runs `gh copilot suggest "<prompt>"` in the worktree directory, and resumes when done.

## Why Changed

Phase 3 deliverable per issue #16. The worktree-aware context passing lets Copilot receive user prompts while scoped to the correct working directory. Interaction history is persisted to SQLite for future auditing/replay.

## Changes

- **`cmd/nexus/app.go`** — `c` key handler; `buildCopilotCmd()` + `spawnCopilotCmd()`; inline textinput prompt state; `agentDoneMsg` handler that logs to DB; `gh` PATH guard; `CopilotEnabled` config flag check
- **`internal/data/agent_history.go`** — `AgentHistoryEntry` struct + `LogAgentRun(db, entry)`
- **`internal/data/db.go`** — `DefaultDBPath()` returning `~/.nexus/nexus.db`
- **`cmd/nexus/main.go`** — best-effort DB open on startup; attaches to model
- **`cmd/nexus/app_test.go`** — 9 new tests (TDD: written first, then implementation)
- **`internal/data/agent_history_test.go`** — 4 new tests for `LogAgentRun`

## Testing

- TDD: 13 tests written before implementation (Red → Green → Refactor)
- `go test ./...` — all 7 packages pass
- `go build ./...` — clean build
- Manual: press `c`, type prompt, Copilot runs, Nexus resumes, `agent_history` row inserted

## Notes

- `agent_history` table was already defined in migration `001_init_schema.sql` — no new migration needed
- DB logging is best-effort: if DB fails to open, Copilot still works, just no history
- `CopilotEnabled` defaults to `false`; must be set in `~/.nexus/config.toml` to activate
