### PR TITLE
feat(modal): add in-app help system (f1/? opens HelpModal)

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -283,6 +283,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case tea.KeyCtrlC:
 			return m, tea.Quit
+		case tea.KeyF1:
+			m.activeModal = modal.NewHelpModal()
+			return m, nil
 		case tea.KeyCtrlN:
 			return m, m.fetchIssuesCmd()
 		case tea.KeyCtrlD:
@@ -318,6 +321,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				} else {
 					m.Error = "No worktree selected — select one first"
 				}
+				return m, nil
+			case "?":
+				m.activeModal = modal.NewHelpModal()
 				return m, nil
 			case "j":
 				m.moveDown()

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -418,6 +418,38 @@ func TestModelUpdate_WorktreeSwitchedMsg_ErrorHandling(t *testing.T) {
 	}
 }
 
+// TestModel_HelpModal_OpenedByF1AndQuestion verifies that F1 and ? both open a HelpModal.
+func TestModel_HelpModal_OpenedByF1AndQuestion(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  tea.KeyMsg
+	}{
+		{
+			name: "F1 opens HelpModal",
+			msg:  tea.KeyMsg{Type: tea.KeyF1},
+		},
+		{
+			name: "? opens HelpModal",
+			msg:  tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("?")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel()
+			require.NotNil(t, m)
+			require.Nil(t, m.activeModal, "no modal should be active initially")
+
+			updated, cmd := m.Update(tt.msg)
+			updatedModel, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.IsType(t, &modal.HelpModal{}, updatedModel.activeModal, "activeModal should be a *HelpModal")
+			assert.Nil(t, cmd)
+		})
+	}
+}
+
 func TestModelUpdate_WorktreesRefreshedMsg_ClampsSelectedIndex(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/internal/tui/modal/help.go
+++ b/internal/tui/modal/help.go
@@ -1,0 +1,244 @@
+package modal
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type helpTab int
+
+const (
+	tabKeybindings    helpTab = iota
+	tabTips                   // Quick Tips
+	tabTroubleshooting        // Troubleshooting
+	tabAbout                  // About
+	helpTabCount              // sentinel
+)
+
+var helpTabLabels = [helpTabCount]string{
+	"Keybindings",
+	"Quick Tips",
+	"Troubleshooting",
+	"About",
+}
+
+// HelpModal is a Bubbletea model for the in-app help overlay (f1 / ?).
+// It renders four tabs: Keybindings, Quick Tips, Troubleshooting, and About.
+type HelpModal struct {
+	activeTab    helpTab
+	scrollOffset int
+}
+
+// NewHelpModal creates a new HelpModal starting on the Keybindings tab.
+func NewHelpModal() *HelpModal {
+	return &HelpModal{}
+}
+
+// Init satisfies tea.Model.
+func (m *HelpModal) Init() tea.Cmd { return nil }
+
+// Title returns the modal title for themed overlay rendering.
+func (m *HelpModal) Title() string { return "NEXUS HELP" }
+
+// Update handles Bubbletea messages.
+func (m *HelpModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch keyMsg.Type {
+	case tea.KeyEsc:
+		return m, func() tea.Msg { return ModalCancelledMsg{} }
+
+	case tea.KeyTab:
+		m.activeTab = (m.activeTab + 1) % helpTabCount
+		m.scrollOffset = 0
+		return m, nil
+
+	case tea.KeyUp:
+		if m.scrollOffset > 0 {
+			m.scrollOffset--
+		}
+		return m, nil
+
+	case tea.KeyDown:
+		m.scrollOffset++
+		return m, nil
+
+	case tea.KeyRunes:
+		switch keyMsg.String() {
+		case "q":
+			return m, func() tea.Msg { return ModalCancelledMsg{} }
+		case "l":
+			m.activeTab = (m.activeTab + 1) % helpTabCount
+			m.scrollOffset = 0
+		case "h":
+			m.activeTab = (m.activeTab + helpTabCount - 1) % helpTabCount
+			m.scrollOffset = 0
+		case "j":
+			m.scrollOffset++
+		case "k":
+			if m.scrollOffset > 0 {
+				m.scrollOffset--
+			}
+		case "1":
+			m.activeTab = tabKeybindings
+			m.scrollOffset = 0
+		case "2":
+			m.activeTab = tabTips
+			m.scrollOffset = 0
+		case "3":
+			m.activeTab = tabTroubleshooting
+			m.scrollOffset = 0
+		case "4":
+			m.activeTab = tabAbout
+			m.scrollOffset = 0
+		}
+	}
+
+	return m, nil
+}
+
+// View renders the help modal content.
+func (m *HelpModal) View() string {
+	var b strings.Builder
+
+	// Tab bar
+	for i := helpTab(0); i < helpTabCount; i++ {
+		if i == m.activeTab {
+			b.WriteString(fmt.Sprintf("[%s]", helpTabLabels[i]))
+		} else {
+			b.WriteString(fmt.Sprintf("  %s  ", helpTabLabels[i]))
+		}
+		if i < helpTabCount-1 {
+			b.WriteString("  ")
+		}
+	}
+	b.WriteString("\n\n")
+
+	// Tab content (with scrolling applied)
+	lines := strings.Split(m.tabContent(), "\n")
+	start := m.scrollOffset
+	if start > len(lines) {
+		start = len(lines)
+	}
+	b.WriteString(strings.Join(lines[start:], "\n"))
+
+	b.WriteString("\n\nTab/h/l: switch tabs   j/k: scroll   Esc/q: close")
+	return b.String()
+}
+
+// tabContent returns the full unscrolled body for the active tab.
+func (m *HelpModal) tabContent() string {
+	switch m.activeTab {
+	case tabKeybindings:
+		return keybindingsContent
+	case tabTips:
+		return tipsContent
+	case tabTroubleshooting:
+		return troubleshootingContent
+	case tabAbout:
+		return aboutContent
+	}
+	return ""
+}
+
+const keybindingsContent = `NAVIGATION
+  ↑/↓  j/k      Navigate within panel
+  ←/→  h/l      Switch between panels / tabs
+  Tab             Cycle panel focus / tab
+  Enter           Open shell in worktree / Select
+
+WORKTREE OPERATIONS
+  Ctrl+N          Create new worktree
+  Ctrl+D          Delete selected worktree
+  s               Open shell in worktree
+
+AI AGENTS (from Context Panel)
+  a               Spawn Claude Code
+  c               Spawn GitHub Copilot
+  Space           Unified agent launcher
+
+VIEWS
+  w / W           Worktrees view
+  i / I           Issues view
+  p / P           PRs view
+  t               Cycle themes
+
+GLOBAL
+  f1 / ?          Open this help modal
+  g               Open selected item in GitHub
+  Esc / Ctrl+C    Quit`
+
+const tipsContent = `COMMON WORKFLOWS
+
+1. Create a worktree from a GitHub issue
+   Press Ctrl+N → pick issue → choose branch type → confirm.
+   Nexus creates the branch and worktree automatically.
+
+2. Switch to a worktree and start coding
+   Navigate to the worktree with ↑/↓, then press Enter or s.
+   Your shell opens directly in the worktree directory.
+
+3. Spawn an AI agent in the right context
+   Select a worktree, then press a (Claude), c (Copilot),
+   or Space to open the unified launcher. Nexus suspends
+   itself and resumes when the agent exits.
+
+4. Keep GitHub data fresh
+   Press r to trigger a manual sync. Nexus auto-syncs on
+   startup and at the configured interval (~5 min default).
+
+5. Open an issue or PR in the browser
+   While in the Issues or PRs view, press g to open the
+   selected item in your default browser via gh CLI.
+
+6. Switch themes on the fly
+   Press t to cycle through Digital Noir, Matrix, and Light.`
+
+const troubleshootingContent = `COMMON ISSUES
+
+GitHub authentication failure
+  Symptom: "gh: not logged in" or empty issues/PRs list.
+  Fix: Run  gh auth login  in your terminal and follow the
+  prompts to authenticate with your GitHub account.
+
+Agent not found (Claude / Copilot / Aider)
+  Symptom: "binary not found" error when spawning an agent.
+  Fix: Install the missing tool, or disable it in config:
+    ~/.nexus/config.toml  →  ai_agents.claude_enabled = false
+  For Claude: https://docs.anthropic.com/en/docs/claude-code
+  For Copilot: gh extension install github/gh-copilot
+
+git not in PATH
+  Symptom: Nexus starts but shows no worktrees.
+  Fix: Ensure git is installed and accessible in your PATH.
+  Run  git --version  to verify.
+
+Worktree list is stale
+  Symptom: Deleted worktrees still appear.
+  Fix: Run  git worktree prune  in your repo, then press r
+  in Nexus to refresh.
+
+Config not loading
+  Symptom: Warning banner on startup.
+  Fix: Check  ~/.nexus/config.toml  for TOML syntax errors.
+  Delete or reset the file to restore defaults.`
+
+const aboutContent = `NEXUS — Git Worktree Orchestrator & AI Agent Hub
+
+Version:   v1.0.0
+Repo:      github.com/m00nk0d3/nexus
+License:   MIT
+
+Built with the Charm.sh ecosystem:
+  • Bubbletea  — TUI framework
+  • Lipgloss   — terminal styling
+  • Bubbles    — UI components
+
+Nexus helps you manage multiple git worktrees and
+launch AI coding agents with the correct filesystem
+context — all from a single terminal interface.`

--- a/internal/tui/modal/help.go
+++ b/internal/tui/modal/help.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/version"
 )
 
 type helpTab int
