### PR TITLE
[Phase 4] Polish - Error Handling & Structured Logging (slog)

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -494,7 +494,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if msg.exitCode > 1 {
-			m.statusErr = fmt.Sprintf("⚠ Agent exited with code %d", msg.exitCode)
+			exitMsg := fmt.Sprintf("⚠ Agent exited with code %d", msg.exitCode)
+			if m.statusErr != "" {
+				m.statusErr = m.statusErr + "; " + exitMsg
+			} else {
+				m.statusErr = exitMsg
+			}
 		}
 		if m.statusErr != "" {
 			return m, tea.Batch(m.refreshWorktreesCmd(), clearErrorCmd())
@@ -578,7 +583,7 @@ func (m *Model) View() string {
 	}
 
 	if m.statusErr != "" {
-		return renderErrorModal(m.statusErr, w, h)
+		return renderErrorModal(m.statusErr, w, h, baseView)
 	}
 
 	return baseView

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -66,6 +66,16 @@ type aiderFilesFetchedMsg struct {
 	err          error
 }
 
+// clearErrorMsg is dispatched after the 5-second auto-dismiss timer fires.
+type clearErrorMsg struct{}
+
+// clearErrorCmd returns a Cmd that fires clearErrorMsg after 5 seconds.
+func clearErrorCmd() tea.Cmd {
+	return tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
+		return clearErrorMsg{}
+	})
+}
+
 // activeView represents the currently active main panel view.
 type activeView int
 
@@ -93,7 +103,7 @@ type Model struct {
 	Config           *domain.Config       // Loaded application configuration
 	selectedIdx      int                  // Currently selected worktree index
 	activeModal      modal.Modal          // Currently open modal (if any)
-	Error            string               // Error message to display (if any)
+	statusErr        string               // Error message to display (if any)
 	themeIdx         int                  // Index into styles.Themes for the active theme
 	view             activeView           // Currently active main panel view
 	width            int                  // Terminal width in columns; 0 means use default
@@ -139,10 +149,10 @@ func NewModel() *Model {
 	}
 
 	return &Model{
-		Config:   cfg,
-		themeIdx: themeIdx,
-		Error:    configErr,
-		focused:  panelList,
+		Config:    cfg,
+		themeIdx:  themeIdx,
+		statusErr: configErr,
+		focused:   panelList,
 	}
 }
 
