### PR TITLE
fix(app): omit the -i flag when copilot prompt is empty

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -701,11 +701,14 @@ func (m *Model) switchWorktreeCmd(path string) tea.Cmd {
 
 // buildCopilotCmd constructs the exec.Cmd for running gh copilot in interactive
 // mode with the given prompt pre-loaded in the specified worktree directory.
+// When prompt is empty, runs "gh copilot" (interactive mode, no pre-loaded prompt).
 // It is extracted as a top-level function to keep it unit-testable.
 func buildCopilotCmd(worktreePath, prompt string) *exec.Cmd {
-	args := []string{"copilot", "-i"}
+	var args []string
 	if prompt != "" {
-		args = append(args, prompt)
+		args = []string{"copilot", "-i", prompt}
+	} else {
+		args = []string{"copilot"}
 	}
 	cmd := exec.Command("gh", args...)
 	cmd.Dir = worktreePath

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -1332,10 +1332,10 @@ func TestBuildCopilotCmd_BuildsCorrectCommand(t *testing.T) {
 			wantDir:      "/repo/feat-branch",
 		},
 		{
-			name:         "empty prompt omits prompt arg",
+			name:         "empty prompt runs gh copilot without -i",
 			worktreePath: "/tmp/my-worktree",
 			prompt:       "",
-			wantArgs:     []string{"gh", "copilot", "-i"},
+			wantArgs:     []string{"gh", "copilot"},
 			wantDir:      "/tmp/my-worktree",
 		},
 	}


### PR DESCRIPTION
Fixes #54

## What Changed

`buildCopilotCmd` now builds `gh copilot` (no `-i` flag) when the user submits an empty prompt, instead of the malformed `gh copilot -i` that caused a crash.

## Why

The `-i` flag expects a prompt argument. Passing it without one makes `gh` exit with an error, surfacing as a confusing failure in the TUI. When no prompt is provided, dropping `-i` launches Copilot in plain interactive mode — a clean, valid invocation.

## Testing

- Updated `TestBuildCopilotCmd_BuildsCorrectCommand` empty-prompt case to assert `["gh", "copilot"]` (no `-i`).
- Full test suite passes: `go test ./...`