@@ -122,8 +123,11 @@ func (m *HelpModal) View() string {
 	// Tab content (with scrolling applied)
 	lines := strings.Split(m.tabContent(), "\n")
 	start := m.scrollOffset
-	if start > len(lines) {
-		start = len(lines)
+	if maxStart := len(lines) - 1; start > maxStart {
+		start = maxStart
+	}
+	if start < 0 {
+		start = 0
 	}
 	b.WriteString(strings.Join(lines[start:], "\n"))
 
@@ -141,7 +145,7 @@ func (m *HelpModal) tabContent() string {
 	case tabTroubleshooting:
 		return troubleshootingContent
 	case tabAbout:
-		return aboutContent
+		return aboutContent()
 	}
 	return ""
 }
@@ -189,8 +193,8 @@ const tipsContent = `COMMON WORKFLOWS
    itself and resumes when the agent exits.
 
 4. Keep GitHub data fresh
-   Press r to trigger a manual sync. Nexus auto-syncs on
-   startup and at the configured interval (~5 min default).
+   Nexus auto-syncs on startup and at the configured interval
+   (~5 min default). Use Ctrl+N to fetch fresh issue data.
 
 5. Open an issue or PR in the browser
    While in the Issues or PRs view, press g to open the
@@ -228,9 +232,10 @@ Config not loading
   Fix: Check  ~/.nexus/config.toml  for TOML syntax errors.
   Delete or reset the file to restore defaults.`
 
-const aboutContent = `NEXUS — Git Worktree Orchestrator & AI Agent Hub
+func aboutContent() string {
+	return fmt.Sprintf(`NEXUS — Git Worktree Orchestrator & AI Agent Hub
 
-Version:   v1.0.0
+Version:   %s
 Repo:      github.com/m00nk0d3/nexus
 License:   MIT
 
@@ -241,4 +246,5 @@ Built with the Charm.sh ecosystem:
 
 Nexus helps you manage multiple git worktrees and
 launch AI coding agents with the correct filesystem
-context — all from a single terminal interface.`
+context — all from a single terminal interface.`, version.Version)
+}