@@ -251,7 +261,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		// Dismiss any visible error overlay on the next keypress.
-		m.Error = ""
+		m.statusErr = ""
 		switch msg.Type {
 		case tea.KeyTab:
 			m.focused = (m.focused + 1) % panelCount
@@ -267,8 +277,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Guard: if any existing worktree already uses this branch, show an error.
 				for _, wt := range m.Worktrees {
 					if wt.Branch == pr.Branch {
-						m.Error = fmt.Sprintf("Worktree for branch %q already exists at %s", pr.Branch, wt.Path)
-						return m, nil
+						m.statusErr = fmt.Sprintf("Worktree for branch %q already exists at %s", pr.Branch, wt.Path)
+						return m, clearErrorCmd()
 					}
 				}
 				m.activeModal = modal.NewPRCheckoutModal(pr, path)
@@ -298,30 +308,30 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.moveDown()
 		case tea.KeySpace:
 			if m.view != viewWorktrees {
-				m.Error = "Agent launcher is only available in the Worktrees view — press w to switch"
-				return m, nil
+				m.statusErr = "Agent launcher is only available in the Worktrees view — press w to switch"
+				return m, clearErrorCmd()
 			}
 			if selected, ok := m.selectedWorktree(); ok {
 				m.activeModal = modal.NewAgentLauncherModal(m.Config, selected.Path)
-			} else {
-				m.Error = "No worktree selected — select one first"
+				return m, nil
 			}
-			return m, nil
+			m.statusErr = "No worktree selected — select one first"
+			return m, clearErrorCmd()
 		case tea.KeyRunes:
 			switch msg.String() {
 			case " ":
 				// Spacebar can arrive as KeyRunes " " on some terminals (e.g. Windows).
 				// Mirror the KeySpace handler above.
 				if m.view != viewWorktrees {
-					m.Error = "Agent launcher is only available in the Worktrees view — press w to switch"
-					return m, nil
+					m.statusErr = "Agent launcher is only available in the Worktrees view — press w to switch"
+					return m, clearErrorCmd()
 				}
 				if selected, ok := m.selectedWorktree(); ok {
 					m.activeModal = modal.NewAgentLauncherModal(m.Config, selected.Path)
-				} else {
-					m.Error = "No worktree selected — select one first"
+					return m, nil
 				}
-				return m, nil
+				m.statusErr = "No worktree selected — select one first"
+				return m, clearErrorCmd()
 			case "?":
 				m.activeModal = modal.NewHelpModal()
 				return m, nil
@@ -352,20 +362,20 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			case "c", "C":
 				if m.view != viewWorktrees {
-					m.Error = "Copilot (c) is only available in the Worktrees view — press w to switch"
-					return m, nil
+					m.statusErr = "Copilot (c) is only available in the Worktrees view — press w to switch"
+					return m, clearErrorCmd()
 				}
 				if !m.Config.AIAgents.CopilotEnabled {
-					m.Error = "Copilot is disabled — set copilot_enabled = true in ~/.nexus/config.toml"
-					return m, nil
+					m.statusErr = "Copilot is disabled — set copilot_enabled = true in ~/.nexus/config.toml"
+					return m, clearErrorCmd()
 				}
 				if _, ok := m.selectedWorktree(); !ok {
-					m.Error = "No worktree selected — select one first"
-					return m, nil
+					m.statusErr = "No worktree selected — select one first"
+					return m, clearErrorCmd()
 				}
 				if _, err := exec.LookPath("gh"); err != nil {
-					m.Error = "gh not found on $PATH — install GitHub CLI to use Copilot"
-					return m, nil
+					m.statusErr = "gh not found on $PATH — install GitHub CLI to use Copilot"
+					return m, clearErrorCmd()
 				}
 				ti := textinput.New()
 				ti.Placeholder = "Enter Copilot prompt…"
@@ -375,20 +385,20 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, focusCmd
 			case "a", "A":
 				if m.view != viewWorktrees {
-					m.Error = "Claude (a) is only available in the Worktrees view — press w to switch"
-					return m, nil
+					m.statusErr = "Claude (a) is only available in the Worktrees view — press w to switch"
+					return m, clearErrorCmd()
 				}
 				if !m.Config.AIAgents.ClaudeEnabled {
-					m.Error = "Claude is disabled — set claude_enabled = true in ~/.nexus/config.toml"
-					return m, nil
+					m.statusErr = "Claude is disabled — set claude_enabled = true in ~/.nexus/config.toml"
+					return m, clearErrorCmd()
 				}
 				if _, ok := m.selectedWorktree(); !ok {
-					m.Error = "No worktree selected — select one first"
-					return m, nil
+					m.statusErr = "No worktree selected — select one first"
+					return m, clearErrorCmd()
 				}
 				if _, err := resolveClaudeBinary(m.Config); err != nil {
-					m.Error = fmt.Sprintf("claude binary not found: %v", err)
-					return m, nil
+					m.statusErr = fmt.Sprintf("claude binary not found: %v", err)
+					return m, clearErrorCmd()
 				}
 				ti := textinput.New()
 				ti.Placeholder = "Enter Claude prompt…"
@@ -398,21 +408,21 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, focusCmd
 			case "f", "F":
 				if m.view != viewWorktrees {
-					m.Error = "Aider (f) is only available in the Worktrees view — press w to switch"
-					return m, nil
+					m.statusErr = "Aider (f) is only available in the Worktrees view — press w to switch"
+					return m, clearErrorCmd()
 				}
 				if !m.Config.AIAgents.AiderEnabled {
-					m.Error = "Aider is disabled — set aider_enabled = true in ~/.nexus/config.toml"
-					return m, nil
+					m.statusErr = "Aider is disabled — set aider_enabled = true in ~/.nexus/config.toml"
+					return m, clearErrorCmd()
 				}
 				selected, ok := m.selectedWorktree()
 				if !ok {
-					m.Error = "No worktree selected — select one first"
-					return m, nil
+					m.statusErr = "No worktree selected — select one first"
+					return m, clearErrorCmd()
 				}
 				if _, err := resolveAiderBinary(m.Config); err != nil {
-					m.Error = "aider not found on $PATH — install Aider to use this feature"
-					return m, nil
+					m.statusErr = "aider not found on $PATH — install Aider to use this feature"
+					return m, clearErrorCmd()
 				}
 				return m, m.fetchAiderFilesCmd(selected.Path)
 			}
@@ -425,22 +435,27 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case aiderFilesFetchedMsg:
 		if msg.err != nil {
-			m.Error = fmt.Sprintf("Failed to list files: %v", msg.err)
-			return m, nil
+			m.statusErr = fmt.Sprintf("Failed to list files: %v", msg.err)
+			return m, clearErrorCmd()
 		}
 		m.activeModal = modal.NewAiderFilePicker(msg.files)
 		return m, nil
 
 	case worktreeOpDoneMsg:
 		// Refresh the worktree list after an add/remove operation.
+		// Surface any git error via the status error modal.
+		if msg.err != nil {
+			m.statusErr = fmt.Sprintf("Git operation failed: %v", msg.err)
+			return m, tea.Batch(m.refreshWorktreesCmd(), clearErrorCmd())
+		}
 		return m, m.refreshWorktreesCmd()
 
 	case worktreeSwitchedMsg:
 		if msg.err != nil {
-			m.Error = fmt.Sprintf("Failed to switch worktree: %v", msg.err)
-			return m, nil
+			m.statusErr = fmt.Sprintf("Failed to switch worktree: %v", msg.err)
+			return m, clearErrorCmd()
 		}
-		m.Error = ""
+		m.statusErr = ""
 		// Refresh worktrees after switching back
 		return m, m.refreshWorktreesCmd()
 
@@ -457,7 +472,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case browserOpenErrMsg:
 		if msg.err != nil {
-			m.Error = fmt.Sprintf("Failed to open in browser: %v", msg.err)
+			m.statusErr = fmt.Sprintf("Failed to open in browser: %v", msg.err)
+			return m, clearErrorCmd()
 		}
 
 	case agentDoneMsg:
@@ -474,17 +490,23 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				EndedAt:   time.Now(),
 			}
 			if err := data.LogAgentRun(m.db, entry); err != nil {
-				m.Error = fmt.Sprintf("failed to log agent run: %v", err)
+				m.statusErr = fmt.Sprintf("failed to log agent run: %v", err)
 			}
 		}
 		if msg.exitCode > 1 {
-			m.Error = fmt.Sprintf("⚠ Agent exited with code %d", msg.exitCode)
+			m.statusErr = fmt.Sprintf("⚠ Agent exited with code %d", msg.exitCode)
+		}
+		if m.statusErr != "" {
+			return m, tea.Batch(m.refreshWorktreesCmd(), clearErrorCmd())
 		}
 		return m, m.refreshWorktreesCmd()
 
 	case githubSyncedMsg:
 		m.syncing = false
 		m.syncErr = msg.err
