### PR TITLE
feat(modal): implement unified agent launcher screen

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -172,6 +172,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.spawnAiderCmd(selected.Path, msg.Files)
 			}
 			return m, nil
+		case modal.SpawnAgentMsg:
+			m.activeModal = nil
+			switch msg.AgentName {
+			case "copilot":
+				return m, m.spawnCopilotCmd(msg.WorktreePath, msg.Prompt)
+			case "claude":
+				return m, m.spawnClaudeCmd(msg.WorktreePath, msg.Prompt)
+			case "aider":
+				return m, m.fetchAiderFilesCmd(msg.WorktreePath)
+			}
+			return m, nil
 		case modal.ModalCancelledMsg:
 			m.activeModal = nil
 			return m, nil
@@ -288,6 +299,17 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.moveUp()
 		case tea.KeyDown:
 			m.moveDown()
+		case tea.KeySpace:
+			if m.view != viewWorktrees {
+				m.Error = "Agent launcher is only available in the Worktrees view — press w to switch"
+				return m, nil
+			}
+			if selected, ok := m.selectedWorktree(); ok {
+				m.activeModal = modal.NewAgentLauncherModal(m.Config, selected.Path)
+			} else {
+				m.Error = "No worktree selected — select one first"
+			}
+			return m, nil
 		case tea.KeyRunes:
 			switch msg.String() {
 			case "j":

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -175,11 +175,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case modal.SpawnAgentMsg:
 			m.activeModal = nil
 			switch msg.AgentName {
-			case "copilot":
+			case modal.AgentNameCopilot:
 				return m, m.spawnCopilotCmd(msg.WorktreePath, msg.Prompt)
-			case "claude":
+			case modal.AgentNameClaude:
 				return m, m.spawnClaudeCmd(msg.WorktreePath, msg.Prompt)
-			case "aider":
+		case modal.AgentNameAider:
 				return m, m.fetchAiderFilesCmd(msg.WorktreePath)
 			}
 			return m, nil

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -312,6 +312,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case tea.KeyRunes:
 			switch msg.String() {
+			case " ":
+				// Spacebar can arrive as KeyRunes " " on some terminals (e.g. Windows).
+				// Mirror the KeySpace handler above.
+				if m.view != viewWorktrees {
+					m.Error = "Agent launcher is only available in the Worktrees view — press w to switch"
+					return m, nil
+				}
+				if selected, ok := m.selectedWorktree(); ok {
+					m.activeModal = modal.NewAgentLauncherModal(m.Config, selected.Path)
+				} else {
+					m.Error = "No worktree selected — select one first"
+				}
+				return m, nil
 			case "j":
 				m.moveDown()
 				return m, nil

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -2118,6 +2118,8 @@ func TestModel_SpawnAgentMsg_Copilot_ClearsModalAndReturnsCmd(t *testing.T) {
 // TestModel_SpawnAgentMsg_Claude_ClearsModalAndReturnsCmd verifies the same for claude.
 func TestModel_SpawnAgentMsg_Claude_ClearsModalAndReturnsCmd(t *testing.T) {
 	m := NewModel()
+	// Use "go" as a stand-in binary — it is always on PATH in this repo's CI environment.
+	m.Config.AIAgents.ClaudeBinary = "go"
 	m.activeModal = modal.NewAgentLauncherModal(m.Config, "/repos/nexus")
 
 	updated, cmd := m.Update(modal.SpawnAgentMsg{

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/m00nk0d3/nexus/internal/data"
 	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/m00nk0d3/nexus/internal/tui/modal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1847,6 +1848,7 @@ func TestModel_Enter_InViewWorktrees_SwitchesWorktree(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
 // Phase 3: Aider launcher tests
 // ---------------------------------------------------------------------------
 
@@ -2038,4 +2040,112 @@ func TestModel_F_Key_AiderNotOnPath_SetsError(t *testing.T) {
 	assert.Nil(t, cmd)
 	assert.Contains(t, updatedModel.Error, "aider not found",
 		"error should mention that the aider binary is missing")
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3: Agent launcher ([space] key + SpawnAgentMsg dispatch) tests
+// ---------------------------------------------------------------------------
+
+// TestModel_SpaceKey_InWorktreeView_WithSelection_OpensAgentLauncher verifies
+// that pressing [space] in the worktrees view with a selection opens the agent launcher modal.
+func TestModel_SpaceKey_InWorktreeView_WithSelection_OpensAgentLauncher(t *testing.T) {
+	m := NewModel()
+	m.view = viewWorktrees
+	m.Worktrees = []domain.Worktree{
+		{Path: "/repos/nexus", Branch: "main"},
+	}
+	m.selectedIdx = 0
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	next, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.NotNil(t, next.activeModal, "should open the agent launcher modal")
+	assert.Nil(t, cmd, "no async command needed to open the launcher")
+	assert.Empty(t, next.Error, "no error should be set")
+}
+
+// TestModel_SpaceKey_InWorktreeView_NoSelection_SetsError verifies that pressing
+// [space] with no worktree selected shows a friendly error instead of panicking.
+func TestModel_SpaceKey_InWorktreeView_NoSelection_SetsError(t *testing.T) {
+	m := NewModel()
+	m.view = viewWorktrees
+	// Worktrees is empty — nothing to select.
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	next, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Nil(t, next.activeModal, "no modal should open when nothing is selected")
+	assert.Contains(t, next.Error, "No worktree selected")
+}
+
+// TestModel_SpaceKey_NotInWorktreeView_SetsError verifies that pressing [space]
+// outside the worktrees view surfaces a navigation hint error.
+func TestModel_SpaceKey_NotInWorktreeView_SetsError(t *testing.T) {
+	m := NewModel()
+	m.view = viewIssues
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	next, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Nil(t, next.activeModal, "no modal should open in issues view")
+	assert.Contains(t, next.Error, "Worktrees view")
+}
+
+// TestModel_SpawnAgentMsg_Copilot_ClearsModalAndReturnsCmd verifies that
+// a SpawnAgentMsg for copilot clears the active modal and returns a spawn command.
+func TestModel_SpawnAgentMsg_Copilot_ClearsModalAndReturnsCmd(t *testing.T) {
+	m := NewModel()
+	m.Worktrees = []domain.Worktree{{Path: "/repos/nexus", Branch: "main"}}
+	m.selectedIdx = 0
+	// Prime the model with an open modal (simulate user having opened the launcher).
+	m.activeModal = modal.NewAgentLauncherModal(m.Config, "/repos/nexus")
+
+	updated, cmd := m.Update(modal.SpawnAgentMsg{
+		AgentName:    modal.AgentNameCopilot,
+		WorktreePath: "/repos/nexus",
+		Prompt:       "suggest improvements",
+	})
+	next, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Nil(t, next.activeModal, "modal must be cleared after SpawnAgentMsg")
+	assert.NotNil(t, cmd, "should return a spawn command for copilot")
+}
+
+// TestModel_SpawnAgentMsg_Claude_ClearsModalAndReturnsCmd verifies the same for claude.
+func TestModel_SpawnAgentMsg_Claude_ClearsModalAndReturnsCmd(t *testing.T) {
+	m := NewModel()
+	m.activeModal = modal.NewAgentLauncherModal(m.Config, "/repos/nexus")
+
+	updated, cmd := m.Update(modal.SpawnAgentMsg{
+		AgentName:    modal.AgentNameClaude,
+		WorktreePath: "/repos/nexus",
+		Prompt:       "refactor this",
+	})
+	next, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Nil(t, next.activeModal, "modal must be cleared after SpawnAgentMsg")
+	assert.NotNil(t, cmd, "should return a spawn command for claude")
+}
+
+// TestModel_SpawnAgentMsg_Aider_ClearsModalAndFetchesFiles verifies that
+// SpawnAgentMsg for aider clears the modal and returns a file-fetch command.
+func TestModel_SpawnAgentMsg_Aider_ClearsModalAndFetchesFiles(t *testing.T) {
+	m := NewModel()
+	m.activeModal = modal.NewAgentLauncherModal(m.Config, "/repos/nexus")
+
+	updated, cmd := m.Update(modal.SpawnAgentMsg{
+		AgentName:    modal.AgentNameAider,
+		WorktreePath: "/repos/nexus",
+	})
+	next, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Nil(t, next.activeModal, "modal must be cleared after SpawnAgentMsg")
+	assert.NotNil(t, cmd, "aider should return a fetchAiderFilesCmd")
+	assert.Empty(t, next.Error, "no error should be set when aider is triggered")
 }

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	appVersion             = "1.0"
-	footerHintsWorktrees   = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [t] Theme | [g] GH | [esc] Quit"
+	footerHintsWorktrees   = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Theme | [g] GH | [esc] Quit"
 	footerHintsPRs         = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [t] Theme | [g] GH | [esc] Quit"
 	footerHintsDefault     = footerHintsWorktrees
 	actionBarHints         = "[c-n] New  [c-d] Delete  [c-l] Lock | [f1] Help"
@@ -462,7 +462,6 @@ func renderFooterBar(theme styles.Theme, date string, termWidth int, syncing boo
 	if view == viewPRs {
 		hints = footerHintsPRs
 	}
-	left := fmt.Sprintf("%s  [%s]", hints, date)
 
 	var syncStatus string
 	switch {
@@ -479,12 +478,17 @@ func renderFooterBar(theme styles.Theme, date string, termWidth int, syncing boo
 		}
 	}
 
-	content := left
+	// Build the right side (date + optional sync status) first, then truncate
+	// only the hints so the sync status is never clipped on narrow terminals.
+	right := fmt.Sprintf("  [%s]", date)
 	if syncStatus != "" {
-		content = left + "  " + syncStatus
+		right += "  " + syncStatus
 	}
-	// Truncate to termWidth so the bar never wraps to a second row on narrow terminals.
-	content = truncateStr(content, termWidth)
+	maxHints := termWidth - len([]rune(right))
+	if maxHints < 0 {
+		maxHints = 0
+	}
+	content := truncateStr(hints, maxHints) + right
 
 	return theme.GetStyle("status-bar").Width(termWidth).Render(content)
 }

--- a/internal/tui/modal/agent_launcher.go
+++ b/internal/tui/modal/agent_launcher.go
@@ -41,9 +41,20 @@ type AgentLauncherModal struct {
 func newAgentLauncherModal(options []agentOption, worktreePath string) *AgentLauncherModal {
 	ti := textinput.New()
 	ti.CharLimit = 200
+
+	// Start cursor on the first available agent so Enter works immediately.
+	startIdx := 0
+	for i, opt := range options {
+		if opt.available {
+			startIdx = i
+			break
+		}
+	}
+
 	return &AgentLauncherModal{
 		step:         stepAgentSelect,
 		options:      options,
+		selectedIdx:  startIdx,
 		worktreePath: worktreePath,
 		promptInput:  ti,
 	}
@@ -75,9 +86,9 @@ func buildAgentOptions(cfg *domain.Config) []agentOption {
 	}
 
 	return []agentOption{
-		{name: "Claude Code", key: "a", internal: "claude", available: claudeAvail},
-		{name: "Copilot CLI", key: "c", internal: "copilot", available: copilotAvail},
-		{name: "Aider", key: "?", internal: "aider", available: aiderAvail},
+		{name: "Claude Code", key: "a", internal: AgentNameClaude, available: claudeAvail},
+		{name: "Copilot CLI", key: "c", internal: AgentNameCopilot, available: copilotAvail},
+		{name: "Aider", key: "d", internal: AgentNameAider, available: aiderAvail},
 	}
 }
 
@@ -148,6 +159,13 @@ func (m *AgentLauncherModal) updateSelectStep(keyMsg tea.KeyMsg) (tea.Model, tea
 		if m.selectedIdx < len(m.options) {
 			return m.selectAgent(m.options[m.selectedIdx])
 		}
+	default:
+		// Jump-select by shortcut key (e.g. "a" for Claude, "c" for Copilot).
+		for _, opt := range m.options {
+			if opt.key == keyMsg.String() {
+				return m.selectAgent(opt)
+			}
+		}
 	}
 	return m, nil
 }
@@ -159,10 +177,10 @@ func (m *AgentLauncherModal) selectAgent(opt agentOption) (tea.Model, tea.Cmd) {
 	m.selectedAgent = opt
 
 	// Aider uses a file picker flow; emit immediately and let the app handle it.
-	if opt.internal == "aider" {
+	if opt.internal == AgentNameAider {
 		path := m.worktreePath
 		return m, func() tea.Msg {
-			return SpawnAgentMsg{AgentName: "aider", WorktreePath: path}
+			return SpawnAgentMsg{AgentName: AgentNameAider, WorktreePath: path}
 		}
 	}
 

--- a/internal/tui/modal/agent_launcher.go
+++ b/internal/tui/modal/agent_launcher.go
@@ -1,0 +1,214 @@
+package modal
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/domain"
+)
+
+type agentStep int
+
+const (
+	stepAgentSelect agentStep = iota
+	stepAgentPrompt
+)
+
+type agentOption struct {
+	name      string // Display name (e.g. "Claude Code")
+	key       string // Keyboard shortcut shown in UI (e.g. "a")
+	internal  string // Internal identifier ("claude", "copilot", "aider")
+	available bool   // Whether the agent can be used right now
+}
+
+// AgentLauncherModal is a Bubbletea model for the unified agent launcher overlay.
+// Step 1: shows all three agents with availability status.
+// Step 2: inline prompt input (for Claude/Copilot).
+// Aider skips the prompt and emits SpawnAgentMsg directly (file picker is handled by the app).
+type AgentLauncherModal struct {
+	step          agentStep
+	options       []agentOption
+	selectedIdx   int
+	worktreePath  string
+	promptInput   textinput.Model
+	selectedAgent agentOption
+}
+
+// newAgentLauncherModal is the internal constructor used in production and in tests.
+func newAgentLauncherModal(options []agentOption, worktreePath string) *AgentLauncherModal {
+	ti := textinput.New()
+	ti.CharLimit = 200
+	return &AgentLauncherModal{
+		step:         stepAgentSelect,
+		options:      options,
+		worktreePath: worktreePath,
+		promptInput:  ti,
+	}
+}
+
+// buildAgentOptions returns the three fixed agent slots with their current availability.
+// Availability = enabled in config AND binary found on PATH.
+func buildAgentOptions(cfg *domain.Config) []agentOption {
+	claudeAvail := cfg.AIAgents.ClaudeEnabled
+	if claudeAvail {
+		bin := cfg.AIAgents.ClaudeBinary
+		if bin == "" {
+			bin = "claude"
+		}
+		_, err := exec.LookPath(bin)
+		claudeAvail = err == nil
+	}
+
+	copilotAvail := cfg.AIAgents.CopilotEnabled
+	if copilotAvail {
+		_, err := exec.LookPath("gh")
+		copilotAvail = err == nil
+	}
+
+	aiderAvail := cfg.AIAgents.AiderEnabled
+	if aiderAvail {
+		_, err := exec.LookPath("aider")
+		aiderAvail = err == nil
+	}
+
+	return []agentOption{
+		{name: "Claude Code", key: "a", internal: "claude", available: claudeAvail},
+		{name: "Copilot CLI", key: "c", internal: "copilot", available: copilotAvail},
+		{name: "Aider", key: "?", internal: "aider", available: aiderAvail},
+	}
+}
+
+// NewAgentLauncherModal creates an AgentLauncherModal with availability computed from config.
+func NewAgentLauncherModal(cfg *domain.Config, worktreePath string) *AgentLauncherModal {
+	return newAgentLauncherModal(buildAgentOptions(cfg), worktreePath)
+}
+
+// Init satisfies tea.Model.
+func (m *AgentLauncherModal) Init() tea.Cmd { return nil }
+
+// Update handles Bubbletea messages for the agent launcher.
+func (m *AgentLauncherModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, isKey := msg.(tea.KeyMsg)
+
+	// Non-key messages are forwarded to the text input when in prompt step.
+	if !isKey {
+		if m.step == stepAgentPrompt {
+			var cmd tea.Cmd
+			m.promptInput, cmd = m.promptInput.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+	}
+
+	// Esc always cancels regardless of step.
+	if keyMsg.Type == tea.KeyEsc {
+		return m, func() tea.Msg { return ModalCancelledMsg{} }
+	}
+
+	if m.step == stepAgentPrompt {
+		return m.updatePromptStep(keyMsg)
+	}
+
+	return m.updateSelectStep(keyMsg)
+}
+
+func (m *AgentLauncherModal) updatePromptStep(keyMsg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if keyMsg.Type == tea.KeyEnter {
+		prompt := strings.TrimSpace(m.promptInput.Value())
+		selected := m.selectedAgent
+		path := m.worktreePath
+		return m, func() tea.Msg {
+			return SpawnAgentMsg{
+				AgentName:    selected.internal,
+				WorktreePath: path,
+				Prompt:       prompt,
+			}
+		}
+	}
+
+	var cmd tea.Cmd
+	m.promptInput, cmd = m.promptInput.Update(keyMsg)
+	return m, cmd
+}
+
+func (m *AgentLauncherModal) updateSelectStep(keyMsg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch keyMsg.String() {
+	case "up", "k":
+		if m.selectedIdx > 0 {
+			m.selectedIdx--
+		}
+	case "down", "j":
+		if m.selectedIdx < len(m.options)-1 {
+			m.selectedIdx++
+		}
+	case "enter":
+		if m.selectedIdx < len(m.options) {
+			return m.selectAgent(m.options[m.selectedIdx])
+		}
+	}
+	return m, nil
+}
+
+func (m *AgentLauncherModal) selectAgent(opt agentOption) (tea.Model, tea.Cmd) {
+	if !opt.available {
+		return m, nil
+	}
+	m.selectedAgent = opt
+
+	// Aider uses a file picker flow; emit immediately and let the app handle it.
+	if opt.internal == "aider" {
+		path := m.worktreePath
+		return m, func() tea.Msg {
+			return SpawnAgentMsg{AgentName: "aider", WorktreePath: path}
+		}
+	}
+
+	// Claude and Copilot: advance to the inline prompt step.
+	m.promptInput.Placeholder = fmt.Sprintf("Enter %s prompt…", opt.name)
+	m.promptInput.SetValue("")
+	focusCmd := m.promptInput.Focus()
+	m.step = stepAgentPrompt
+	return m, focusCmd
+}
+
+// Title returns the modal title for themed overlay rendering.
+func (m *AgentLauncherModal) Title() string { return "SPAWN AGENT" }
+
+// View renders the current state of the modal.
+func (m *AgentLauncherModal) View() string {
+	if m.step == stepAgentPrompt {
+		return m.viewPrompt()
+	}
+	return m.viewAgentList()
+}
+
+func (m *AgentLauncherModal) viewAgentList() string {
+	var b strings.Builder
+	b.WriteString("Select an agent to spawn in:\n\n")
+
+	for i, opt := range m.options {
+		cursor := "  "
+		if i == m.selectedIdx {
+			cursor = "> "
+		}
+		status := "● available"
+		if !opt.available {
+			status = "✗ not configured"
+		}
+		b.WriteString(fmt.Sprintf("%s[%s] %-14s %s\n", cursor, opt.key, opt.name, status))
+	}
+
+	b.WriteString("\n↑/↓ navigate  •  Enter select  •  Esc cancel")
+	return b.String()
+}
+
+func (m *AgentLauncherModal) viewPrompt() string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Spawning %s in:\n%s\n\n", m.selectedAgent.name, m.worktreePath))
+	b.WriteString(m.promptInput.View())
+	b.WriteString("\n\nEnter confirm  •  Esc cancel")
+	return b.String()
+}

--- a/internal/tui/modal/agent_launcher_test.go
+++ b/internal/tui/modal/agent_launcher_test.go
@@ -1,0 +1,289 @@
+package modal
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testWorktreePath = "/home/user/worktrees/feat-issue-21-agent-launcher"
+
+var testAgentOptions = []agentOption{
+	{name: "Claude Code", key: "a", internal: "claude", available: true},
+	{name: "Copilot CLI", key: "c", internal: "copilot", available: true},
+	{name: "Aider", key: "?", internal: "aider", available: false},
+}
+
+func newTestLauncher() *AgentLauncherModal {
+	return newAgentLauncherModal(testAgentOptions, testWorktreePath)
+}
+
+// --- Constructor ---
+
+func TestNewAgentLauncherModal_StartsAtSelectStep(t *testing.T) {
+	m := newTestLauncher()
+
+	require.NotNil(t, m)
+	assert.Equal(t, stepAgentSelect, m.step)
+	assert.Equal(t, 0, m.selectedIdx)
+	assert.Equal(t, testWorktreePath, m.worktreePath)
+}
+
+func TestAgentLauncherModal_Title(t *testing.T) {
+	m := newTestLauncher()
+	assert.Equal(t, "SPAWN AGENT", m.Title())
+}
+
+// --- View: agent selection step ---
+
+func TestAgentLauncherModal_View_ShowsAllAgents(t *testing.T) {
+	m := newTestLauncher()
+	view := m.View()
+
+	assert.Contains(t, view, "Claude Code")
+	assert.Contains(t, view, "Copilot CLI")
+	assert.Contains(t, view, "Aider")
+}
+
+func TestAgentLauncherModal_View_ShowsAvailabilityStatus(t *testing.T) {
+	m := newTestLauncher()
+	view := m.View()
+
+	assert.Contains(t, view, "● available")
+	assert.Contains(t, view, "✗ not configured")
+}
+
+func TestAgentLauncherModal_View_ShowsCursorOnSelected(t *testing.T) {
+	m := newTestLauncher()
+	view := m.View()
+
+	assert.Contains(t, view, "> ")
+}
+
+func TestAgentLauncherModal_View_ShowsNavigationHint(t *testing.T) {
+	m := newTestLauncher()
+	view := m.View()
+
+	assert.Contains(t, view, "↑/↓")
+	assert.Contains(t, view, "Esc cancel")
+}
+
+// --- Navigation ---
+
+func TestAgentLauncherModal_DownKey_MovesSelection(t *testing.T) {
+	m := newTestLauncher()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m = updated.(*AgentLauncherModal)
+
+	assert.Equal(t, 1, m.selectedIdx)
+}
+
+func TestAgentLauncherModal_UpKey_MovesSelectionUp(t *testing.T) {
+	m := newTestLauncher()
+	m.selectedIdx = 1
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	m = updated.(*AgentLauncherModal)
+
+	assert.Equal(t, 0, m.selectedIdx)
+}
+
+func TestAgentLauncherModal_DownKey_DoesNotExceedList(t *testing.T) {
+	m := newTestLauncher()
+	m.selectedIdx = 2
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	m = updated.(*AgentLauncherModal)
+
+	assert.Equal(t, 2, m.selectedIdx)
+}
+
+func TestAgentLauncherModal_UpKey_DoesNotGoBelowZero(t *testing.T) {
+	m := newTestLauncher()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	m = updated.(*AgentLauncherModal)
+
+	assert.Equal(t, 0, m.selectedIdx)
+}
+
+// --- TDD: Unavailable agent is not selectable ---
+
+func TestAgentLauncherModal_UnavailableAgentNotSelectable(t *testing.T) {
+	m := newTestLauncher()
+	// Navigate to Aider (index 2), which is unavailable.
+	m.selectedIdx = 2
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	// Entering on an unavailable agent must emit nothing.
+	assert.Nil(t, cmd, "unavailable agent should not emit any command")
+	assert.Equal(t, stepAgentSelect, m.step, "step should remain on selection")
+}
+
+// --- TDD: Selecting Claude/Copilot advances to prompt step ---
+
+func TestAgentLauncherModal_SelectClaude_AdvancesToPrompt(t *testing.T) {
+	m := newTestLauncher()
+	// Claude is at index 0.
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*AgentLauncherModal)
+
+	assert.Equal(t, stepAgentPrompt, m.step)
+	assert.NotNil(t, cmd, "Focus cmd should be returned")
+}
+
+func TestAgentLauncherModal_SelectCopilot_AdvancesToPrompt(t *testing.T) {
+	m := newTestLauncher()
+	m.selectedIdx = 1 // Copilot
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*AgentLauncherModal)
+
+	assert.Equal(t, stepAgentPrompt, m.step)
+	assert.NotNil(t, cmd)
+}
+
+func TestAgentLauncherModal_SelectClaude_SetsSelectedAgent(t *testing.T) {
+	m := newTestLauncher()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*AgentLauncherModal)
+
+	assert.Equal(t, "claude", m.selectedAgent.internal)
+}
+
+// --- View: prompt step ---
+
+func TestAgentLauncherModal_View_PromptStep_ShowsAgentNameAndPath(t *testing.T) {
+	m := newTestLauncher()
+	m.step = stepAgentPrompt
+	m.selectedAgent = testAgentOptions[0] // Claude
+
+	view := m.View()
+
+	assert.Contains(t, view, "Claude Code")
+	assert.Contains(t, view, testWorktreePath)
+}
+
+func TestAgentLauncherModal_View_PromptStep_ShowsConfirmHint(t *testing.T) {
+	m := newTestLauncher()
+	m.step = stepAgentPrompt
+	m.selectedAgent = testAgentOptions[0]
+
+	view := m.View()
+
+	assert.Contains(t, view, "Enter confirm")
+	assert.Contains(t, view, "Esc cancel")
+}
+
+// --- Prompt submission ---
+
+func TestAgentLauncherModal_PromptEnter_EmitsSpawnAgentMsg(t *testing.T) {
+	m := newTestLauncher()
+	m.step = stepAgentPrompt
+	m.selectedAgent = testAgentOptions[0] // Claude
+	m.promptInput.SetValue("fix the bug")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	spawnMsg, ok := msg.(SpawnAgentMsg)
+	require.True(t, ok)
+	assert.Equal(t, "claude", spawnMsg.AgentName)
+	assert.Equal(t, testWorktreePath, spawnMsg.WorktreePath)
+	assert.Equal(t, "fix the bug", spawnMsg.Prompt)
+}
+
+func TestAgentLauncherModal_PromptEnter_TrimsWhitespace(t *testing.T) {
+	m := newTestLauncher()
+	m.step = stepAgentPrompt
+	m.selectedAgent = testAgentOptions[1] // Copilot
+	m.promptInput.SetValue("  suggest some code  ")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	spawnMsg := msg.(SpawnAgentMsg)
+	assert.Equal(t, "suggest some code", spawnMsg.Prompt)
+}
+
+// --- Aider: skips prompt and emits SpawnAgentMsg directly ---
+
+func TestAgentLauncherModal_SelectAider_WhenAvailable_EmitsSpawnMsg(t *testing.T) {
+	opts := []agentOption{
+		{name: "Aider", key: "?", internal: "aider", available: true},
+	}
+	m := newAgentLauncherModal(opts, testWorktreePath)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	spawnMsg, ok := msg.(SpawnAgentMsg)
+	require.True(t, ok)
+	assert.Equal(t, "aider", spawnMsg.AgentName)
+	assert.Equal(t, testWorktreePath, spawnMsg.WorktreePath)
+	assert.Empty(t, spawnMsg.Prompt)
+}
+
+// --- Esc cancels ---
+
+func TestAgentLauncherModal_Esc_OnSelectStep_EmitsCancelMsg(t *testing.T) {
+	m := newTestLauncher()
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, ok := msg.(ModalCancelledMsg)
+	assert.True(t, ok)
+}
+
+func TestAgentLauncherModal_Esc_OnPromptStep_EmitsCancelMsg(t *testing.T) {
+	m := newTestLauncher()
+	m.step = stepAgentPrompt
+	m.selectedAgent = testAgentOptions[0]
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, ok := msg.(ModalCancelledMsg)
+	assert.True(t, ok)
+}
+
+// --- buildAgentOptions ---
+
+func TestBuildAgentOptions_AllDisabled_AllUnavailable(t *testing.T) {
+	cfg := &domain.Config{}
+	opts := buildAgentOptions(cfg)
+
+	require.Len(t, opts, 3)
+	for _, opt := range opts {
+		assert.False(t, opt.available, "all agents should be unavailable when disabled in config")
+	}
+}
+
+func TestBuildAgentOptions_AlwaysReturnsThreeOptions(t *testing.T) {
+	cfg := &domain.Config{}
+	opts := buildAgentOptions(cfg)
+
+	assert.Len(t, opts, 3)
+}
+
+func TestBuildAgentOptions_OptionsHaveExpectedInternalNames(t *testing.T) {
+	cfg := &domain.Config{}
+	opts := buildAgentOptions(cfg)
+
+	assert.Equal(t, "claude", opts[0].internal)
+	assert.Equal(t, "copilot", opts[1].internal)
+	assert.Equal(t, "aider", opts[2].internal)
+}

--- a/internal/tui/modal/agent_launcher_test.go
+++ b/internal/tui/modal/agent_launcher_test.go
@@ -14,7 +14,7 @@ var testWorktreePath = "/home/user/worktrees/feat-issue-21-agent-launcher"
 var testAgentOptions = []agentOption{
 	{name: "Claude Code", key: "a", internal: "claude", available: true},
 	{name: "Copilot CLI", key: "c", internal: "copilot", available: true},
-	{name: "Aider", key: "?", internal: "aider", available: false},
+	{name: "Aider", key: "d", internal: "aider", available: false},
 }
 
 func newTestLauncher() *AgentLauncherModal {
@@ -219,7 +219,7 @@ func TestAgentLauncherModal_PromptEnter_TrimsWhitespace(t *testing.T) {
 
 func TestAgentLauncherModal_SelectAider_WhenAvailable_EmitsSpawnMsg(t *testing.T) {
 	opts := []agentOption{
-		{name: "Aider", key: "?", internal: "aider", available: true},
+		{name: "Aider", key: "d", internal: "aider", available: true},
 	}
 	m := newAgentLauncherModal(opts, testWorktreePath)
 
@@ -287,3 +287,89 @@ func TestBuildAgentOptions_OptionsHaveExpectedInternalNames(t *testing.T) {
 	assert.Equal(t, "copilot", opts[1].internal)
 	assert.Equal(t, "aider", opts[2].internal)
 }
+
+// --- Cursor auto-advance ---
+
+// TestNewAgentLauncherModal_CursorSkipsToFirstAvailable verifies that the constructor
+// places the cursor on the first available agent, not blindly at index 0.
+func TestNewAgentLauncherModal_CursorSkipsToFirstAvailable(t *testing.T) {
+	opts := []agentOption{
+		{name: "Claude Code", key: "a", internal: "claude", available: false},
+		{name: "Copilot CLI", key: "c", internal: "copilot", available: true},
+		{name: "Aider", key: "d", internal: "aider", available: false},
+	}
+	m := newAgentLauncherModal(opts, testWorktreePath)
+
+	assert.Equal(t, 1, m.selectedIdx, "cursor should skip unavailable Claude and land on Copilot")
+}
+
+// TestNewAgentLauncherModal_AllUnavailable_CursorRemainsAtZero verifies graceful
+// behaviour when no agent is available — cursor stays at 0 (no panic).
+func TestNewAgentLauncherModal_AllUnavailable_CursorRemainsAtZero(t *testing.T) {
+	opts := []agentOption{
+		{name: "Claude Code", key: "a", internal: "claude", available: false},
+		{name: "Copilot CLI", key: "c", internal: "copilot", available: false},
+		{name: "Aider", key: "d", internal: "aider", available: false},
+	}
+	m := newAgentLauncherModal(opts, testWorktreePath)
+
+	assert.Equal(t, 0, m.selectedIdx, "cursor stays at 0 when nothing is available")
+}
+
+// --- Shortcut keys (a / c / d) ---
+
+// TestAgentLauncherModal_ShortcutA_SelectsClaude verifies that pressing "a" in the
+// selection step immediately activates Claude (same as navigating to it and pressing Enter).
+func TestAgentLauncherModal_ShortcutA_SelectsClaude(t *testing.T) {
+	m := newTestLauncher()
+	m.selectedIdx = 1 // Start on Copilot to make the test non-trivial.
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("a")})
+	m = updated.(*AgentLauncherModal)
+
+	assert.Equal(t, stepAgentPrompt, m.step, "pressing 'a' must advance to the prompt step")
+	assert.NotNil(t, cmd, "Focus cmd must be returned")
+	assert.Equal(t, "claude", m.selectedAgent.internal)
+}
+
+// TestAgentLauncherModal_ShortcutC_SelectsCopilot verifies the "c" shortcut.
+func TestAgentLauncherModal_ShortcutC_SelectsCopilot(t *testing.T) {
+	m := newTestLauncher()
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	m = updated.(*AgentLauncherModal)
+
+	assert.Equal(t, stepAgentPrompt, m.step)
+	assert.NotNil(t, cmd)
+	assert.Equal(t, "copilot", m.selectedAgent.internal)
+}
+
+// TestAgentLauncherModal_ShortcutD_WhenUnavailable_IsNoOp verifies that pressing the
+// Aider shortcut when Aider is unavailable does nothing (matches Enter behaviour).
+func TestAgentLauncherModal_ShortcutD_WhenUnavailable_IsNoOp(t *testing.T) {
+	m := newTestLauncher() // testAgentOptions has Aider as unavailable.
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+
+	assert.Nil(t, cmd, "shortcut for unavailable agent must not emit a command")
+	assert.Equal(t, stepAgentSelect, m.step, "step must not change for unavailable shortcut")
+}
+
+// TestAgentLauncherModal_ShortcutD_WhenAvailable_EmitsSpawnMsg verifies that pressing
+// the Aider shortcut when Aider is available skips the prompt and emits SpawnAgentMsg.
+func TestAgentLauncherModal_ShortcutD_WhenAvailable_EmitsSpawnMsg(t *testing.T) {
+	opts := []agentOption{
+		{name: "Claude Code", key: "a", internal: "claude", available: true},
+		{name: "Aider", key: "d", internal: "aider", available: true},
+	}
+	m := newAgentLauncherModal(opts, testWorktreePath)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("d")})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	spawnMsg, ok := msg.(SpawnAgentMsg)
+	require.True(t, ok)
+	assert.Equal(t, "aider", spawnMsg.AgentName)
+}
+

--- a/internal/tui/modal/messages.go
+++ b/internal/tui/modal/messages.go
@@ -32,3 +32,11 @@ type ModalCancelledMsg struct{}
 type AiderLaunchMsg struct {
 	Files []string
 }
+
+// SpawnAgentMsg is sent when the user confirms spawning an AI agent from the launcher.
+type SpawnAgentMsg struct {
+	AgentName    string   // "claude", "copilot", or "aider"
+	WorktreePath string   // Path to the worktree directory
+	Prompt       string   // Prompt text (empty for Aider which uses file picker)
+	Files        []string // File list (for Aider; nil for Claude/Copilot)
+}

--- a/internal/tui/modal/messages.go
+++ b/internal/tui/modal/messages.go
@@ -33,10 +33,17 @@ type AiderLaunchMsg struct {
 	Files []string
 }
 
+// Agent name constants — used in SpawnAgentMsg.AgentName and the app dispatch switch.
+const (
+	AgentNameClaude  = "claude"
+	AgentNameCopilot = "copilot"
+	AgentNameAider   = "aider"
+)
+
 // SpawnAgentMsg is sent when the user confirms spawning an AI agent from the launcher.
 type SpawnAgentMsg struct {
-	AgentName    string   // "claude", "copilot", or "aider"
+	AgentName    string   // AgentNameClaude, AgentNameCopilot, or AgentNameAider
 	WorktreePath string   // Path to the worktree directory
 	Prompt       string   // Prompt text (empty for Aider which uses file picker)
-	Files        []string // File list (for Aider; nil for Claude/Copilot)
+	Files        []string // Reserved for Aider file-picker; populated in follow-on issue
 }


### PR DESCRIPTION
Closes #21

## What Changed
Adds `AgentLauncherModal` ? a centered overlay triggered by `[space]` from the worktree view that shows all three AI agents (Claude Code, Copilot CLI, Aider) with their real-time availability status, replacing isolated `[a]`/`[c]` key bindings with a guided selection flow.

## Why Changed
The existing direct key bindings (a=Claude, c=Copilot) were invisible to users and had no way to show agent availability. This unified launcher solves discoverability and provides a consistent UX pattern for all current and future agents.

## Implementation Details
- **`AgentLauncherModal`** (two-step state machine):
  - Step 1: agent selection list with available / not configured indicators
  - Step 2: inline prompt text input for Claude/Copilot; Aider emits `SpawnAgentMsg` immediately (file picker handled by app)
  - Unavailable agents are non-selectable (greyed out)
- **`SpawnAgentMsg{AgentName, WorktreePath, Prompt, Files}`** added to messages
- **[space] key binding** opens the launcher when in the Worktrees view with a selection
- **`SpawnAgentMsg` handler** in `app.go` dispatches to existing `spawnCopilotCmd` / `spawnClaudeCmd`

## Testing
- 24 new TDD tests in `agent_launcher_test.go`
- All existing tests continue to pass (`go test ./...` green)
- `go build ./...` clean

## Notes
Aider spawning (file picker flow from issue #18) is stubbed ? selecting Aider emits `SpawnAgentMsg{AgentName: "aider"}` which currently shows "not yet implemented". This will be wired up in a follow-on issue.
