### PR TITLE
[Phase 3] Implement Suspend/Resume Mechanism (Signal Handling + Terminal Restore)

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -477,6 +477,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.Error = fmt.Sprintf("failed to log agent run: %v", err)
 			}
 		}
+		if msg.exitCode != 0 {
+			m.Error = fmt.Sprintf("⚠ Agent exited with code %d", msg.exitCode)
+		}
+		return m, m.refreshWorktreesCmd()
 
 	case githubSyncedMsg:
 		m.syncing = false

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -2151,3 +2151,68 @@ func TestModel_SpawnAgentMsg_Aider_ClearsModalAndFetchesFiles(t *testing.T) {
 	assert.NotNil(t, cmd, "aider should return a fetchAiderFilesCmd")
 	assert.Empty(t, next.Error, "no error should be set when aider is triggered")
 }
+
+// ---------------------------------------------------------------------------
+// Phase 3: Suspend/Resume tests
+// ---------------------------------------------------------------------------
+
+// TestAgentDoneMsg_NonZeroExit_ShowsErrorInStatusBar verifies that when an agent
+// exits with a non-zero code, the model's Error field is set to the expected
+// warning message so it is displayed in the status bar.
+func TestAgentDoneMsg_NonZeroExit_ShowsErrorInStatusBar(t *testing.T) {
+	tests := []struct {
+		name      string
+		exitCode  int
+		wantError string
+	}{
+		{
+			name:      "exit code 1 shows warning",
+			exitCode:  1,
+			wantError: "⚠ Agent exited with code 1",
+		},
+		{
+			name:      "exit code 127 shows warning",
+			exitCode:  127,
+			wantError: "⚠ Agent exited with code 127",
+		},
+		{
+			name:      "exit code 0 does not set error",
+			exitCode:  0,
+			wantError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+
+			updated, cmd := model.Update(agentDoneMsg{
+				agentName: "copilot",
+				prompt:    "test",
+				exitCode:  tt.exitCode,
+			})
+			m, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.wantError, m.Error,
+				"Error field should match expected warning for exit code %d", tt.exitCode)
+			// agentDoneMsg must always trigger a worktree refresh.
+			assert.NotNil(t, cmd, "agentDoneMsg must return a refreshWorktreesCmd")
+		})
+	}
+}
+
+// TestAgentDoneMsg_ZeroExit_TriggersRefresh verifies that even a successful
+// agent exit (code 0) still returns a refreshWorktreesCmd so the worktree list
+// is reloaded after the subprocess exits.
+func TestAgentDoneMsg_ZeroExit_TriggersRefresh(t *testing.T) {
+	model := NewModel()
+
+	_, cmd := model.Update(agentDoneMsg{
+		agentName: "claude",
+		prompt:    "refactor",
+		exitCode:  0,
+	})
+
+	assert.NotNil(t, cmd, "zero-exit agentDoneMsg must still return a refreshWorktreesCmd")
+}

--- a/cmd/nexus/main.go
+++ b/cmd/nexus/main.go
@@ -41,6 +41,7 @@ func run() error {
 	}
 
 	p := tea.NewProgram(m, opts...)
+	installSIGTSTP(p)
 	_, err = p.Run()
 	return err
 }

--- a/cmd/nexus/signal_unix.go
+++ b/cmd/nexus/signal_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// installSIGTSTP installs a SIGTSTP (Ctrl+Z) signal handler that cleanly
+// suspends the Bubbletea program by sending tea.SuspendMsg. The TUI is fully
+// restored when the process is resumed with fg.
+func installSIGTSTP(p *tea.Program) {
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTSTP)
+	go func() {
+		for range sigCh {
+			p.Send(tea.SuspendMsg{})
+		}
+	}()
+}

--- a/cmd/nexus/signal_windows.go
+++ b/cmd/nexus/signal_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package main
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// installSIGTSTP is a no-op on Windows — SIGTSTP does not exist on this platform.
+func installSIGTSTP(_ *tea.Program) {}


### PR DESCRIPTION
Closes #22

## What Changed
Implements the full suspend/resume mechanism for Nexus when spawning AI agents or opening a shell.

## Changes
- **cmd/nexus/app.go** - agentDoneMsg handler now returns refreshWorktreesCmd() on every exit and shows warning for non-zero exit codes
- **cmd/nexus/signal_unix.go** (new, !windows build tag) - installs SIGTSTP goroutine sending tea.SuspendMsg{} so Ctrl+Z cleanly suspends the TUI
- **cmd/nexus/signal_windows.go** (new, windows build tag) - no-op installSIGTSTP stub
- **cmd/nexus/main.go** - calls installSIGTSTP(p) after creating the program
- **cmd/nexus/app_test.go** - adds TestAgentDoneMsg_NonZeroExit_ShowsErrorInStatusBar and TestAgentDoneMsg_ZeroExit_TriggersRefresh

## Why Changed
The missing pieces for full suspend/resume were:
1. Worktree refresh after resume (subprocess may have changed the FS)
2. User-visible warning on non-zero exit (agent crash/Ctrl+C)
3. SIGTSTP forwarding so Ctrl+Z suspends the TUI cleanly on Unix

## Testing
- TestAgentDoneMsg_NonZeroExit_ShowsErrorInStatusBar (new, mandated by issue)
- TestAgentDoneMsg_ZeroExit_TriggersRefresh (new, regression guard)
- All go test ./cmd/nexus/... tests pass
- go build ./... passes on Windows