+		if msg.err != nil {
+			m.statusErr = fmt.Sprintf("GitHub sync failed: %v", msg.err)
+		}
 		if msg.err == nil {
 			m.prs = msg.prs
 			m.issues = msg.issues
@@ -496,9 +518,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// On error, m.prs and m.issues intentionally retain their previous values
 		// so the UI continues to show the last known good data.
 		// Schedule next periodic sync tick.
-		return m, tea.Tick(m.Config.GitHub.SyncInterval(), func(t time.Time) tea.Msg {
+		nextTick := tea.Tick(m.Config.GitHub.SyncInterval(), func(t time.Time) tea.Msg {
 			return syncTickMsg{}
 		})
+		if msg.err != nil {
+			return m, tea.Batch(nextTick, clearErrorCmd())
+		}
+		return m, nextTick
+
+	case clearErrorMsg:
+		m.statusErr = ""
 
 	case syncTickMsg:
 		m.syncing = true
@@ -548,8 +577,8 @@ func (m *Model) View() string {
 			fmt.Sprintf("> %s\n\nEnter confirm (prompt optional)  •  Esc cancel", m.claudePromptInput.View()))
 	}
 
-	if m.Error != "" {
-		return overlay("⚠ Error", m.Error+"\n\nPress any key to dismiss")
+	if m.statusErr != "" {
+		return renderErrorModal(m.statusErr, w, h)
 	}
 
 	return baseView
@@ -721,8 +750,8 @@ func buildClaudeCmd(worktreePath, prompt, binaryPath string) *exec.Cmd {
 func (m *Model) spawnClaudeCmd(worktreePath, prompt string) tea.Cmd {
 	binaryPath, err := resolveClaudeBinary(m.Config)
 	if err != nil {
-		m.Error = fmt.Sprintf("claude binary not found: %v", err)
-		return nil
+		m.statusErr = fmt.Sprintf("claude binary not found: %v", err)
+		return clearErrorCmd()
 	}
 	startedAt := time.Now()
 	cmd := buildClaudeCmd(worktreePath, prompt, binaryPath)
@@ -764,8 +793,8 @@ func buildAiderCmd(worktreePath string, files []string, binaryPath string) *exec
 func (m *Model) spawnAiderCmd(worktreePath string, files []string) tea.Cmd {
 	binaryPath, err := resolveAiderBinary(m.Config)
 	if err != nil {
-		m.Error = fmt.Sprintf("aider not found: %v", err)
-		return nil
+		m.statusErr = fmt.Sprintf("aider not found: %v", err)
+		return clearErrorCmd()
 	}
 	startedAt := time.Now()
 	cmd := buildAiderCmd(worktreePath, files, binaryPath)

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -505,11 +505,11 @@ func TestModelView_ShowsErrorMessage(t *testing.T) {
 	model.statusErr = "Failed to switch worktree: boom"
 
 	view := model.View()
-	// Error is rendered as a bottom-right modal box.
+	// Error content is present in the overlay.
 	assert.Contains(t, view, "Failed to switch worktree: boom")
 	assert.Contains(t, view, "Press any key to dismiss")
-	// Base view is replaced by the modal — the TUI chrome should not be visible.
-	assert.NotContains(t, view, "GIT WORKTREE ORCHESTRATOR")
+	// Base view remains visible underneath the overlay modal.
+	assert.Contains(t, view, "GIT WORKTREE ORCHESTRATOR")
 }
 
 func TestModel_T_KeyCyclesTheme(t *testing.T) {

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -398,7 +398,7 @@ func TestModelUpdate_WorktreeSwitchedMsg_ErrorHandling(t *testing.T) {
 			name:         "sets model error when switch fails",
 			msg:          worktreeSwitchedMsg{err: errors.New("switch failed")},
 			wantError:    "Failed to switch worktree: switch failed",
-			wantCmdIsNil: true,
+			wantCmdIsNil: false,
 		},
 	}
 
@@ -410,9 +410,11 @@ func TestModelUpdate_WorktreeSwitchedMsg_ErrorHandling(t *testing.T) {
 			updated, cmd := model.Update(tt.msg)
 			updatedModel, ok := updated.(*Model)
 			require.True(t, ok)
-			assert.Equal(t, tt.wantError, updatedModel.Error)
+			assert.Equal(t, tt.wantError, updatedModel.statusErr)
 			if tt.wantCmdIsNil {
 				assert.Nil(t, cmd)
+			} else {
+				assert.NotNil(t, cmd)
 			}
 		})
 	}
@@ -500,13 +502,13 @@ func TestModelUpdate_WorktreesRefreshedMsg_ClampsSelectedIndex(t *testing.T) {
 func TestModelView_ShowsErrorMessage(t *testing.T) {
 	model := NewModel()
 	require.NotNil(t, model)
-	model.Error = "Failed to switch worktree: boom"
+	model.statusErr = "Failed to switch worktree: boom"
 
 	view := model.View()
-	// Error is rendered as a centered overlay box, not prepended to the base view.
+	// Error is rendered as a bottom-right modal box.
 	assert.Contains(t, view, "Failed to switch worktree: boom")
 	assert.Contains(t, view, "Press any key to dismiss")
-	// Base view is replaced by the overlay — the TUI chrome should not be visible.
+	// Base view is replaced by the modal — the TUI chrome should not be visible.
 	assert.NotContains(t, view, "GIT WORKTREE ORCHESTRATOR")
 }
 
@@ -990,8 +992,8 @@ func TestModel_BrowserOpenErrMsg_SetsError(t *testing.T) {
 	m, ok := updated.(*Model)
 	require.True(t, ok)
 
-	assert.Contains(t, m.Error, "Failed to open in browser")
-	assert.Contains(t, m.Error, "gh: not found")
+	assert.Contains(t, m.statusErr, "Failed to open in browser")
+	assert.Contains(t, m.statusErr, "gh: not found")
 }
 
 // TestModel_BrowserOpenErrMsg_NilErrorNoChange verifies that a nil-error
@@ -1004,7 +1006,7 @@ func TestModel_BrowserOpenErrMsg_NilErrorNoChange(t *testing.T) {
 	m, ok := updated.(*Model)
 	require.True(t, ok)
 
-	assert.Empty(t, m.Error)
+	assert.Empty(t, m.statusErr)
 }
 
 // ---------------------------------------------------------------------------
@@ -1298,7 +1300,7 @@ func TestModel_C_Key_TriggersCopilotPrompt(t *testing.T) {
 
 			assert.False(t, updatedModel.copilotPromptActive,
 				"copilotPromptActive should be false")
-			assert.NotEmpty(t, updatedModel.Error, "should show an error message to the user")
+			assert.NotEmpty(t, updatedModel.statusErr, "should show an error message to the user")
 		})
 	}
 
@@ -1339,7 +1341,7 @@ func TestModel_C_Key_TriggersCopilotPrompt(t *testing.T) {
 
 		assert.False(t, updatedModel.copilotPromptActive,
 			"copilotPromptActive should stay false when not in worktrees view")
-		assert.NotEmpty(t, updatedModel.Error, "should show an error message when not in worktrees view")
+		assert.NotEmpty(t, updatedModel.statusErr, "should show an error message when not in worktrees view")
 	})
 }
 
@@ -1483,7 +1485,7 @@ func TestModel_AgentDoneMsg_LogsToDBWhenAvailable(t *testing.T) {
 	require.True(t, ok)
 
 	// No error should be set on the model.
-	assert.Empty(t, updatedModel.Error, "DB log should not set an error on success")
+	assert.Empty(t, updatedModel.statusErr, "DB log should not set an error on success")
 
 	// Verify the row was actually written.
 	var count int
@@ -1626,7 +1628,7 @@ func TestModel_A_Key_TriggersClaude(t *testing.T) {
 
 			assert.False(t, updatedModel.claudePromptActive,
 				"claudePromptActive should be false")
-			assert.NotEmpty(t, updatedModel.Error, "should show an error message to the user")
+			assert.NotEmpty(t, updatedModel.statusErr, "should show an error message to the user")
 		})
 	}
 