--- a/internal/tui/modal/help_test.go
+++ b/internal/tui/modal/help_test.go
@@ -1,0 +1,267 @@
+package modal
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHelpModal_StartsOnKeybindingsTab(t *testing.T) {
+	m := NewHelpModal()
+
+	require.NotNil(t, m)
+	assert.Equal(t, tabKeybindings, m.activeTab)
+	assert.Equal(t, 0, m.scrollOffset)
+}
+
+func TestHelpModal_Title_ReturnsNexusHelp(t *testing.T) {
+	m := NewHelpModal()
+
+	assert.Equal(t, "NEXUS HELP", m.Title())
+}
+
+func TestHelpModal_Init_ReturnsNil(t *testing.T) {
+	m := NewHelpModal()
+
+	cmd := m.Init()
+	assert.Nil(t, cmd)
+}
+
+// TestHelpModal_TabSwitching verifies all four tab switching mechanisms.
+func TestHelpModal_TabSwitching(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      tea.KeyMsg
+		startTab helpTab
+		wantTab  helpTab
+	}{
+		{
+			name:     "Tab key advances to next tab",
+			key:      tea.KeyMsg{Type: tea.KeyTab},
+			startTab: tabKeybindings,
+			wantTab:  tabTips,
+		},
+		{
+			name:     "Tab key wraps from About back to Keybindings",
+			key:      tea.KeyMsg{Type: tea.KeyTab},
+			startTab: tabAbout,
+			wantTab:  tabKeybindings,
+		},
+		{
+			name:     "l advances to next tab",
+			key:      tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")},
+			startTab: tabKeybindings,
+			wantTab:  tabTips,
+		},
+		{
+			name:     "h goes to previous tab",
+			key:      tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")},
+			startTab: tabTips,
+			wantTab:  tabKeybindings,
+		},
+		{
+			name:     "h wraps from Keybindings to About",
+			key:      tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("h")},
+			startTab: tabKeybindings,
+			wantTab:  tabAbout,
+		},
+		{
+			name:     "1 selects Keybindings tab",
+			key:      tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("1")},
+			startTab: tabAbout,
+			wantTab:  tabKeybindings,
+		},
+		{
+			name:     "2 selects Tips tab",
+			key:      tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("2")},
+			startTab: tabKeybindings,
+			wantTab:  tabTips,
+		},
+		{
+			name:     "3 selects Troubleshooting tab",
+			key:      tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("3")},
+			startTab: tabKeybindings,
+			wantTab:  tabTroubleshooting,
+		},
+		{
+			name:     "4 selects About tab",
+			key:      tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("4")},
+			startTab: tabKeybindings,
+			wantTab:  tabAbout,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := NewHelpModal()
+			m.activeTab = tc.startTab
+
+			updated, _ := m.Update(tc.key)
+			result, ok := updated.(*HelpModal)
+			require.True(t, ok)
+			assert.Equal(t, tc.wantTab, result.activeTab)
+		})
+	}
+}
+
+// TestHelpModal_EscClosesModal verifies that Esc emits ModalCancelledMsg.
+func TestHelpModal_EscClosesModal(t *testing.T) {
+	m := NewHelpModal()
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, ok := msg.(ModalCancelledMsg)
+	assert.True(t, ok, "expected ModalCancelledMsg, got %T", msg)
+}
+
+func TestHelpModal_QClosesModal(t *testing.T) {
+	m := NewHelpModal()
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, ok := msg.(ModalCancelledMsg)
+	assert.True(t, ok, "expected ModalCancelledMsg, got %T", msg)
+}
+
+func TestHelpModal_TabSwitching_ResetsScrollOffset(t *testing.T) {
+	m := NewHelpModal()
+	m.scrollOffset = 5
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyTab})
+	result, ok := updated.(*HelpModal)
+	require.True(t, ok)
+
+	assert.Equal(t, 0, result.scrollOffset)
+}
+
+func TestHelpModal_JKey_IncreasesScrollOffset(t *testing.T) {
+	m := NewHelpModal()
+	m.scrollOffset = 0
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	result, ok := updated.(*HelpModal)
+	require.True(t, ok)
+
+	assert.Equal(t, 1, result.scrollOffset)
+}
+
+func TestHelpModal_KKey_DecreasesScrollOffset(t *testing.T) {
+	m := NewHelpModal()
+	m.scrollOffset = 3
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	result, ok := updated.(*HelpModal)
+	require.True(t, ok)
+
+	assert.Equal(t, 2, result.scrollOffset)
+}
+
+func TestHelpModal_KKey_DoesNotGoBelowZero(t *testing.T) {
+	m := NewHelpModal()
+	m.scrollOffset = 0
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	result, ok := updated.(*HelpModal)
+	require.True(t, ok)
+
+	assert.Equal(t, 0, result.scrollOffset)
+}
+
+func TestHelpModal_DownArrow_IncreasesScrollOffset(t *testing.T) {
+	m := NewHelpModal()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	result, ok := updated.(*HelpModal)
+	require.True(t, ok)
+
+	assert.Equal(t, 1, result.scrollOffset)
+}
+
+func TestHelpModal_UpArrow_DecreasesScrollOffset(t *testing.T) {
+	m := NewHelpModal()
+	m.scrollOffset = 2
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	result, ok := updated.(*HelpModal)
+	require.True(t, ok)
+
+	assert.Equal(t, 1, result.scrollOffset)
+}
+
+func TestHelpModal_View_ShowsTabHeaders(t *testing.T) {
+	m := NewHelpModal()
+	view := m.View()
+
+	assert.Contains(t, view, "Keybindings")
+	assert.Contains(t, view, "Quick Tips")
+	assert.Contains(t, view, "Troubleshooting")
+	assert.Contains(t, view, "About")
+}
+
+func TestHelpModal_View_KeybindingsTab_ShowsNavigationSection(t *testing.T) {
+	m := NewHelpModal()
+	m.activeTab = tabKeybindings
+	view := m.View()
+
+	assert.Contains(t, view, "NAVIGATION")
+}
+
+func TestHelpModal_View_KeybindingsTab_ShowsWorktreeOpsSection(t *testing.T) {
+	m := NewHelpModal()
+	m.activeTab = tabKeybindings
+	view := m.View()
+
+	assert.Contains(t, view, "WORKTREE")
+}
+
+func TestHelpModal_View_TipsTab_ShowsContent(t *testing.T) {
+	m := NewHelpModal()
+	m.activeTab = tabTips
+	view := m.View()
+
+	assert.True(t, len(view) > 0)
+	assert.Contains(t, strings.ToLower(view), "worktree")
+}
+
+func TestHelpModal_View_TroubleshootingTab_ShowsContent(t *testing.T) {
+	m := NewHelpModal()
+	m.activeTab = tabTroubleshooting
+	view := m.View()
+
+	assert.True(t, len(view) > 0)
+	assert.Contains(t, strings.ToLower(view), "github")
+}
+
+func TestHelpModal_View_AboutTab_ShowsRepoURL(t *testing.T) {
+	m := NewHelpModal()
+	m.activeTab = tabAbout
+	view := m.View()
+
+	assert.Contains(t, view, "github.com/m00nk0d3/nexus")
+}
+
+func TestHelpModal_View_ShowsHelpHint(t *testing.T) {
+	m := NewHelpModal()
+	view := m.View()
+
+	assert.Contains(t, view, "Esc")
+}
+
+func TestHelpModal_NonKeyMsg_DoesNothing(t *testing.T) {
+	m := NewHelpModal()
+	original := m.activeTab
+
+	updated, cmd := m.Update("not a key message")
+	result, ok := updated.(*HelpModal)
+	require.True(t, ok)
+
+	assert.Equal(t, original, result.activeTab)
+	assert.Nil(t, cmd)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+// Version is set at build time via:
+//
+//	go build -ldflags "-X github.com/m00nk0d3/nexus/internal/version.Version=vX.Y.Z" ./...
+var Version = "dev"


### PR DESCRIPTION
Closes #24

## What Changed
Implements a HelpModal Bubbletea model in internal/tui/modal/help.go with four scrollable tabs, and wires f1 / ? keys in app.go to open it from any view.

## Why Changed
Issue #24 requires an in-app help system so users can discover keybindings and workflows without leaving the TUI. Previously there was no help system at all.

## Implementation Details
- Keybindings tab: all shortcuts organised by category (Navigation, Worktree Ops, AI Agents, Views, Global)
- Quick Tips tab: six common workflows including create-from-issue, spawn-agent, theme switching
- Troubleshooting tab: GitHub auth failure, agent not found, git not in PATH, stale worktrees, config errors
- About tab: version, repo URL, MIT license, tech stack credits
- Tab switching: Tab, h/l, or number keys 1-4
- Scrolling: j/k / arrow keys; scroll resets on tab change
- Close: Esc or q emits ModalCancelledMsg{}

## Testing
- 23 unit tests written first (TDD red-green cycle)
- TestHelpModal_TabSwitching: all 9 switching paths (Tab wrap, h/l, 1-4)
- TestHelpModal_EscClosesModal: Esc emits ModalCancelledMsg
- TestHelpModal_QClosesModal: q emits ModalCancelledMsg
- Scroll clamping, view content assertions per tab, non-key passthrough
- Full suite: go test ./... all packages pass