### PR TITLE
[Phase 3] Implement Claude Code Launcher

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -103,8 +103,12 @@ type Model struct {
 	db *data.DB
 
 	// Copilot prompt state
-	copilotPromptActive bool           // true while the inline Copilot prompt is open
+	copilotPromptActive bool            // true while the inline Copilot prompt is open
 	copilotPromptInput  textinput.Model // text input for entering the Copilot prompt
+
+	// Claude prompt state
+	claudePromptActive bool            // true while the inline Claude prompt is open
+	claudePromptInput  textinput.Model // text input for entering the Claude prompt
 }
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
@@ -189,6 +193,35 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Non-key message: fall through to the main switch to handle it normally.
 	}
 
+	// While the Claude inline prompt is open, route key events to the textinput.
+	// Non-key messages fall through to the main switch below.
+	if m.claudePromptActive {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			switch keyMsg.Type {
+			case tea.KeyEnter:
+				prompt := strings.TrimSpace(m.claudePromptInput.Value())
+				if prompt == "" {
+					return m, nil
+				}
+				m.claudePromptActive = false
+				if selected, ok := m.selectedWorktree(); ok {
+					return m, m.spawnClaudeCmd(selected.Path, prompt)
+				}
+				m.claudePromptInput.SetValue("")
+				return m, nil
+			case tea.KeyEsc:
+				m.claudePromptActive = false
+				m.claudePromptInput.SetValue("")
+				return m, nil
+			default:
+				var cmd tea.Cmd
+				m.claudePromptInput, cmd = m.claudePromptInput.Update(keyMsg)
+				return m, cmd
+			}
+		}
+		// Non-key message: fall through to the main switch to handle it normally.
+	}
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.Type {
@@ -256,6 +289,21 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return m, focusCmd
 					}
 				}
+			case "a", "A":
+				if m.view == viewWorktrees && m.Config.AIAgents.ClaudeEnabled {
+					if _, ok := m.selectedWorktree(); ok {
+						if _, err := resolveClaudeBinary(m.Config); err != nil {
+							m.Error = fmt.Sprintf("claude binary not found: %v", err)
+							return m, nil
+						}
+						ti := textinput.New()
+						ti.Placeholder = "Enter Claude prompt…"
+						focusCmd := ti.Focus()
+						m.claudePromptInput = ti
+						m.claudePromptActive = true
+						return m, focusCmd
+					}
+				}
 			}
 		}
 
@@ -296,6 +344,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case agentDoneMsg:
 		m.copilotPromptActive = false
 		m.copilotPromptInput.SetValue("")