@@ -1666,7 +1668,7 @@ func TestModel_A_Key_TriggersClaude(t *testing.T) {
 
 		assert.False(t, updatedModel.claudePromptActive,
 			"claudePromptActive should stay false when not in worktrees view")
-		assert.NotEmpty(t, updatedModel.Error, "should show an error message when not in worktrees view")
+		assert.NotEmpty(t, updatedModel.statusErr, "should show an error message when not in worktrees view")
 	})
 }
 
@@ -1779,8 +1781,8 @@ func TestModel_A_Key_BinaryNotFound_SetsError(t *testing.T) {
 
 	assert.False(t, updatedModel.claudePromptActive,
 		"prompt should not open when binary is not found")
-	assert.Nil(t, cmd, "no cmd should be returned when binary is missing")
-	assert.Contains(t, updatedModel.Error, "claude binary not found",
+	assert.NotNil(t, cmd, "clearErrorCmd should be returned when binary is missing")
+	assert.Contains(t, updatedModel.statusErr, "claude binary not found",
 		"error should mention the missing binary")
 }
 
@@ -1862,9 +1864,9 @@ func TestModel_Enter_InViewPRs_WorktreeExists_SetsError(t *testing.T) {
 	updatedModel, ok := updated.(*Model)
 	require.True(t, ok)
 
-	assert.Nil(t, cmd, "no cmd when error shown")
+	assert.NotNil(t, cmd, "clearErrorCmd should be returned")
 	assert.Nil(t, updatedModel.activeModal, "no modal should be opened")
-	assert.Contains(t, updatedModel.Error, "feat/issue-1-my-pr", "error should mention the branch")
+	assert.Contains(t, updatedModel.statusErr, "feat/issue-1-my-pr", "error should mention the branch")
 }
 
 // TestModel_Enter_InViewPRs_EmptyList_NoOp verifies that pressing Enter in the PR
@@ -1946,15 +1948,15 @@ func TestBuildAiderCmd_PassesSelectedFiles(t *testing.T) {
 }
 
 // TestSpawnAiderCmd_BinaryNotFound_ReturnsNilCmd verifies that spawnAiderCmd
-// returns nil and sets m.Error when the configured aider binary is not found.
+// returns a clearErrorCmd and sets statusErr when the configured aider binary is not found.
 func TestSpawnAiderCmd_BinaryNotFound_ReturnsNilCmd(t *testing.T) {
 	model := NewModel()
 	model.Config.AIAgents.AiderBinary = "definitely-not-a-real-binary-xyz-12345"
 
 	cmd := model.spawnAiderCmd("/tmp/my-wt", []string{"main.go"})
 
-	assert.Nil(t, cmd, "spawnAiderCmd must return nil when binary is not found")
-	assert.Contains(t, model.Error, "aider not found")
+	assert.NotNil(t, cmd, "spawnAiderCmd must return clearErrorCmd when binary is not found")
+	assert.Contains(t, model.statusErr, "aider not found")
 }
 
 // TestResolveAiderBinary_DefaultsToAider verifies that an empty AiderBinary
@@ -1996,8 +1998,8 @@ func TestModel_F_Key_AiderDisabled_SetsError(t *testing.T) {
 	updatedModel, ok := updated.(*Model)
 	require.True(t, ok)
 
-	assert.Nil(t, cmd)
-	assert.Contains(t, updatedModel.Error, "aider_enabled")
+	assert.NotNil(t, cmd, "clearErrorCmd should be returned when aider is disabled")
+	assert.Contains(t, updatedModel.statusErr, "aider_enabled")
 }
 
 // TestModel_F_Key_NoWorktree_SetsError verifies that pressing 'f' with
@@ -2012,8 +2014,8 @@ func TestModel_F_Key_NoWorktree_SetsError(t *testing.T) {
 	updatedModel, ok := updated.(*Model)
 	require.True(t, ok)
 
-	assert.Nil(t, cmd)
-	assert.NotEmpty(t, updatedModel.Error)
+	assert.NotNil(t, cmd, "clearErrorCmd should be returned when no worktree selected")
+	assert.NotEmpty(t, updatedModel.statusErr)
 }
 
 // TestModel_F_Key_WrongView_SetsError verifies that pressing 'f' in a non-worktrees
@@ -2030,8 +2032,8 @@ func TestModel_F_Key_WrongView_SetsError(t *testing.T) {
 	updatedModel, ok := updated.(*Model)
 	require.True(t, ok)
 
-	assert.Nil(t, cmd)
-	assert.Contains(t, updatedModel.Error, "Worktrees view")
+	assert.NotNil(t, cmd, "clearErrorCmd should be returned when in wrong view")
+	assert.Contains(t, updatedModel.statusErr, "Worktrees view")
 }
 
 // TestModel_AiderFilesFetchedMsg_OpensModal verifies that receiving a successful
@@ -2066,9 +2068,9 @@ func TestModel_AiderFilesFetchedMsg_ErrorSetsError(t *testing.T) {
 	m, ok := updated.(*Model)
 	require.True(t, ok)
 
-	assert.Nil(t, cmd)
+	assert.NotNil(t, cmd, "clearErrorCmd should be returned on file fetch error")
 	assert.Nil(t, m.activeModal)
-	assert.Contains(t, m.Error, "Failed to list files")
+	assert.Contains(t, m.statusErr, "Failed to list files")
 }
 
 // TestModel_F_Key_AiderNotOnPath_SetsError verifies that pressing 'f' when
@@ -2086,8 +2088,8 @@ func TestModel_F_Key_AiderNotOnPath_SetsError(t *testing.T) {
 	updatedModel, ok := updated.(*Model)
 	require.True(t, ok)
 
-	assert.Nil(t, cmd)
-	assert.Contains(t, updatedModel.Error, "aider not found",
+	assert.NotNil(t, cmd, "clearErrorCmd should be returned when aider binary is missing")
+	assert.Contains(t, updatedModel.statusErr, "aider not found",
 		"error should mention that the aider binary is missing")
 }
 
@@ -2111,7 +2113,7 @@ func TestModel_SpaceKey_InWorktreeView_WithSelection_OpensAgentLauncher(t *testi
 
 	assert.NotNil(t, next.activeModal, "should open the agent launcher modal")
 	assert.Nil(t, cmd, "no async command needed to open the launcher")
-	assert.Empty(t, next.Error, "no error should be set")
+	assert.Empty(t, next.statusErr, "no error should be set")
 }
 
 // TestModel_SpaceKey_InWorktreeView_NoSelection_SetsError verifies that pressing
@@ -2126,7 +2128,7 @@ func TestModel_SpaceKey_InWorktreeView_NoSelection_SetsError(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Nil(t, next.activeModal, "no modal should open when nothing is selected")
-	assert.Contains(t, next.Error, "No worktree selected")
+	assert.Contains(t, next.statusErr, "No worktree selected")
 }
 
 // TestModel_SpaceKey_NotInWorktreeView_SetsError verifies that pressing [space]
@@ -2140,7 +2142,7 @@ func TestModel_SpaceKey_NotInWorktreeView_SetsError(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Nil(t, next.activeModal, "no modal should open in issues view")
-	assert.Contains(t, next.Error, "Worktrees view")
+	assert.Contains(t, next.statusErr, "Worktrees view")
 }
 
 // TestModel_SpawnAgentMsg_Copilot_ClearsModalAndReturnsCmd verifies that
@@ -2198,7 +2200,7 @@ func TestModel_SpawnAgentMsg_Aider_ClearsModalAndFetchesFiles(t *testing.T) {
 
 	assert.Nil(t, next.activeModal, "modal must be cleared after SpawnAgentMsg")
 	assert.NotNil(t, cmd, "aider should return a fetchAiderFilesCmd")
-	assert.Empty(t, next.Error, "no error should be set when aider is triggered")
+	assert.Empty(t, next.statusErr, "no error should be set when aider is triggered")
 }
 
 // ---------------------------------------------------------------------------
@@ -2248,8 +2250,8 @@ func TestAgentDoneMsg_NonZeroExit_ShowsErrorInStatusBar(t *testing.T) {
 			m, ok := updated.(*Model)
 			require.True(t, ok)
 
-			assert.Equal(t, tt.wantError, m.Error,
-				"Error field should match expected warning for exit code %d", tt.exitCode)
+			assert.Equal(t, tt.wantError, m.statusErr,
+				"statusErr field should match expected warning for exit code %d", tt.exitCode)
 			// agentDoneMsg must always trigger a worktree refresh.
 			assert.NotNil(t, cmd, "agentDoneMsg must return a refreshWorktreesCmd")
 		})
@@ -2269,4 +2271,49 @@ func TestAgentDoneMsg_ZeroExit_TriggersRefresh(t *testing.T) {
 	})
 
 	assert.NotNil(t, cmd, "zero-exit agentDoneMsg must still return a refreshWorktreesCmd")
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: Error handling & structured logging tests
+// ---------------------------------------------------------------------------
+
+// TestModel_GitError_ShowsErrorModal verifies that a worktreeOpDoneMsg with an error
+// sets the statusErr field and triggers the error modal.
+func TestModel_GitError_ShowsErrorModal(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+
+	updated, cmd := m.Update(worktreeOpDoneMsg{err: errors.New("git failed")})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Contains(t, updatedModel.statusErr, "git failed",
+		"statusErr should contain the error message")
+	assert.NotNil(t, cmd, "should return a cmd (refresh + clear timer)")
+}
+
+// TestModel_ErrorModalDismissesOnKeypress verifies that any keypress clears the statusErr.
+func TestModel_ErrorModalDismissesOnKeypress(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+	m.statusErr = "some error"
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Empty(t, updatedModel.statusErr, "keypress should clear statusErr")
+}
+
+// TestModel_ErrorModalClearsAfter5s verifies that clearErrorMsg clears the statusErr field.
+func TestModel_ErrorModalClearsAfter5s(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+	m.statusErr = "some error"
+
+	updated, _ := m.Update(clearErrorMsg{})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Empty(t, updatedModel.statusErr, "clearErrorMsg should clear statusErr")
 }

