### PR TITLE
feat(agents): allow spawning agents with no prompt

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -203,9 +203,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch keyMsg.Type {
 			case tea.KeyEnter:
 				prompt := strings.TrimSpace(m.copilotPromptInput.Value())
-				if prompt == "" {
-					return m, nil
-				}
 				m.copilotPromptActive = false
 				if selected, ok := m.selectedWorktree(); ok {
 					return m, m.spawnCopilotCmd(selected.Path, prompt)
@@ -232,9 +229,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch keyMsg.Type {
 			case tea.KeyEnter:
 				prompt := strings.TrimSpace(m.claudePromptInput.Value())
-				if prompt == "" {
-					return m, nil
-				}
 				m.claudePromptActive = false
 				if selected, ok := m.selectedWorktree(); ok {
 					return m, m.spawnClaudeCmd(selected.Path, prompt)
@@ -523,22 +517,25 @@ func (m *Model) View() string {
 	// Overlay helpers — center a themed RenderBox over the full base view.
 	overlay := func(title, content string) string {
 		theme := styles.NewTheme(styles.Themes[m.themeIdx])
-		box := theme.RenderBox(title, content)
+		box := theme.RenderBox(title, content, w)
 		return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, box)
 	}
 
 	if m.activeModal != nil {
+		if wa, ok := m.activeModal.(interface{ SetWidth(int) }); ok {
+			wa.SetWidth(w)
+		}
 		return overlay(m.activeModal.Title(), m.activeModal.View())
 	}
 
 	if m.copilotPromptActive {
 		return overlay("Spawn Copilot",
-			fmt.Sprintf("> %s\n\nEnter confirm  •  Esc cancel", m.copilotPromptInput.View()))
+			fmt.Sprintf("> %s\n\nEnter confirm (prompt optional)  •  Esc cancel", m.copilotPromptInput.View()))
 	}
 
 	if m.claudePromptActive {
 		return overlay("Spawn Claude Code",
-			fmt.Sprintf("> %s\n\nEnter confirm  •  Esc cancel", m.claudePromptInput.View()))
+			fmt.Sprintf("> %s\n\nEnter confirm (prompt optional)  •  Esc cancel", m.claudePromptInput.View()))
 	}
 
 	if m.Error != "" {
@@ -644,7 +641,11 @@ func (m *Model) switchWorktreeCmd(path string) tea.Cmd {
 // mode with the given prompt pre-loaded in the specified worktree directory.
 // It is extracted as a top-level function to keep it unit-testable.
 func buildCopilotCmd(worktreePath, prompt string) *exec.Cmd {
-	cmd := exec.Command("gh", "copilot", "-i", prompt)
+	args := []string{"copilot", "-i"}
+	if prompt != "" {
+		args = append(args, prompt)
+	}
+	cmd := exec.Command("gh", args...)
 	cmd.Dir = worktreePath
 	return cmd
 }
@@ -695,7 +696,12 @@ func resolveAiderBinary(cfg *domain.Config) (string, error) {
 // given prompt in the specified worktree directory.
 // It is extracted as a top-level function to keep it unit-testable.
 func buildClaudeCmd(worktreePath, prompt, binaryPath string) *exec.Cmd {
-	cmd := exec.Command(binaryPath, prompt)
+	var cmd *exec.Cmd
+	if prompt != "" {
+		cmd = exec.Command(binaryPath, prompt)
+	} else {
+		cmd = exec.Command(binaryPath)
+	}
 	cmd.Dir = worktreePath
 	return cmd
 }

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -1335,6 +1335,13 @@ func TestBuildCopilotCmd_BuildsCorrectCommand(t *testing.T) {
 			wantArgs:     []string{"gh", "copilot", "-i", "add unit tests for auth handler"},
 			wantDir:      "/repo/feat-branch",
 		},
+		{
+			name:         "empty prompt omits prompt arg",
+			worktreePath: "/tmp/my-worktree",
+			prompt:       "",
+			wantArgs:     []string{"gh", "copilot", "-i"},
+			wantDir:      "/tmp/my-worktree",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1377,22 +1384,21 @@ func TestModel_CopilotPrompt_EscClearsInputValue(t *testing.T) {
 		"Esc should clear the copilot prompt input value")
 }
 
-// TestModel_CopilotPrompt_EnterWithEmptyPrompt_DoesNotSpawn verifies that
-// pressing Enter with an empty (or whitespace-only) prompt is a no-op.
-func TestModel_CopilotPrompt_EnterWithEmptyPrompt_DoesNotSpawn(t *testing.T) {
+// TestModel_CopilotPrompt_EnterWithEmptyPrompt_Spawns verifies that
+// pressing Enter with an empty prompt spawns the agent without a prompt arg.
+func TestModel_CopilotPrompt_EnterWithEmptyPrompt_Spawns(t *testing.T) {
 	model := NewModel()
 	model.copilotPromptActive = true
+	model.Worktrees = []domain.Worktree{{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"}}
 	// Leave input value empty (default)
 
 	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updatedModel, ok := updated.(*Model)
 	require.True(t, ok)
 
-	// With an empty prompt, state should not change (prompt stays active)
-	// and no cmd should be spawned.
-	assert.True(t, updatedModel.copilotPromptActive,
-		"empty-prompt Enter should leave copilotPromptActive true")
-	assert.Nil(t, cmd, "empty-prompt Enter should not return a spawn Cmd")
+	assert.False(t, updatedModel.copilotPromptActive,
+		"empty-prompt Enter should close the copilot prompt")
+	assert.NotNil(t, cmd, "empty-prompt Enter should return a spawn Cmd")
 }
 
 // TestModel_AgentDoneMsg_ClearsPrompt verifies that receiving agentDoneMsg
@@ -1499,6 +1505,14 @@ func TestSpawnClaudeCmd_UsesCustomBinaryPath(t *testing.T) {
 			binaryPath:   "/usr/local/bin/claude",
 			wantArgs:     []string{"/usr/local/bin/claude", "write unit tests"},
 			wantDir:      "/repo/feat-branch",
+		},
+		{
+			name:         "empty prompt omits prompt arg",
+			worktreePath: "/tmp/my-worktree",
+			prompt:       "",
+			binaryPath:   "claude",
+			wantArgs:     []string{"claude"},
+			wantDir:      "/tmp/my-worktree",
 		},
 	}
 
@@ -1654,19 +1668,22 @@ func TestModel_ClaudePrompt_EscClearsInputValue(t *testing.T) {
 		"Esc should clear the claude prompt input value")
 }
 
-// TestModel_ClaudePrompt_EnterWithEmptyPrompt_DoesNotSpawn verifies that
-// pressing Enter with an empty (or whitespace-only) prompt is a no-op.
-func TestModel_ClaudePrompt_EnterWithEmptyPrompt_DoesNotSpawn(t *testing.T) {
+// TestModel_ClaudePrompt_EnterWithEmptyPrompt_Spawns verifies that
+// pressing Enter with an empty prompt spawns the agent without a prompt arg.
+func TestModel_ClaudePrompt_EnterWithEmptyPrompt_Spawns(t *testing.T) {
 	model := NewModel()
 	model.claudePromptActive = true
+	model.Config.AIAgents.ClaudeEnabled = true
+	model.Config.AIAgents.ClaudeBinary = "go" // "go" is always on PATH when running go test
+	model.Worktrees = []domain.Worktree{{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"}}
 
 	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	updatedModel, ok := updated.(*Model)
 	require.True(t, ok)
 
-	assert.True(t, updatedModel.claudePromptActive,
-		"empty-prompt Enter should leave claudePromptActive true")
-	assert.Nil(t, cmd, "empty-prompt Enter should not return a spawn Cmd")
+	assert.False(t, updatedModel.claudePromptActive,
+		"empty-prompt Enter should close the claude prompt")
+	assert.NotNil(t, cmd, "empty-prompt Enter should return a spawn Cmd")
 }
 
 // TestModel_AgentDoneMsg_ClearsClaudePrompt verifies that receiving agentDoneMsg

--- a/internal/tui/modal/agent_launcher.go
+++ b/internal/tui/modal/agent_launcher.go
@@ -35,6 +35,7 @@ type AgentLauncherModal struct {
 	worktreePath  string
 	promptInput   textinput.Model
 	selectedAgent agentOption
+	width         int // terminal width, set by the parent view
 }
 
 // newAgentLauncherModal is the internal constructor used in production and in tests.
@@ -192,6 +193,18 @@ func (m *AgentLauncherModal) selectAgent(opt agentOption) (tea.Model, tea.Cmd) {
 	return m, focusCmd
 }
 
+// SetWidth receives the terminal width from the parent view so the text input
+// can span the full inner content area of the popup box (total width minus the
+// 4-column border+padding overhead added by RenderBox).
+func (m *AgentLauncherModal) SetWidth(w int) {
+	m.width = w
+	inner := w - 4
+	if inner < 20 {
+		inner = 20
+	}
+	m.promptInput.Width = inner
+}
+
 // Title returns the modal title for themed overlay rendering.
 func (m *AgentLauncherModal) Title() string { return "SPAWN AGENT" }
 
@@ -227,6 +240,6 @@ func (m *AgentLauncherModal) viewPrompt() string {
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("Spawning %s in:\n%s\n\n", m.selectedAgent.name, m.worktreePath))
 	b.WriteString(m.promptInput.View())
-	b.WriteString("\n\nEnter confirm  •  Esc cancel")
+	b.WriteString("\n\nEnter confirm (prompt optional)  •  Esc cancel")
 	return b.String()
 }

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -155,11 +155,16 @@ func (t Theme) MutedBorder(s lipgloss.Style) lipgloss.Style {
 }
 
 // RenderBox renders content inside a rounded-border panel with an optional title.
-func (t Theme) RenderBox(title, content string) string {
+// width sets the total rendered width in terminal columns; 0 means size to content.
+func (t Theme) RenderBox(title, content string, width int) string {
 	style := lipgloss.NewStyle().
 		BorderStyle(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color(t.accent)).
 		Padding(0, 1)
+	// Overhead: 1 border + 1 padding on each side = 4 columns total.
+	if width > 4 {
+		style = style.Width(width - 4)
+	}
 	if title != "" {
 		return style.Render(fmt.Sprintf("%s\n%s", title, content))
 	}

--- a/internal/tui/styles/theme_test.go
+++ b/internal/tui/styles/theme_test.go
@@ -98,7 +98,7 @@ func TestTheme_RenderBox_ContentsPresent(t *testing.T) {
 	theme := NewTheme("digital-noir")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out := theme.RenderBox(tt.title, tt.content)
+			out := theme.RenderBox(tt.title, tt.content, 0)
 			for _, want := range tt.wantIn {
 				assert.Contains(t, out, want)
 			}


### PR DESCRIPTION
Remove the empty-prompt early-return guards for Copilot and Claude inline prompts so users can press Enter with a blank input and launch the agent in interactive mode with no pre-loaded task.

- Drop empty-prompt no-op in Copilot and Claude keyEnter handlers
- buildCopilotCmd: omit prompt arg when empty
- buildClaudeCmd: omit prompt arg when empty
- Update inline and modal view hints to say prompt optional
- Flip empty-prompt tests from DoesNotSpawn to Spawns with correct assertions
- Add empty-prompt test cases to buildCopilotCmd and buildClaudeCmd