+		m.claudePromptActive = false
+		m.claudePromptInput.SetValue("")
 		if m.db != nil {
 			entry := data.AgentHistoryEntry{
 				AgentName: msg.agentName,
@@ -354,6 +404,16 @@ func (m *Model) View() string {
 		prompt := theme.RenderBox(
 			"Spawn Copilot",
 			fmt.Sprintf("> %s\n\nEnter confirm  •  Esc cancel", m.copilotPromptInput.View()),
+		)
+		return fmt.Sprintf("%s\n\n%s", prompt, baseView)
+	}
+
+	// When the Claude inline prompt is active, overlay it on top of the normal view.
+	if m.claudePromptActive {
+		theme := styles.NewTheme(styles.Themes[m.themeIdx])
+		prompt := theme.RenderBox(
+			"Spawn Claude Code",
+			fmt.Sprintf("> %s\n\nEnter confirm  •  Esc cancel", m.claudePromptInput.View()),
 		)
 		return fmt.Sprintf("%s\n\n%s", prompt, baseView)
 	}
@@ -462,6 +522,51 @@ func (m *Model) spawnCopilotCmd(worktreePath, prompt string) tea.Cmd {
 		}
 		return agentDoneMsg{
 			agentName: "copilot",
+			prompt:    prompt,
+			exitCode:  exitCode,
+			startedAt: startedAt,
+		}
+	})
+}
+
+// resolveClaudeBinary returns the resolved path for the Claude binary.
+// It reads cfg.AIAgents.ClaudeBinary, defaulting to "claude", then
+// uses exec.LookPath to verify the binary is on the PATH.
+func resolveClaudeBinary(cfg *domain.Config) (string, error) {
+	bin := cfg.AIAgents.ClaudeBinary
+	if bin == "" {
+		bin = "claude"
+	}
+	return exec.LookPath(bin)
+}
+
+// buildClaudeCmd constructs the exec.Cmd for running the Claude CLI with the
+// given prompt in the specified worktree directory.
+// It is extracted as a top-level function to keep it unit-testable.
+func buildClaudeCmd(worktreePath, prompt, binaryPath string) *exec.Cmd {
+	cmd := exec.Command(binaryPath, prompt)
+	cmd.Dir = worktreePath
+	return cmd
+}
+
+// spawnClaudeCmd returns a Cmd that runs the Claude binary in the worktree
+// directory and dispatches agentDoneMsg when the process exits.
+func (m *Model) spawnClaudeCmd(worktreePath, prompt string) tea.Cmd {
+	binaryPath, err := resolveClaudeBinary(m.Config)
+	if err != nil {
+		m.Error = fmt.Sprintf("claude binary not found: %v", err)
+		return nil
+	}
+	startedAt := time.Now()
+	cmd := buildClaudeCmd(worktreePath, prompt, binaryPath)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg {
+		exitCode := 0
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+		return agentDoneMsg{
+			agentName: "claude",
 			prompt:    prompt,
 			exitCode:  exitCode,
 			startedAt: startedAt,

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -1453,3 +1453,267 @@ func TestModel_View_ShowsCopilotPromptWhenActive(t *testing.T) {
 		"View should show the cancel hint when copilot prompt is active")
 }
 
+// ---------------------------------------------------------------------------
+// Phase 3: Claude Code launcher tests
+// ---------------------------------------------------------------------------
+
+// TestSpawnClaudeCmd_UsesCustomBinaryPath verifies that buildClaudeCmd
+// places the custom binary path as the executable and the prompt as arg.
+func TestSpawnClaudeCmd_UsesCustomBinaryPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		worktreePath string
+		prompt       string
+		binaryPath   string
+		wantArgs     []string
+		wantDir      string
+	}{
+		{
+			name:         "uses default claude binary",
+			worktreePath: "/tmp/my-worktree",
+			prompt:       "refactor the handler",
+			binaryPath:   "claude",
+			wantArgs:     []string{"claude", "refactor the handler"},
+			wantDir:      "/tmp/my-worktree",
+		},
+		{
+			name:         "uses custom binary path",
+			worktreePath: "/repo/feat-branch",
+			prompt:       "write unit tests",
+			binaryPath:   "/usr/local/bin/claude",
+			wantArgs:     []string{"/usr/local/bin/claude", "write unit tests"},
+			wantDir:      "/repo/feat-branch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := buildClaudeCmd(tt.worktreePath, tt.prompt, tt.binaryPath)
+			require.NotNil(t, cmd)
+			assert.Equal(t, tt.wantArgs, cmd.Args)
+			assert.Equal(t, tt.wantDir, cmd.Dir)
+		})
+	}
+}
+
+// TestSpawnClaudeCmd_BinaryNotFound_ReturnsError verifies that resolveClaudeBinary
+// returns an error when the binary is not found on PATH.
+func TestSpawnClaudeCmd_BinaryNotFound_ReturnsError(t *testing.T) {
+	cfg := domain.DefaultConfig()
+	cfg.AIAgents.ClaudeBinary = "definitely-not-a-real-binary-xyz-12345"
+
+	_, err := resolveClaudeBinary(cfg)
+	require.Error(t, err, "resolveClaudeBinary should return error for missing binary")
+}
+
+// TestResolveClaudeBinary_DefaultsToClaudeBinary verifies that an empty ClaudeBinary
+// config field falls back to "claude" (which may or may not be on PATH).
+func TestResolveClaudeBinary_DefaultsToClaudeBinary(t *testing.T) {
+	cfg := domain.DefaultConfig()
+	cfg.AIAgents.ClaudeBinary = ""
+
+	// We cannot assume "claude" is installed, so we only check that the error
+	// message (if any) mentions "claude" rather than an empty string.
+	path, err := resolveClaudeBinary(cfg)
+	if err != nil {
+		assert.Contains(t, err.Error(), "claude",
+			"error for missing default binary should mention 'claude'")
+	} else {
+		assert.NotEmpty(t, path, "resolved path should be non-empty when claude is on PATH")
+	}
+}
+
+// TestModel_A_Key_TriggersClaude verifies [a] key activates the Claude prompt
+// when ClaudeEnabled=true and a worktree is selected (if binary exists),
+// and is a no-op when disabled or no worktree exists.
+func TestModel_A_Key_TriggersClaude(t *testing.T) {
+	tests := []struct {
+		name             string
+		claudeEnabled    bool
+		hasWorktree      bool
+		wantPromptActive bool
+	}{
+		{
+			name:             "a key with disabled config does nothing",
+			claudeEnabled:    false,
+			hasWorktree:      true,
+			wantPromptActive: false,
+		},
+		{
+			name:             "a key with no worktree does nothing",
+			claudeEnabled:    true,
+			hasWorktree:      false,
+			wantPromptActive: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			model.Config.AIAgents.ClaudeEnabled = tt.claudeEnabled
+			model.view = viewWorktrees
+			if tt.hasWorktree {
+				model.Worktrees = []domain.Worktree{
+					{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"},
+				}
+			}
+
+			updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+			updatedModel, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.False(t, updatedModel.claudePromptActive,
+				"claudePromptActive should be false")
+		})
+	}
+
+	// Happy path: only run if claude is actually on PATH.
+	t.Run("a key with enabled config and selected worktree activates prompt", func(t *testing.T) {
+		if _, err := exec.LookPath("claude"); err != nil {
+			t.Skip("claude not on PATH; skipping test that requires claude binary")
+		}
+
+		model := NewModel()
+		model.Config.AIAgents.ClaudeEnabled = true
+		model.view = viewWorktrees
+		model.Worktrees = []domain.Worktree{
+			{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"},
+		}
+
+		updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+		updatedModel, ok := updated.(*Model)
+		require.True(t, ok)
+
+		assert.True(t, updatedModel.claudePromptActive,
+			"claudePromptActive should be true when claude is on PATH")
+		assert.NotNil(t, cmd, "textinput.Focus() should return a non-nil cmd")
+	})
+
+	t.Run("a key in issues view does nothing even when enabled", func(t *testing.T) {
+		model := NewModel()
+		model.Config.AIAgents.ClaudeEnabled = true
+		model.view = viewIssues
+		model.Worktrees = []domain.Worktree{
+			{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"},
+		}
+
+		updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+		updatedModel, ok := updated.(*Model)
+		require.True(t, ok)
+
+		assert.False(t, updatedModel.claudePromptActive,
+			"claudePromptActive should stay false when not in worktrees view")
+	})
+}
+
+// TestModel_ClaudePrompt_EscCancels verifies that pressing Esc while the
+// Claude prompt is active clears claudePromptActive without spawning.
+func TestModel_ClaudePrompt_EscCancels(t *testing.T) {
+	model := NewModel()
+	model.claudePromptActive = true
+	model.Worktrees = []domain.Worktree{{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"}}
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.False(t, updatedModel.claudePromptActive,
+		"Esc should deactivate the claude prompt")
+}
+
+// TestModel_ClaudePrompt_EscClearsInputValue verifies that Esc also resets
+// the Claude text input value so it starts fresh on the next invocation.
+func TestModel_ClaudePrompt_EscClearsInputValue(t *testing.T) {
+	model := NewModel()
+	model.claudePromptActive = true
+	model.claudePromptInput.SetValue("some typed text")
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Equal(t, "", updatedModel.claudePromptInput.Value(),
+		"Esc should clear the claude prompt input value")
+}
+
+// TestModel_ClaudePrompt_EnterWithEmptyPrompt_DoesNotSpawn verifies that
+// pressing Enter with an empty (or whitespace-only) prompt is a no-op.
+func TestModel_ClaudePrompt_EnterWithEmptyPrompt_DoesNotSpawn(t *testing.T) {
+	model := NewModel()
+	model.claudePromptActive = true
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.True(t, updatedModel.claudePromptActive,
+		"empty-prompt Enter should leave claudePromptActive true")
+	assert.Nil(t, cmd, "empty-prompt Enter should not return a spawn Cmd")
+}
+
+// TestModel_AgentDoneMsg_ClearsClaudePrompt verifies that receiving agentDoneMsg
+// clears the claude prompt state regardless of exit code.
+func TestModel_AgentDoneMsg_ClearsClaudePrompt(t *testing.T) {
+	tests := []struct {
+		name     string
+		exitCode int
+	}{
+		{name: "exit code 0 clears claude prompt", exitCode: 0},
+		{name: "non-zero exit code still clears claude prompt", exitCode: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			model.claudePromptActive = true
+
+			updated, _ := model.Update(agentDoneMsg{
+				agentName: "claude",
+				prompt:    "test prompt",
+				exitCode:  tt.exitCode,
+			})
+			updatedModel, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.False(t, updatedModel.claudePromptActive,
+				"agentDoneMsg should clear claudePromptActive")
+		})
+	}
+}
+
+// TestModel_View_ShowsClaudePromptWhenActive verifies that View() returns a
+// string containing the Claude prompt UI when claudePromptActive is true.
+func TestModel_View_ShowsClaudePromptWhenActive(t *testing.T) {
+	model := NewModel()
+	model.claudePromptActive = true
+
+	view := model.View()
+
+	assert.Contains(t, view, "Spawn Claude Code",
+		"View should show the Claude prompt header when active")
+	assert.Contains(t, view, "Esc cancel",
+		"View should show the cancel hint when claude prompt is active")
+}
+
+// TestModel_A_Key_BinaryNotFound_SetsError verifies that pressing [a] when
+// the claude binary is not resolvable sets a user-visible error on the model.
+func TestModel_A_Key_BinaryNotFound_SetsError(t *testing.T) {
+	model := NewModel()
+	model.Config.AIAgents.ClaudeEnabled = true
+	model.Config.AIAgents.ClaudeBinary = "definitely-not-a-real-binary-xyz-12345"
+	model.view = viewWorktrees
+	model.Worktrees = []domain.Worktree{
+		{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"},
+	}
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.False(t, updatedModel.claudePromptActive,
+		"prompt should not open when binary is not found")
+	assert.Nil(t, cmd, "no cmd should be returned when binary is missing")
+	assert.Contains(t, updatedModel.Error, "claude binary not found",
+		"error should mention the missing binary")
+}
+


### PR DESCRIPTION
﻿Closes #17

## What Changed
Implements the Claude Code CLI launcher from the context panel. Pressing `[a]` opens an inline prompt input — on submit, Nexus suspends and runs the `claude` binary with the worktree path as the working directory.

## Why Changed
Phase 3 requires all three agent launchers in the context panel: Shell (`s`), Copilot (`c`), and Claude (`a`). This adds the Claude launcher following the exact same tea.ExecProcess pattern established in issues #6 and #16.

## What's Included
- resolveClaudeBinary(cfg) resolves binary via exec.LookPath, defaults to "claude", shows error in status bar if not found
- buildClaudeCmd(worktreePath, prompt, binaryPath) constructs exec.Cmd (extracted for testability)
- spawnClaudeCmd() runs via tea.ExecProcess, dispatches agentDoneMsg{agentName: "claude"}
- [a] key handler: respects Config.AIAgents.ClaudeEnabled, opens inline prompt (same UX as [c])
- agentDoneMsg now clears both copilot and claude prompt state
- View() overlays "Spawn Claude Code" box when claudePromptActive is true

## Testing
- TDD: 10 new test cases covering binary resolution, prompt lifecycle, error paths, and view rendering
- go test ./cmd/nexus/... passes
- Binary-on-PATH happy path is automatically skipped when claude is not installed

## Notes
Future issue #19 will add richer context (git diff, file list) via env vars or temp file.