--- a/cmd/nexus/main.go
+++ b/cmd/nexus/main.go
@@ -12,25 +12,17 @@ import (
 	"github.com/m00nk0d3/nexus/internal/logging"
 )
 
-// defaultLogPath returns the default path for the application log file.
-// It falls back to a relative path if the user home directory cannot be determined.
-func defaultLogPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(".", ".nexus", "logs", "nexus.log")
-	}
-	return filepath.Join(home, ".nexus", "logs", "nexus.log")
-}
-
 func run() error {
 	// Initialise structured logger; non-fatal if it fails (falls back to discard).
-	logger, logCloser, err := logging.InitLogger(defaultLogPath())
+	// Sets it as the slog default so any log.slog.Info/Warn/Error calls in the
+	// codebase are automatically routed to the log file.
+	logger, logCloser, err := logging.InitLogger(logging.DefaultLogPath())
 	if err != nil {
 		logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
 	} else {
 		defer logCloser.Close()
 	}
-	_ = logger // will be wired into model/commands in future phases
+	slog.SetDefault(logger)
 
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/cmd/nexus/main.go
+++ b/cmd/nexus/main.go
@@ -2,14 +2,36 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/m00nk0d3/nexus/internal/data"
+	"github.com/m00nk0d3/nexus/internal/logging"
 )
 
