### PR TITLE
[Phase 3] Implement Context Builder (Git State, Diff, Log for Agents)

### DIFF
--- a/internal/data/context_snapshot.go
+++ b/internal/data/context_snapshot.go
@@ -1,0 +1,26 @@
+package data
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+)
+
+// SaveContextSnapshot persists a WorktreeContext to the context_snapshots table
+// before an agent launch. Returns a wrapped error on failure.
+func SaveContextSnapshot(db *DB, worktreeID int64, ctx *domain.WorktreeContext) error {
+	fileList := strings.Join(ctx.ChangedFiles, "\n")
+	_, err := db.Conn.Exec(
+		`INSERT INTO context_snapshots (worktree_id, git_status, file_list, recent_log)
+		 VALUES (?, ?, ?, ?)`,
+		worktreeID,
+		ctx.GitStatus,
+		fileList,
+		ctx.RecentLog,
+	)
+	if err != nil {
+		return fmt.Errorf("save context snapshot: %w", err)
+	}
+	return nil
+}

--- a/internal/data/context_snapshot.go
+++ b/internal/data/context_snapshot.go
@@ -12,12 +12,13 @@ import (
 func SaveContextSnapshot(db *DB, worktreeID int64, ctx *domain.WorktreeContext) error {
 	fileList := strings.Join(ctx.ChangedFiles, "\n")
 	_, err := db.Conn.Exec(
-		`INSERT INTO context_snapshots (worktree_id, git_status, file_list, recent_log)
-		 VALUES (?, ?, ?, ?)`,
+		`INSERT INTO context_snapshots (worktree_id, git_status, file_list, recent_log, diff_summary)
+		 VALUES (?, ?, ?, ?, ?)`,
 		worktreeID,
 		ctx.GitStatus,
 		fileList,
 		ctx.RecentLog,
+		ctx.DiffSummary,
 	)
 	if err != nil {
 		return fmt.Errorf("save context snapshot: %w", err)

--- a/internal/data/context_snapshot_test.go
+++ b/internal/data/context_snapshot_test.go
@@ -1,0 +1,110 @@
+package data_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/m00nk0d3/nexus/internal/data"
+	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func insertTestWorktree(t *testing.T, db *data.DB, path, branch string) int64 {
+	t.Helper()
+	res, err := db.Conn.Exec(
+		"INSERT INTO worktrees (path, branch) VALUES (?, ?)", path, branch,
+	)
+	require.NoError(t, err)
+	id, err := res.LastInsertId()
+	require.NoError(t, err)
+	return id
+}
+
+func TestSaveContextSnapshot_PopulatesAllFields(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	wtID := insertTestWorktree(t, db, "/repo/feature", "feat/issue-19")
+
+	ctx := &domain.WorktreeContext{
+		Path:         "/repo/feature",
+		Branch:       "feat/issue-19",
+		GitStatus:    "M internal/exec/git.go",
+		RecentLog:    "abc1234 feat: add context builder",
+		ChangedFiles: []string{"internal/exec/git.go", "internal/domain/context.go"},
+		DiffSummary:  "1 file changed, 42 insertions(+)",
+	}
+
+	err = data.SaveContextSnapshot(db, wtID, ctx)
+	require.NoError(t, err, "SaveContextSnapshot should insert without error")
+
+	var gotStatus, gotFileList, gotLog string
+	err = db.Conn.QueryRow(
+		"SELECT git_status, file_list, recent_log FROM context_snapshots WHERE worktree_id = ?", wtID,
+	).Scan(&gotStatus, &gotFileList, &gotLog)
+	require.NoError(t, err)
+
+	assert.Equal(t, ctx.GitStatus, gotStatus)
+	assert.Equal(t, strings.Join(ctx.ChangedFiles, "\n"), gotFileList)
+	assert.Equal(t, ctx.RecentLog, gotLog)
+}
+
+func TestSaveContextSnapshot_EmptyChangedFiles(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	wtID := insertTestWorktree(t, db, "/repo/clean", "main")
+
+	ctx := &domain.WorktreeContext{
+		Path:         "/repo/clean",
+		GitStatus:    "",
+		RecentLog:    "abc1234 initial commit",
+		ChangedFiles: []string{},
+	}
+
+	err = data.SaveContextSnapshot(db, wtID, ctx)
+	require.NoError(t, err)
+
+	var gotFileList string
+	err = db.Conn.QueryRow(
+		"SELECT file_list FROM context_snapshots WHERE worktree_id = ?", wtID,
+	).Scan(&gotFileList)
+	require.NoError(t, err)
+	assert.Equal(t, "", gotFileList)
+}
+
+func TestSaveContextSnapshot_MultipleSnapshots(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	wtID := insertTestWorktree(t, db, "/repo/feature", "feat/ctx")
+
+	ctx1 := &domain.WorktreeContext{GitStatus: "M file1.go", ChangedFiles: []string{}}
+	ctx2 := &domain.WorktreeContext{GitStatus: "M file2.go", ChangedFiles: []string{}}
+
+	require.NoError(t, data.SaveContextSnapshot(db, wtID, ctx1))
+	require.NoError(t, data.SaveContextSnapshot(db, wtID, ctx2))
+
+	var count int
+	err = db.Conn.QueryRow(
+		"SELECT COUNT(*) FROM context_snapshots WHERE worktree_id = ?", wtID,
+	).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestSaveContextSnapshot_ClosedDB_ReturnsError(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	ctx := &domain.WorktreeContext{ChangedFiles: []string{}}
+	err = data.SaveContextSnapshot(db, 1, ctx)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "save context snapshot")
+}

--- a/internal/data/context_snapshot_test.go
+++ b/internal/data/context_snapshot_test.go
@@ -40,15 +40,16 @@ func TestSaveContextSnapshot_PopulatesAllFields(t *testing.T) {
 	err = data.SaveContextSnapshot(db, wtID, ctx)
 	require.NoError(t, err, "SaveContextSnapshot should insert without error")
 
-	var gotStatus, gotFileList, gotLog string
+	var gotStatus, gotFileList, gotLog, gotDiffSummary string
 	err = db.Conn.QueryRow(
-		"SELECT git_status, file_list, recent_log FROM context_snapshots WHERE worktree_id = ?", wtID,
-	).Scan(&gotStatus, &gotFileList, &gotLog)
+		"SELECT git_status, file_list, recent_log, diff_summary FROM context_snapshots WHERE worktree_id = ?", wtID,
+	).Scan(&gotStatus, &gotFileList, &gotLog, &gotDiffSummary)
 	require.NoError(t, err)
 
 	assert.Equal(t, ctx.GitStatus, gotStatus)
 	assert.Equal(t, strings.Join(ctx.ChangedFiles, "\n"), gotFileList)
 	assert.Equal(t, ctx.RecentLog, gotLog)
+	assert.Equal(t, ctx.DiffSummary, gotDiffSummary)
 }
 
 func TestSaveContextSnapshot_EmptyChangedFiles(t *testing.T) {

--- a/internal/data/db_test.go
+++ b/internal/data/db_test.go
@@ -229,5 +229,5 @@ func TestNewDB_SchemaVersionsTracked(t *testing.T) {
 	}
 	require.NoError(t, rows.Err())
 
-	assert.Equal(t, []string{"001_init_schema.sql"}, filenames)
+	assert.Equal(t, []string{"001_init_schema.sql", "002_add_diff_summary_to_context_snapshots.sql"}, filenames)
 }

--- a/internal/data/migrations/002_add_diff_summary_to_context_snapshots.sql
+++ b/internal/data/migrations/002_add_diff_summary_to_context_snapshots.sql
@@ -1,0 +1,2 @@
+-- context_snapshots: add diff_summary column to persist git diff --stat output
+ALTER TABLE context_snapshots ADD COLUMN diff_summary TEXT;

--- a/internal/domain/context.go
+++ b/internal/domain/context.go
@@ -1,0 +1,11 @@
+package domain
+
+// WorktreeContext holds the current git state of a worktree for passing to AI agents.
+type WorktreeContext struct {
+	Path         string
+	Branch       string
+	GitStatus    string   // output of git status --short
+	RecentLog    string   // last 10 commits: sha + message
+	ChangedFiles []string // from git diff --name-only HEAD
+	DiffSummary  string   // git diff --stat HEAD
+}

--- a/internal/exec/context_builder.go
+++ b/internal/exec/context_builder.go
@@ -1,0 +1,41 @@
+package exec
+
+import (
+	"fmt"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+)
+
+const defaultLogCount = 10
+
+// BuildContext collects the current git state of the worktree at path and
+// returns a populated WorktreeContext ready to pass to AI agents.
+func BuildContext(gitCmd *GitCommand, path string) (*domain.WorktreeContext, error) {
+	status, err := gitCmd.GitStatus(path)
+	if err != nil {
+		return nil, fmt.Errorf("build context: %w", err)
+	}
+
+	log, err := gitCmd.GitLog(path, defaultLogCount)
+	if err != nil {
+		return nil, fmt.Errorf("build context: %w", err)
+	}
+
+	changedFiles, err := gitCmd.GitDiffNameOnly(path)
+	if err != nil {
+		return nil, fmt.Errorf("build context: %w", err)
+	}
+
+	diffStat, err := gitCmd.GitDiffStat(path)
+	if err != nil {
+		return nil, fmt.Errorf("build context: %w", err)
+	}
+
+	return &domain.WorktreeContext{
+		Path:         path,
+		GitStatus:    status,
+		RecentLog:    log,
+		ChangedFiles: changedFiles,
+		DiffSummary:  diffStat,
+	}, nil
+}

--- a/internal/exec/context_builder.go
+++ b/internal/exec/context_builder.go
@@ -11,6 +11,11 @@ const defaultLogCount = 10
 // BuildContext collects the current git state of the worktree at path and
 // returns a populated WorktreeContext ready to pass to AI agents.
 func BuildContext(gitCmd *GitCommand, path string) (*domain.WorktreeContext, error) {
+	branch, err := gitCmd.GitBranch(path)
+	if err != nil {
+		return nil, fmt.Errorf("build context: %w", err)
+	}
+
 	status, err := gitCmd.GitStatus(path)
 	if err != nil {
 		return nil, fmt.Errorf("build context: %w", err)
@@ -33,6 +38,7 @@ func BuildContext(gitCmd *GitCommand, path string) (*domain.WorktreeContext, err
 
 	return &domain.WorktreeContext{
 		Path:         path,
+		Branch:       branch,
 		GitStatus:    status,
 		RecentLog:    log,
 		ChangedFiles: changedFiles,

--- a/internal/exec/context_builder_test.go
+++ b/internal/exec/context_builder_test.go
@@ -1,0 +1,121 @@
+package exec
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildContext_PopulatesAllFields(t *testing.T) {
+	const worktreePath = "/repo/feature"
+
+	runner := func(repoPath string, args ...string) (string, error) {
+		if len(args) == 0 {
+			return "", nil
+		}
+		switch args[0] {
+		case "status":
+			return "M internal/exec/git.go\n?? new_file.go\n", nil
+		case "log":
+			return "abc1234 feat: add context builder\ndef5678 fix: handle empty status\n", nil
+		case "diff":
+			if len(args) >= 2 && args[1] == "--name-only" {
+				return "internal/exec/git.go\ninternal/domain/context.go\n", nil
+			}
+			return " internal/exec/git.go | 42 ++++++\n 1 file changed, 42 insertions(+)\n", nil
+		}
+		return "", nil
+	}
+
+	cmd := NewGitCommandWithRunner("/repo/main", runner)
+	ctx, err := BuildContext(cmd, worktreePath)
+
+	require.NoError(t, err)
+	assert.Equal(t, worktreePath, ctx.Path)
+	assert.Equal(t, "M internal/exec/git.go\n?? new_file.go", ctx.GitStatus)
+	assert.Equal(t, "abc1234 feat: add context builder\ndef5678 fix: handle empty status", ctx.RecentLog)
+	assert.Equal(t, []string{"internal/exec/git.go", "internal/domain/context.go"}, ctx.ChangedFiles)
+	assert.Equal(t, "internal/exec/git.go | 42 ++++++\n 1 file changed, 42 insertions(+)", ctx.DiffSummary)
+}
+
+func TestBuildContext_EmptyRepo_ReturnsEmptyStatus(t *testing.T) {
+	runner := func(repoPath string, args ...string) (string, error) {
+		return "", nil
+	}
+
+	cmd := NewGitCommandWithRunner("/repo/main", runner)
+	ctx, err := BuildContext(cmd, "/repo/empty")
+
+	require.NoError(t, err)
+	assert.Equal(t, "/repo/empty", ctx.Path)
+	assert.Equal(t, "", ctx.GitStatus)
+	assert.Equal(t, "", ctx.RecentLog)
+	assert.Equal(t, []string{}, ctx.ChangedFiles)
+	assert.Equal(t, "", ctx.DiffSummary)
+}
+
+func TestBuildContext_GitStatusError_ReturnsError(t *testing.T) {
+	runner := func(repoPath string, args ...string) (string, error) {
+		if args[0] == "status" {
+			return "", errors.New("permission denied")
+		}
+		return "", nil
+	}
+
+	cmd := NewGitCommandWithRunner("/repo/main", runner)
+	_, err := BuildContext(cmd, "/repo/feature")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build context")
+	assert.Contains(t, err.Error(), "git status")
+}
+
+func TestBuildContext_GitLogError_ReturnsError(t *testing.T) {
+	runner := func(repoPath string, args ...string) (string, error) {
+		if args[0] == "log" {
+			return "", errors.New("not a git repo")
+		}
+		return "", nil
+	}
+
+	cmd := NewGitCommandWithRunner("/repo/main", runner)
+	_, err := BuildContext(cmd, "/repo/feature")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build context")
+	assert.Contains(t, err.Error(), "git log")
+}
+
+func TestBuildContext_GitDiffNameOnlyError_ReturnsError(t *testing.T) {
+	runner := func(repoPath string, args ...string) (string, error) {
+		if args[0] == "diff" && len(args) >= 2 && args[1] == "--name-only" {
+			return "", errors.New("fatal: ambiguous argument")
+		}
+		return "", nil
+	}
+
+	cmd := NewGitCommandWithRunner("/repo/main", runner)
+	_, err := BuildContext(cmd, "/repo/feature")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build context")
+	assert.Contains(t, err.Error(), "git diff name-only")
+}
+
+func TestBuildContext_GitDiffStatError_ReturnsError(t *testing.T) {
+	runner := func(repoPath string, args ...string) (string, error) {
+		if args[0] == "diff" && len(args) >= 2 && args[1] == "--stat" {
+			return "", errors.New("fatal: bad HEAD")
+		}
+		return "", nil
+	}
+
+	cmd := NewGitCommandWithRunner("/repo/main", runner)
+	_, err := BuildContext(cmd, "/repo/feature")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build context")
+	assert.Contains(t, err.Error(), "git diff stat")
+}

--- a/internal/exec/context_builder_test.go
+++ b/internal/exec/context_builder_test.go
@@ -16,6 +16,8 @@ func TestBuildContext_PopulatesAllFields(t *testing.T) {
 			return "", nil
 		}
 		switch args[0] {
+		case "rev-parse":
+			return "feat/issue-19\n", nil
 		case "status":
 			return "M internal/exec/git.go\n?? new_file.go\n", nil
 		case "log":
@@ -34,6 +36,7 @@ func TestBuildContext_PopulatesAllFields(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, worktreePath, ctx.Path)
+	assert.Equal(t, "feat/issue-19", ctx.Branch)
 	assert.Equal(t, "M internal/exec/git.go\n?? new_file.go", ctx.GitStatus)
 	assert.Equal(t, "abc1234 feat: add context builder\ndef5678 fix: handle empty status", ctx.RecentLog)
 	assert.Equal(t, []string{"internal/exec/git.go", "internal/domain/context.go"}, ctx.ChangedFiles)
@@ -50,10 +53,27 @@ func TestBuildContext_EmptyRepo_ReturnsEmptyStatus(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "/repo/empty", ctx.Path)
+	assert.Equal(t, "", ctx.Branch)
 	assert.Equal(t, "", ctx.GitStatus)
 	assert.Equal(t, "", ctx.RecentLog)
 	assert.Equal(t, []string{}, ctx.ChangedFiles)
 	assert.Equal(t, "", ctx.DiffSummary)
+}
+
+func TestBuildContext_GitBranchError_ReturnsError(t *testing.T) {
+	runner := func(repoPath string, args ...string) (string, error) {
+		if args[0] == "rev-parse" {
+			return "", errors.New("not a git repo")
+		}
+		return "", nil
+	}
+
+	cmd := NewGitCommandWithRunner("/repo/main", runner)
+	_, err := BuildContext(cmd, "/repo/feature")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "build context")
+	assert.Contains(t, err.Error(), "git branch")
 }
 
 func TestBuildContext_GitStatusError_ReturnsError(t *testing.T) {

--- a/internal/exec/git.go
+++ b/internal/exec/git.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"fmt"
 	osexec "os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/m00nk0d3/nexus/internal/domain"
@@ -113,6 +114,46 @@ func (g *GitCommand) LockWorktree(path, reason string) error {
 // UnlockWorktree unlocks the worktree at path.
 func (g *GitCommand) UnlockWorktree(path string) error {
 	return g.runNoOutput("unlock worktree", "worktree", "unlock", path)
+}
+
+// GitStatus returns the short git status for the worktree at path.
+func (g *GitCommand) GitStatus(path string) (string, error) {
+	output, err := g.runner(path, "status", "--short")
+	if err != nil {
+		return "", fmt.Errorf("git status: %w", err)
+	}
+	return strings.TrimSpace(output), nil
+}
+
+// GitLog returns the last n commits for the worktree at path in oneline format.
+func (g *GitCommand) GitLog(path string, n int) (string, error) {
+	output, err := g.runner(path, "log", "--oneline", "-n", strconv.Itoa(n))
+	if err != nil {
+		return "", fmt.Errorf("git log: %w", err)
+	}
+	return strings.TrimSpace(output), nil
+}
+
+// GitDiffNameOnly returns the list of changed files for the worktree at path.
+func (g *GitCommand) GitDiffNameOnly(path string) ([]string, error) {
+	output, err := g.runner(path, "diff", "--name-only", "HEAD")
+	if err != nil {
+		return nil, fmt.Errorf("git diff name-only: %w", err)
+	}
+	trimmed := strings.TrimSpace(output)
+	if trimmed == "" {
+		return []string{}, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}
+
+// GitDiffStat returns the diff stat for the worktree at path.
+func (g *GitCommand) GitDiffStat(path string) (string, error) {
+	output, err := g.runner(path, "diff", "--stat", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("git diff stat: %w", err)
+	}
+	return strings.TrimSpace(output), nil
 }
 
 func (g *GitCommand) run(op string, args ...string) (string, error) {

--- a/internal/exec/git.go
+++ b/internal/exec/git.go
@@ -156,6 +156,15 @@ func (g *GitCommand) GitDiffStat(path string) (string, error) {
 	return strings.TrimSpace(output), nil
 }
 
+// GitBranch returns the current branch name for the worktree at path.
+func (g *GitCommand) GitBranch(path string) (string, error) {
+	output, err := g.runner(path, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("git branch: %w", err)
+	}
+	return strings.TrimSpace(output), nil
+}
+
 func (g *GitCommand) run(op string, args ...string) (string, error) {
 	output, err := g.runner(g.repoPath, args...)
 	if err != nil {

--- a/internal/exec/git_test.go
+++ b/internal/exec/git_test.go
@@ -653,6 +653,270 @@ func TestGitCommand_UnlockWorktree(t *testing.T) {
 	}
 }
 
+func TestGitCommand_GitStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoPath  string
+		path      string
+		runOutput string
+		runErr    error
+		wantArgs  []string
+		wantOut   string
+		expectErr string
+	}{
+		{
+			name:      "returns trimmed short status",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			runOutput: " M internal/exec/git.go\n?? new_file.go\n",
+			wantArgs:  []string{"status", "--short"},
+			wantOut:   "M internal/exec/git.go\n?? new_file.go",
+		},
+		{
+			name:     "returns empty string for clean worktree",
+			repoPath: "/repo/main",
+			path:     "/repo/feature",
+			wantArgs: []string{"status", "--short"},
+			wantOut:  "",
+		},
+		{
+			name:      "returns runner error with context",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			runErr:    errors.New("permission denied"),
+			wantArgs:  []string{"status", "--short"},
+			expectErr: "git status: permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledPath string
+			var calledArgs []string
+
+			runner := func(repoPath string, args ...string) (string, error) {
+				calledPath = repoPath
+				calledArgs = append([]string{}, args...)
+				return tt.runOutput, tt.runErr
+			}
+
+			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
+			out, err := cmd.GitStatus(tt.path)
+
+			assert.Equal(t, tt.path, calledPath)
+			assert.Equal(t, tt.wantArgs, calledArgs)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOut, out)
+		})
+	}
+}
+
+func TestGitCommand_GitLog(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoPath  string
+		path      string
+		n         int
+		runOutput string
+		runErr    error
+		wantArgs  []string
+		wantOut   string
+		expectErr string
+	}{
+		{
+			name:      "returns oneline log with n commits",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			n:         10,
+			runOutput: "abc1234 feat: add context builder\ndef5678 fix: handle empty repo\n",
+			wantArgs:  []string{"log", "--oneline", "-n", "10"},
+			wantOut:   "abc1234 feat: add context builder\ndef5678 fix: handle empty repo",
+		},
+		{
+			name:     "passes correct n to git log",
+			repoPath: "/repo/main",
+			path:     "/repo/feature",
+			n:        5,
+			wantArgs: []string{"log", "--oneline", "-n", "5"},
+		},
+		{
+			name:      "returns runner error with context",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			n:         10,
+			runErr:    errors.New("not a git repository"),
+			wantArgs:  []string{"log", "--oneline", "-n", "10"},
+			expectErr: "git log: not a git repository",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledPath string
+			var calledArgs []string
+
+			runner := func(repoPath string, args ...string) (string, error) {
+				calledPath = repoPath
+				calledArgs = append([]string{}, args...)
+				return tt.runOutput, tt.runErr
+			}
+
+			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
+			out, err := cmd.GitLog(tt.path, tt.n)
+
+			assert.Equal(t, tt.path, calledPath)
+			assert.Equal(t, tt.wantArgs, calledArgs)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOut, out)
+		})
+	}
+}
+
+func TestGitCommand_GitDiffNameOnly(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoPath  string
+		path      string
+		runOutput string
+		runErr    error
+		wantArgs  []string
+		wantFiles []string
+		expectErr string
+	}{
+		{
+			name:      "returns list of changed files",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			runOutput: "internal/exec/git.go\ninternal/domain/context.go\n",
+			wantArgs:  []string{"diff", "--name-only", "HEAD"},
+			wantFiles: []string{"internal/exec/git.go", "internal/domain/context.go"},
+		},
+		{
+			name:      "returns empty slice when no files changed",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			runOutput: "",
+			wantArgs:  []string{"diff", "--name-only", "HEAD"},
+			wantFiles: []string{},
+		},
+		{
+			name:      "returns runner error with context",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			runErr:    errors.New("fatal: not a git repository"),
+			wantArgs:  []string{"diff", "--name-only", "HEAD"},
+			expectErr: "git diff name-only: fatal: not a git repository",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledPath string
+			var calledArgs []string
+
+			runner := func(repoPath string, args ...string) (string, error) {
+				calledPath = repoPath
+				calledArgs = append([]string{}, args...)
+				return tt.runOutput, tt.runErr
+			}
+
+			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
+			files, err := cmd.GitDiffNameOnly(tt.path)
+
+			assert.Equal(t, tt.path, calledPath)
+			assert.Equal(t, tt.wantArgs, calledArgs)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFiles, files)
+		})
+	}
+}
+
+func TestGitCommand_GitDiffStat(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoPath  string
+		path      string
+		runOutput string
+		runErr    error
+		wantArgs  []string
+		wantOut   string
+		expectErr string
+	}{
+		{
+			name:      "returns trimmed diff stat",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			runOutput: " internal/exec/git.go | 42 ++++++\n 1 file changed, 42 insertions(+)\n",
+			wantArgs:  []string{"diff", "--stat", "HEAD"},
+			wantOut:   "internal/exec/git.go | 42 ++++++\n 1 file changed, 42 insertions(+)",
+		},
+		{
+			name:     "returns empty string for no diff",
+			repoPath: "/repo/main",
+			path:     "/repo/feature",
+			wantArgs: []string{"diff", "--stat", "HEAD"},
+			wantOut:  "",
+		},
+		{
+			name:      "returns runner error with context",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			runErr:    errors.New("fatal: ambiguous argument"),
+			wantArgs:  []string{"diff", "--stat", "HEAD"},
+			expectErr: "git diff stat: fatal: ambiguous argument",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledPath string
+			var calledArgs []string
+
+			runner := func(repoPath string, args ...string) (string, error) {
+				calledPath = repoPath
+				calledArgs = append([]string{}, args...)
+				return tt.runOutput, tt.runErr
+			}
+
+			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
+			out, err := cmd.GitDiffStat(tt.path)
+
+			assert.Equal(t, tt.path, calledPath)
+			assert.Equal(t, tt.wantArgs, calledArgs)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOut, out)
+		})
+	}
+}
+
 func TestRunGitCommand_IncludesOutputOnFailure(t *testing.T) {
 	_, err := runGitCommand(t.TempDir(), "not-a-real-git-subcommand")
 

--- a/internal/exec/git_test.go
+++ b/internal/exec/git_test.go
@@ -917,6 +917,72 @@ func TestGitCommand_GitDiffStat(t *testing.T) {
 	}
 }
 
