### PR TITLE
[Phase 4] Polish - Build System (Makefile + goreleaser + Version Injection)

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -21,4 +21,4 @@ jobs:
           cache: true
 
       - name: Run tests
-        run: go test ./... -v -count=1
+        run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Goreleaser
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: make test
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,6 +23,10 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+release:
+  draft: false
+  prerelease: auto
+
 changelog:
   sort: asc
   filters:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,32 @@
+version: 2
+
+project_name: nexus
+
+builds:
+  - main: ./cmd/nexus
+    binary: nexus
+    goos: [linux, darwin, windows]
+    goarch: [amd64, arm64]
+    ignore:
+      - goos: windows
+        goarch: arm64
+    ldflags:
+      - -X github.com/m00nk0d3/nexus/internal/version.Version={{.Version}}
+
+archives:
+  - formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BINARY  := nexus
 PKG     := github.com/m00nk0d3/nexus/internal/version
 LDFLAGS := -X $(PKG).Version=$(VERSION)
 
+# Cross-compile targets require a POSIX shell (Git Bash / WSL on Windows).
 .PHONY: build test lint clean install release snapshot \
         build-linux build-darwin build-windows
 
@@ -11,6 +12,7 @@ build:
 
 build-linux:
 	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(BINARY)-linux-amd64 ./cmd/nexus
+	GOOS=linux GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $(BINARY)-linux-arm64 ./cmd/nexus
 
 build-darwin:
 	GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(BINARY)-darwin-amd64 ./cmd/nexus
@@ -27,6 +29,7 @@ lint:
 
 clean:
 	rm -f $(BINARY) $(BINARY)-linux-* $(BINARY)-darwin-* $(BINARY).exe
+	go clean -testcache
 
 install:
 	go install -ldflags "$(LDFLAGS)" ./cmd/nexus

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+BINARY  := nexus
+PKG     := github.com/m00nk0d3/nexus/internal/version
+LDFLAGS := -X $(PKG).Version=$(VERSION)
+
+.PHONY: build test lint clean install release snapshot \
+        build-linux build-darwin build-windows
+
+build:
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/nexus
+
+build-linux:
+	GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(BINARY)-linux-amd64 ./cmd/nexus
+
+build-darwin:
+	GOOS=darwin GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(BINARY)-darwin-amd64 ./cmd/nexus
+	GOOS=darwin GOARCH=arm64 go build -ldflags "$(LDFLAGS)" -o $(BINARY)-darwin-arm64 ./cmd/nexus
+
+build-windows:
+	GOOS=windows GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o $(BINARY).exe ./cmd/nexus
+
+test:
+	go test ./... -v -count=1
+
+lint:
+	golangci-lint run
+
+clean:
+	rm -f $(BINARY) $(BINARY)-linux-* $(BINARY)-darwin-* $(BINARY).exe
+
+install:
+	go install -ldflags "$(LDFLAGS)" ./cmd/nexus
+
+release:
+	goreleaser release --clean
+
+snapshot:
+	goreleaser release --snapshot --clean

--- a/cmd/nexus/main.go
+++ b/cmd/nexus/main.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/m00nk0d3/nexus/internal/data"
 	"github.com/m00nk0d3/nexus/internal/logging"
+	"github.com/m00nk0d3/nexus/internal/version"
 )
 
 func run() error {
@@ -61,6 +62,10 @@ func run() error {
 }
 
 func main() {
+	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
+		fmt.Printf("nexus version %s\n", version.Version)
+		return
+	}
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)
 		os.Exit(1)


### PR DESCRIPTION
﻿Closes #28

## What Changed
Adds a Makefile, .goreleaser.yml, and --version flag to standardise building, testing, linting, and cross-platform releasing of Nexus binaries.

## Why Changed
No standardised build targets existed. Cross-platform releases required manual steps. CI used raw go test instead of a shared make test target, making local/CI parity impossible.

## Changes
- Makefile -- build, test, lint, clean, install, release, snapshot targets plus build-linux, build-darwin, build-windows cross-platform targets
- .goreleaser.yml -- multi-platform binary releases (linux/darwin/windows, amd64/arm64) with tar.gz/zip archives and checksum file
- cmd/nexus/main.go -- --version / -v flag prints "nexus version <VERSION>" using internal/version.Version
- .github/workflows/ci-tests.yml -- updated to use make test instead of raw go test ./...
- Version injected at build time via -X github.com/m00nk0d3/nexus/internal/version.Version (reuses existing internal/version package)

## Testing
- go build ./... passes
- go test ./... -count=1 -- all 8 packages pass
- nexus-test.exe --version correctly prints the injected version string