+// defaultLogPath returns the default path for the application log file.
+// It falls back to a relative path if the user home directory cannot be determined.
+func defaultLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".nexus", "logs", "nexus.log")
+	}
+	return filepath.Join(home, ".nexus", "logs", "nexus.log")
+}
+
 func run() error {
+	// Initialise structured logger; non-fatal if it fails (falls back to discard).
+	logger, logCloser, err := logging.InitLogger(defaultLogPath())
+	if err != nil {
+		logger = slog.New(slog.NewJSONHandler(io.Discard, nil))
+	} else {
+		defer logCloser.Close()
+	}
+	_ = logger // will be wired into model/commands in future phases
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 	"github.com/m00nk0d3/nexus/internal/domain"
 	"github.com/m00nk0d3/nexus/internal/tui/styles"
@@ -680,8 +681,9 @@ func formatLabels(labels []string) string {
 }
 
 // renderErrorModal renders a floating error notification box anchored to the
-// bottom-right corner of the terminal viewport.
-func renderErrorModal(msg string, termWidth, termHeight int) string {
+// bottom-right corner of the terminal viewport, overlaid on top of the base view
+// so the user retains context while the error is displayed.
+func renderErrorModal(msg string, termWidth, termHeight int, baseView string) string {
 	if termWidth <= 0 {
 		termWidth = defaultTermWidth
 	}
@@ -689,12 +691,62 @@ func renderErrorModal(msg string, termWidth, termHeight int) string {
 		termHeight = 24
 	}
 
-	content := lipgloss.NewStyle().
+	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("#FF0000")).
 		Padding(0, 1).
 		MaxWidth(60).
 		Render("✗ " + msg + "\n\nPress any key to dismiss  •  Auto-dismisses in 5s")
 
-	return lipgloss.Place(termWidth, termHeight, lipgloss.Right, lipgloss.Bottom, content)
+	return overlayBottomRight(baseView, box, termWidth)
+}
+
+// overlayBottomRight places the overlay string at the bottom-right corner of the
+// base string. ANSI escape codes in both strings are handled correctly via
+// charmbracelet/x/ansi. base is assumed to be a multi-line string filling the
+// terminal; lines shorter than required are padded with spaces.
+func overlayBottomRight(base, overlay string, termWidth int) string {
+	baseLines := strings.Split(base, "\n")
+	overlayLines := strings.Split(overlay, "\n")
+
+	// Visual width of the overlay block.
+	ow := 0
+	for _, l := range overlayLines {
+		if w := lipgloss.Width(l); w > ow {
+			ow = w
+		}
+	}
+
+	// First base line that the overlay occupies.
+	startLine := len(baseLines) - len(overlayLines)
+	if startLine < 0 {
+		startLine = 0
+	}
+
+	// Horizontal start column for the overlay (right-aligned).
+	startCol := termWidth - ow
+	if startCol < 0 {
+		startCol = 0
+	}
+
+	result := make([]string, len(baseLines))
+	copy(result, baseLines)
+
+	for i, ol := range overlayLines {
+		idx := startLine + i
+		if idx >= len(result) {
+			break
+		}
+		bl := result[idx]
+		bw := lipgloss.Width(bl)
+		switch {
+		case bw < startCol:
+			bl += strings.Repeat(" ", startCol-bw)
+		case bw > startCol:
+			bl = ansi.Truncate(bl, startCol, "")
+		}
+		result[idx] = bl + ol
+	}
+
+	return strings.Join(result, "\n")
 }

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -679,3 +679,22 @@ func formatLabels(labels []string) string {
 	return strings.Join(strs, "")
 }
 
+// renderErrorModal renders a floating error notification box anchored to the
+// bottom-right corner of the terminal viewport.
+func renderErrorModal(msg string, termWidth, termHeight int) string {
+	if termWidth <= 0 {
+		termWidth = defaultTermWidth
+	}
+	if termHeight <= 0 {
+		termHeight = 24
+	}
+
+	content := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("#FF0000")).
+		Padding(0, 1).
+		MaxWidth(60).
+		Render("✗ " + msg + "\n\nPress any key to dismiss  •  Auto-dismisses in 5s")
+
+	return lipgloss.Place(termWidth, termHeight, lipgloss.Right, lipgloss.Bottom, content)
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,0 +1,49 @@
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+const maxLogSize = 10 * 1024 * 1024 // 10MB
+
+// InitLogger initialises a JSON slog.Logger that appends to path.
+// The parent directory is created if it does not exist.
+// If the log file exceeds maxLogSize, it is rotated first.
+// The caller is responsible for closing the returned io.Closer when done.
+func InitLogger(path string) (*slog.Logger, io.Closer, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, nil, fmt.Errorf("create log dir: %w", err)
+	}
+	if err := RotateIfNeeded(path); err != nil {
+		return nil, nil, fmt.Errorf("rotate log: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open log file: %w", err)
+	}
+	handler := slog.NewJSONHandler(f, &slog.HandlerOptions{Level: slog.LevelInfo})
+	return slog.New(handler), f, nil
+}
+
+// RotateIfNeeded renames path to path+".1" when the file size exceeds maxLogSize.
+// It is a no-op when the file does not exist.
+func RotateIfNeeded(path string) error {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stat log file: %w", err)
+	}
+	if info.Size() < maxLogSize {
+		return nil
+	}
+	rotated := path + ".1"
+	// Remove old rotated file if it exists.
+	_ = os.Remove(rotated)
+	return os.Rename(path, rotated)
+}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -29,8 +29,20 @@ func InitLogger(path string) (*slog.Logger, io.Closer, error) {
 	return slog.New(handler), f, nil
 }
 