+func TestGitCommand_GitBranch(t *testing.T) {
+	tests := []struct {
+		name      string
+		repoPath  string
+		path      string
+		runOutput string
+		runErr    error
+		wantArgs  []string
+		wantOut   string
+		expectErr string
+	}{
+		{
+			name:      "returns trimmed branch name",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			runOutput: "feat/issue-19\n",
+			wantArgs:  []string{"rev-parse", "--abbrev-ref", "HEAD"},
+			wantOut:   "feat/issue-19",
+		},
+		{
+			name:      "returns HEAD for detached head state",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			runOutput: "HEAD\n",
+			wantArgs:  []string{"rev-parse", "--abbrev-ref", "HEAD"},
+			wantOut:   "HEAD",
+		},
+		{
+			name:      "returns runner error with context",
+			repoPath:  "/repo/main",
+			path:      "/repo/feature",
+			runErr:    errors.New("not a git repository"),
+			wantArgs:  []string{"rev-parse", "--abbrev-ref", "HEAD"},
+			expectErr: "git branch: not a git repository",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calledPath string
+			var calledArgs []string
+
+			runner := func(repoPath string, args ...string) (string, error) {
+				calledPath = repoPath
+				calledArgs = append([]string{}, args...)
+				return tt.runOutput, tt.runErr
+			}
+
+			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
+			out, err := cmd.GitBranch(tt.path)
+
+			assert.Equal(t, tt.path, calledPath)
+			assert.Equal(t, tt.wantArgs, calledArgs)
+
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantOut, out)
+		})
+	}
+}
+
 func TestRunGitCommand_IncludesOutputOnFailure(t *testing.T) {
 	_, err := runGitCommand(t.TempDir(), "not-a-real-git-subcommand")
 


### PR DESCRIPTION
Closes #19

## What Changed
Implements the \ContextBuilder\ — a utility that collects rich git state from a worktree and packages it for passing to AI agents.

## Why Changed
Agent launchers currently only receive a bare \Dir = worktreePath\. This PR gives them structured context (git status, recent commits, changed files, diff summary) so they can reason intelligently about the worktree's current state.

## Files Added / Changed
- \internal/domain/context.go\ — \WorktreeContext\ struct (Path, Branch, GitStatus, RecentLog, ChangedFiles, DiffSummary)
- \internal/exec/git.go\ — 4 new methods: \GitStatus\, \GitLog\, \GitDiffNameOnly\, \GitDiffStat\
- \internal/exec/context_builder.go\ — \BuildContext(gitCmd, path)\ assembles the full context
- \internal/data/context_snapshot.go\ — \SaveContextSnapshot(db, worktreeID, ctx)\ persists snapshots to the existing \context_snapshots\ SQLite table

## Testing
- Full table-driven TDD tests for all 4 new git methods
- \TestBuildContext_PopulatesAllFields\ — verifies all fields populated from mocked runner
- \TestBuildContext_EmptyRepo_ReturnsEmptyStatus\ — verifies graceful handling of empty repos
- Error propagation tests for each git command failure path
- \SaveContextSnapshot\ tested with in-memory SQLite (success, empty files, multiple snapshots, closed DB)
- \go test ./internal/...\ — all packages pass