+// DefaultLogPath returns the canonical path for the application log file.
+// It falls back to a relative path when the user home directory cannot be determined.
+func DefaultLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".nexus", "logs", "nexus.log")
+	}
+	return filepath.Join(home, ".nexus", "logs", "nexus.log")
+}
+
 // RotateIfNeeded renames path to path+".1" when the file size exceeds maxLogSize.
 // It is a no-op when the file does not exist.
+// Only a single backup (.log.1) is kept; the previous .log.1 is overwritten on
+// each rotation.
 func RotateIfNeeded(path string) error {
 	info, err := os.Stat(path)
 	if os.IsNotExist(err) {

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,97 @@
+package logging_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/m00nk0d3/nexus/internal/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogger_WritesToFile(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "nexus.log")
+
+	logger, closer, err := logging.InitLogger(logPath)
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	logger.Info("test message", "key", "value")
+
+	content, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	assert.True(t, strings.Contains(string(content), "test message"),
+		"log file should contain the written message")
+	assert.True(t, strings.Contains(string(content), `"key":"value"`),
+		"log file should contain structured fields")
+}
+
+func TestLogger_CreatesParentDirectories(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "subdir", "nested", "nexus.log")
+
+	logger, closer, err := logging.InitLogger(logPath)
+	require.NoError(t, err)
+	require.NotNil(t, logger)
+	t.Cleanup(func() { _ = closer.Close() })
+
+	_, err = os.Stat(logPath)
+	assert.NoError(t, err, "log file should be created")
+}
+
+func TestLogger_RotatesAt10MB(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "nexus.log")
+
+	// Write > 10MB to the log file
+	bigData := make([]byte, 11*1024*1024)
+	for i := range bigData {
+		bigData[i] = 'x'
+	}
+	err := os.WriteFile(logPath, bigData, 0o644)
+	require.NoError(t, err)
+
+	err = logging.RotateIfNeeded(logPath)
+	require.NoError(t, err)
+
+	// Original file should be renamed to nexus.log.1
+	_, err = os.Stat(logPath + ".1")
+	assert.NoError(t, err, "rotated file should exist at nexus.log.1")
+
+	// Original path should no longer exist
+	_, err = os.Stat(logPath)
+	assert.True(t, os.IsNotExist(err), "original log file should be removed after rotation")
+}
+
+func TestLogger_NoRotateUnder10MB(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "nexus.log")
+
+	// Write < 10MB
+	smallData := []byte("small log content")
+	err := os.WriteFile(logPath, smallData, 0o644)
+	require.NoError(t, err)
+
+	err = logging.RotateIfNeeded(logPath)
+	require.NoError(t, err)
+
+	// File should still exist at original path
+	_, err = os.Stat(logPath)
+	assert.NoError(t, err, "small log file should not be rotated")
+
+	// .1 file should NOT exist
+	_, err = os.Stat(logPath + ".1")
+	assert.True(t, os.IsNotExist(err), "rotated file should not exist for small log")
+}
+
+func TestLogger_NonExistentFile_NoRotationNeeded(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "nonexistent.log")
+
+	err := logging.RotateIfNeeded(logPath)
+	assert.NoError(t, err, "should handle non-existent file gracefully")
+}


### PR DESCRIPTION
Closes #23

## What Changed
Implements phase 4 polish: bottom-right floating error modal with auto-dismiss and structured JSON logging via stdlib log/slog.

## Why Changed
Users had zero visibility into why operations fail. Errors were propagated via Go error values but never surfaced in the TUI, and no logging existed anywhere in the codebase.

## Key Changes

### Error Modal (bottom-right corner)
- Renamed Model.Error string to Model.statusErr string (unexported) throughout app.go
- Added clearErrorMsg type and clearErrorCmd() using tea.Tick(5s)
- All error-setting paths now return clearErrorCmd() for 5-second auto-dismiss
- Any keypress clears statusErr immediately
- Added renderErrorModal() in renderer.go: red rounded-border box anchored to bottom-right
- Surfaced previously-silent errors: worktreeOpDoneMsg.err, githubSyncedMsg.err

### Structured Logging
- New internal/logging/logger.go: InitLogger(path) (JSON slog, append mode) + RotateIfNeeded (rename to .log.1 when >10MB)
- Logger initialised in main.go before bubbletea starts; falls back to io.Discard on failure
- Log path: ~/.nexus/logs/nexus.log

## Testing
- 3 new app tests: TestModel_GitError_ShowsErrorModal, TestModel_ErrorModalClearsAfter5s, TestModel_ErrorModalDismissesOnKeypress
- 5 new logging tests: TestLogger_WritesToFile, TestLogger_CreatesParentDirectories, TestLogger_RotatesAt10MB, TestLogger_NoRotateUnder10MB, TestLogger_NonExistentFile_NoRotationNeeded
- go test ./... — all 8 packages pass