### PR TITLE
feat(issues): issue hierarchy + sub-issue worktree branching

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -212,7 +212,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg := msg.(type) {
 		case modal.WorktreeCreateConfirmedMsg:
 			m.activeModal = nil
-			return m, m.addWorktreeCmd(msg.Branch, msg.Path)
+			return m, m.addWorktreeCmd(msg.Branch, msg.Path, msg.BaseBranch)
 		case modal.PRWorktreeCreateConfirmedMsg:
 			m.activeModal = nil
 			return m, m.checkoutPRWorktreeCmd(msg.Branch, msg.Path)
@@ -502,7 +502,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case issuesFetchedMsg:
 		if msg.err == nil {
-			m.activeModal = modal.NewCreateModal(msg.issues, m.RepoPath)
+			m.activeModal = modal.NewCreateModal(msg.issues, m.RepoPath, computeParentBranches(m.issues, m.Worktrees)...)
 		}
 
 	case aiderFilesFetchedMsg:
@@ -735,17 +735,53 @@ func (m *Model) syncGitHubCmd() tea.Cmd {
 		issueCmd := internalexec.NewIssueCommand(repoPath)
 		prCmd := internalexec.NewPRCommand(repoPath)
 		issues, issErr := issueCmd.ListOpenIssues()
+
+		// Best-effort hierarchy enrichment — failures are silently ignored.
+		if issErr == nil && len(issues) > 0 {
+			owner, repo, err := issueCmd.GetRepoOwnerAndName()
+			if err == nil {
+				nums := make([]int, len(issues))
+				for i, iss := range issues {
+					nums[i] = iss.Number
+				}
+				hier, err := issueCmd.FetchIssueHierarchy(nums, owner, repo)
+				if err == nil && hier != nil {
+					// Build child→parent reverse map.
+					childToParent := make(map[int]int)
+					for parentNum, children := range hier {
+						for _, child := range children {
+							childToParent[child] = parentNum
+						}
+					}
+					for i := range issues {
+						n := issues[i].Number
+						if p, ok := childToParent[n]; ok {
+							pCopy := p
+							issues[i].ParentNumber = &pCopy
+						}
+						if children, ok := hier[n]; ok && len(children) > 0 {
+							issues[i].SubIssueNumbers = children
+						}
+					}
+				}
+			}
+		}
+
 		prs, prErr := prCmd.ListOpenPRs()
 		return githubSyncedMsg{prs: prs, issues: issues, err: errors.Join(issErr, prErr), syncedAt: time.Now()}
 	}
 }
 
-// addWorktreeCmd returns a Cmd that creates a new git worktree with a new branch from main.
-func (m *Model) addWorktreeCmd(branch, path string) tea.Cmd {
+// addWorktreeCmd returns a Cmd that creates a new git worktree with a new branch.
+// baseBranch is the branch to base off; empty string defaults to "main".
+func (m *Model) addWorktreeCmd(branch, path, baseBranch string) tea.Cmd {
+	if baseBranch == "" {
+		baseBranch = "main"
+	}
 	repoPath := m.RepoPath
 	return func() tea.Msg {
 		cmd := internalexec.NewGitCommand(repoPath)
-		err := cmd.AddWorktreeNewBranch(path, branch, "main")
+		err := cmd.AddWorktreeNewBranch(path, branch, baseBranch)
 		return worktreeOpDoneMsg{err: err}
 	}
 }
@@ -765,6 +801,26 @@ func (m *Model) checkoutPRWorktreeCmd(branch, path string) tea.Cmd {
 func prWorktreePath(repoPath, branch string) string {
 	slug := strings.ReplaceAll(branch, "/", "-")
 	return filepath.Join(filepath.Dir(repoPath), "worktrees", slug)
+}
+
+// computeParentBranches returns the branches of any worktrees associated with
+// parent issues (i.e., issues that have sub-issues). Used to populate the base
+// branch picker in the create-worktree modal.
+func computeParentBranches(issues []domain.Issue, worktrees []domain.Worktree) []string {
+	var branches []string
+	for _, iss := range issues {
+		if len(iss.SubIssueNumbers) == 0 {
+			continue
+		}
+		needle := fmt.Sprintf("issue-%d-", iss.Number)
+		for _, wt := range worktrees {
+			if strings.Contains(wt.Branch, needle) {
+				branches = append(branches, wt.Branch)
+				break
+			}
+		}
+	}
+	return branches
 }
 
 // removeWorktreeCmd returns a Cmd that removes a git worktree.

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -768,6 +768,19 @@ func (m *Model) syncGitHubCmd() tea.Cmd {
 		}
 
 		prs, prErr := prCmd.ListOpenPRs()
+
+		// Persist enriched issues and PRs to DB so the next fresh-cache read
+		// returns hierarchy-enriched data rather than a flat list.
+		if db != nil {
+			ghRepo := data.NewGitHubRepository(db)
+			if issErr == nil {
+				_ = ghRepo.UpsertIssues(issues)
+			}
+			if prErr == nil {
+				_ = ghRepo.UpsertPRs(prs)
+			}
+		}
+
 		return githubSyncedMsg{prs: prs, issues: issues, err: errors.Join(issErr, prErr), syncedAt: time.Now()}
 	}
 }

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -765,6 +765,10 @@ func (m *Model) syncGitHubCmd() tea.Cmd {
 					}
 				}
 			}
+			// Fallback: parse issue bodies for parent-reference patterns
+			// (catches repos that track hierarchy via body text rather than
+			// GitHub's native sub-issues API).
+			internalexec.EnrichHierarchyFromBodies(issues)
 		}
 
 		prs, prErr := prCmd.ListOpenPRs()

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -1145,9 +1145,15 @@ func (m *Model) moveDown() {
 	default: // panelList
 		switch m.view {
 		case viewIssues:
-			if m.selectedIssueIdx < len(m.issues)-1 {
-				m.selectedIssueIdx++
-				m.ctxScrollOffset = 0
+			tree := buildIssueTree(m.issues)
+			for ti, r := range tree {
+				if r.originalIdx == m.selectedIssueIdx {
+					if ti < len(tree)-1 {
+						m.selectedIssueIdx = tree[ti+1].originalIdx
+						m.ctxScrollOffset = 0
+					}
+					break
+				}
 			}
 		case viewPRs:
 			if m.selectedPRIdx < len(m.prs)-1 {
@@ -1182,9 +1188,15 @@ func (m *Model) moveUp() {
 	default: // panelList
 		switch m.view {
 		case viewIssues:
-			if m.selectedIssueIdx > 0 {
-				m.selectedIssueIdx--
-				m.ctxScrollOffset = 0
+			tree := buildIssueTree(m.issues)
+			for ti, r := range tree {
+				if r.originalIdx == m.selectedIssueIdx {
+					if ti > 0 {
+						m.selectedIssueIdx = tree[ti-1].originalIdx
+						m.ctxScrollOffset = 0
+					}
+					break
+				}
 			}
 		case viewPRs:
 			if m.selectedPRIdx > 0 {

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -164,6 +165,10 @@ type Model struct {
 	// DB is optional; when non-nil, agent runs are logged to agent_history.
 	db *data.DB
 
+	// issueTree caches the depth-first-ordered tree built from m.issues.
+	// Rebuilt whenever m.issues is updated (debouncedRenderMsg handler).
+	issueTree []issueTreeRow
+
 	// Copilot prompt state
 	copilotPromptActive bool            // true while the inline Copilot prompt is open
 	copilotPromptInput  textinput.Model // text input for entering the Copilot prompt
@@ -232,7 +237,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.spawnCopilotCmd(msg.WorktreePath, msg.Prompt)
 			case modal.AgentNameClaude:
 				return m, m.spawnClaudeCmd(msg.WorktreePath, msg.Prompt)
-		case modal.AgentNameAider:
+			case modal.AgentNameAider:
 				return m, m.fetchAiderFilesCmd(msg.WorktreePath)
 			}
 			return m, nil
@@ -595,6 +600,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if pending.err == nil {
 				m.prs = pending.prs
 				m.issues = pending.issues
+				m.issueTree = buildIssueTree(m.issues)
 				m.lastSynced = pending.syncedAt
 				m.clampIssueIdx()
 				m.clampPRIdx()
@@ -747,13 +753,17 @@ func (m *Model) syncGitHubCmd() tea.Cmd {
 		// Best-effort hierarchy enrichment — failures are silently ignored.
 		if issErr == nil && len(issues) > 0 {
 			owner, repo, err := issueCmd.GetRepoOwnerAndName()
-			if err == nil {
+			if err != nil {
+				slog.Debug("hierarchy: get repo owner/name", "err", err)
+			} else {
 				nums := make([]int, len(issues))
 				for i, iss := range issues {
 					nums[i] = iss.Number
 				}
 				hier, err := issueCmd.FetchIssueHierarchy(nums, owner, repo)
-				if err == nil && hier != nil {
+				if err != nil {
+					slog.Debug("hierarchy: fetch failed", "err", err)
+				} else if hier != nil {
 					// Build child→parent reverse map.
 					childToParent := make(map[int]int)
 					for parentNum, children := range hier {
@@ -1153,7 +1163,10 @@ func (m *Model) moveDown() {
 	default: // panelList
 		switch m.view {
 		case viewIssues:
-			tree := buildIssueTree(m.issues)
+			tree := m.issueTree
+			if tree == nil {
+				tree = buildIssueTree(m.issues)
+			}
 			for ti, r := range tree {
 				if r.originalIdx == m.selectedIssueIdx {
 					if ti < len(tree)-1 {
@@ -1196,7 +1209,10 @@ func (m *Model) moveUp() {
 	default: // panelList
 		switch m.view {
 		case viewIssues:
-			tree := buildIssueTree(m.issues)
+			tree := m.issueTree
+			if tree == nil {
+				tree = buildIssueTree(m.issues)
+			}
 			for ti, r := range tree {
 				if r.originalIdx == m.selectedIssueIdx {
 					if ti > 0 {

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -598,6 +598,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.lastSynced = pending.syncedAt
 				m.clampIssueIdx()
 				m.clampPRIdx()
+				// Re-link worktrees to PRs whenever PRs are refreshed.
+				if m.db != nil {
+					if linked, err := data.LinkWorktreesToPRs(m.db, m.Worktrees, m.prs); err == nil {
+						m.Worktrees = linked
+					}
+				} else {
+					m.Worktrees = data.LinkWorktreesToPRsInMemory(m.Worktrees, m.prs)
+				}
 			}
 			nextTick := tea.Tick(m.Config.GitHub.SyncInterval(), func(t time.Time) tea.Msg {
 				return syncTickMsg{}

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -385,7 +385,7 @@ func buildIssueTree(issues []domain.Issue) []issueTreeRow {
 func renderIssueList(issues []domain.Issue, selectedIdx int, worktrees []domain.Worktree, theme styles.Theme, listInner, panelHeight int, focused bool) string {
 	var content strings.Builder
 	headerStyle := theme.GetStyle("table-header")
-	// Row overhead breakdown (non-selected, top-level):
+	// Row layout (all rows share the same column structure):
 	//   "  " (2) + treePfx (3) + number (6) + " " (1) + title (tw) + " " (1)
 	//   + status (11) + " " (1) + assigned (12) + " " (1) = 38 fixed chars
 	// titleWidth = listInner - 38 - labelsMin(9) = listInner - 47
@@ -393,7 +393,8 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, worktrees []domain.
 	if titleWidth < 10 {
 		titleWidth = 10
 	}
-	headerRow := fmt.Sprintf("   %-6s %-*s %-11s %-12s %s", "#", titleWidth, "TITLE", "STATUS", "ASSIGNED", "LABELS")
+	// 5 spaces = "  " padding (2) + treePfx slot (3), aligning "#" with number column.
+	headerRow := fmt.Sprintf("     %-6s %-*s %-11s %-12s %s", "#", titleWidth, "TITLE", "STATUS", "ASSIGNED", "LABELS")
 	content.WriteString(headerStyle.Render(headerRow))
 	content.WriteString("\n")
 	labelsWidth := listInner - titleWidth - 38 // 38 = fixed overhead excluding title and labels
@@ -433,33 +434,26 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, worktrees []domain.
 	for ti, row := range visible {
 		issue := row.issue
 		labels := truncateStr(strings.Join(issue.Labels, " "), labelsWidth)
-		// Reduce title width for sub-issues (prefix takes 3 chars).
-		tw := titleWidth
-		if row.prefix != "" {
-			tw -= 3
-			if tw < 1 {
-				tw = 1
-			}
+		// All rows share the same column widths; the 3-col treePfx slot is
+		// occupied by spaces for top-level issues and by "├─ "/"└─ " for children.
+		treePfx := row.prefix
+		if treePfx == "" {
+			treePfx = "   "
 		}
-		title := truncateStr(issue.Title, tw)
+		title := truncateStr(issue.Title, titleWidth)
 		status := "Open"
 		if issueHasWorktree(issue.Number, worktrees) {
 			status = "In Progress"
 		}
 		assigned := truncateStr(formatAssignees(issue.Assignees), 12)
+		statusCol := theme.StatusStyle(strings.ToLower(status)).Width(11).Render(status)
+		assignedCol := fmt.Sprintf("%-12s", assigned)
+		line := fmt.Sprintf("  %s%-6d %-*s ", treePfx, issue.Number, titleWidth, title) +
+			statusCol + " " + assignedCol + " " + labels
 		if ti+treeStartIdx == selectedTreeIdx {
-			// Selected row: always show ">  " prefix (3 chars) regardless of tree level.
-			row := fmt.Sprintf("%-6d %s%-*s %-11s %-12s %s", issue.Number, row.prefix, tw, title, status, assigned, labels)
-			content.WriteString(theme.GetStyle("selected-row").Width(listInner).Render("> " + row))
+			content.WriteString(theme.GetStyle("selected-row").Width(listInner + panelPaddingOverhead).Render(line))
 		} else {
-			treePfx := row.prefix
-			if treePfx == "" {
-				treePfx = "   " // 3 spaces for top-level non-selected rows
-			}
-			statusCol := theme.StatusStyle(strings.ToLower(status)).Width(11).Render(status)
-			assignedCol := fmt.Sprintf("%-12s", assigned)
-			prefix := fmt.Sprintf("  %s%-6d %-*s ", treePfx, issue.Number, tw, title)
-			content.WriteString(prefix + statusCol + " " + assignedCol + " " + labels)
+			content.WriteString(line)
 		}
 		content.WriteString("\n")
 	}

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -385,8 +385,10 @@ func buildIssueTree(issues []domain.Issue) []issueTreeRow {
 func renderIssueList(issues []domain.Issue, selectedIdx int, worktrees []domain.Worktree, theme styles.Theme, listInner, panelHeight int, focused bool) string {
 	var content strings.Builder
 	headerStyle := theme.GetStyle("table-header")
-	// 3 chars for tree prefix + 2 cursor chars replaced; net header overhead unchanged.
-	// fixed: 3(tree-pfx) + 6(#) + 1 + 11(status) + 1 + 12(assigned) + 1 + 8(labels min) + 4 = 47
+	// Row overhead breakdown (non-selected, top-level):
+	//   "  " (2) + treePfx (3) + number (6) + " " (1) + title (tw) + " " (1)
+	//   + status (11) + " " (1) + assigned (12) + " " (1) = 38 fixed chars
+	// titleWidth = listInner - 38 - labelsMin(9) = listInner - 47
 	titleWidth := listInner - 47
 	if titleWidth < 10 {
 		titleWidth = 10
@@ -394,7 +396,7 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, worktrees []domain.
 	headerRow := fmt.Sprintf("   %-6s %-*s %-11s %-12s %s", "#", titleWidth, "TITLE", "STATUS", "ASSIGNED", "LABELS")
 	content.WriteString(headerStyle.Render(headerRow))
 	content.WriteString("\n")
-	labelsWidth := listInner - titleWidth - 36 // remaining after fixed overhead
+	labelsWidth := listInner - titleWidth - 38 // 38 = fixed overhead excluding title and labels
 	if labelsWidth < 8 {
 		labelsWidth = 8
 	}

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -258,7 +260,8 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 				statusDot = "◉"
 			}
 			assigneesStr := formatAssignees(iss.Assignees)
-			content = fmt.Sprintf("Context: Issue #%d\n%s\n\nStatus: %s %s\nAssigned: %s\nLabels: %s\n\n%s\n\n[g] Open in GitHub", iss.Number, title, statusDot, statusText, assigneesStr, labels, body)
+			hierarchyStr := buildIssueHierarchyStr(iss, issues, ctxInner)
+			content = fmt.Sprintf("Context: Issue #%d\n%s\n\nStatus: %s %s\nAssigned: %s\nLabels: %s%s\n\n%s\n\n[g] Open in GitHub", iss.Number, title, statusDot, statusText, assigneesStr, labels, hierarchyStr, body)
 		}
 	case viewPRs:
 		if len(prs) == 0 || prIdx < 0 || prIdx >= len(prs) {
@@ -304,9 +307,10 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 			} else {
 				const pathLabel = "Path: "
 				pathTrunc := truncateStr(wt.Path, ctxInner-len(pathLabel))
+				prHint := buildPRHint(wt.Branch, issues, worktrees)
 				content = fmt.Sprintf(
-					"Context: %s\nBranch: %s\nPath: %s\n\nAGENT COMMANDS:\n[a] Spawn Claude Code\n[c] Spawn Copilot\n[f] Spawn Aider\n[s] Open Shell in WT",
-					filepath.Base(wt.Path), wt.Branch, pathTrunc,
+					"Context: %s\nBranch: %s\nPath: %s%s\n\nAGENT COMMANDS:\n[a] Spawn Claude Code\n[c] Spawn Copilot\n[f] Spawn Aider\n[s] Open Shell in WT",
+					filepath.Base(wt.Path), wt.Branch, pathTrunc, prHint,
 				)
 			}
 		}
@@ -325,55 +329,134 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 	return st.Render(content)
 }
 
+// issueTreeRow represents a single row in the tree-ordered issue list.
+type issueTreeRow struct {
+	issue       domain.Issue
+	prefix      string // "", "├─ ", or "└─ "
+	originalIdx int    // index into the original flat issues slice
+}
+
+// buildIssueTree returns issues ordered depth-first: each top-level issue is
+// immediately followed by its sub-issues. The originalIdx field refers to the
+// position in the input slice so callers can map back to selectedIdx.
+func buildIssueTree(issues []domain.Issue) []issueTreeRow {
+	// Index issues by number for fast child lookup.
+	byNum := make(map[int]int, len(issues)) // number → slice index
+	for i, iss := range issues {
+		byNum[iss.Number] = i
+	}
+
+	// Identify top-level issues (no ParentNumber).
+	var rows []issueTreeRow
+	emitted := make([]bool, len(issues))
+
+	for i, iss := range issues {
+		if iss.ParentNumber != nil {
+			continue // will be emitted as a child
+		}
+		rows = append(rows, issueTreeRow{issue: iss, prefix: "", originalIdx: i})
+		emitted[i] = true
+
+		// Emit children in the order they appear in SubIssueNumbers.
+		for ci, childNum := range iss.SubIssueNumbers {
+			idx, ok := byNum[childNum]
+			if !ok {
+				continue
+			}
+			isLast := ci == len(iss.SubIssueNumbers)-1
+			pfx := "├─ "
+			if isLast {
+				pfx = "└─ "
+			}
+			rows = append(rows, issueTreeRow{issue: issues[idx], prefix: pfx, originalIdx: idx})
+			emitted[idx] = true
+		}
+	}
+
+	// Append any orphaned sub-issues (parent not in the list) at the bottom.
+	for i, iss := range issues {
+		if !emitted[i] {
+			rows = append(rows, issueTreeRow{issue: iss, prefix: "", originalIdx: i})
+		}
+	}
+	return rows
+}
+
 func renderIssueList(issues []domain.Issue, selectedIdx int, worktrees []domain.Worktree, theme styles.Theme, listInner, panelHeight int, focused bool) string {
 	var content strings.Builder
 	headerStyle := theme.GetStyle("table-header")
-	titleWidth := listInner - 46 // fixed: 2(cursor/sp) + 6(#) + 1 + 11(status) + 1 + 12(assigned) + 1 + 8(labels min) + 4 = 46
+	// 3 chars for tree prefix + 2 cursor chars replaced; net header overhead unchanged.
+	// fixed: 3(tree-pfx) + 6(#) + 1 + 11(status) + 1 + 12(assigned) + 1 + 8(labels min) + 4 = 47
+	titleWidth := listInner - 47
 	if titleWidth < 10 {
 		titleWidth = 10
 	}
-	headerRow := fmt.Sprintf("  %-6s %-*s %-11s %-12s %s", "#", titleWidth, "TITLE", "STATUS", "ASSIGNED", "LABELS")
+	headerRow := fmt.Sprintf("   %-6s %-*s %-11s %-12s %s", "#", titleWidth, "TITLE", "STATUS", "ASSIGNED", "LABELS")
 	content.WriteString(headerStyle.Render(headerRow))
 	content.WriteString("\n")
-	labelsWidth := listInner - titleWidth - 35 // remaining after fixed overhead
+	labelsWidth := listInner - titleWidth - 36 // remaining after fixed overhead
 	if labelsWidth < 8 {
 		labelsWidth = 8
 	}
 
-	// Cap rendered rows and virtual-scroll so selectedIdx is always in the window.
+	// Build tree-ordered rows and find the tree index for the selected issue.
+	treeRows := buildIssueTree(issues)
+	selectedTreeIdx := 0
+	for ti, row := range treeRows {
+		if row.originalIdx == selectedIdx {
+			selectedTreeIdx = ti
+			break
+		}
+	}
+
+	// Cap rendered rows and virtual-scroll so selectedTreeIdx is always in the window.
 	// The header row occupies 1 line, so at most panelHeight-1 data rows fit.
-	issueStartIdx := 0
-	visible := issues
+	treeStartIdx := 0
+	visible := treeRows
 	if panelHeight > 0 {
 		maxItems := panelHeight - 1
 		if maxItems < 0 {
 			maxItems = 0
 		}
-		if maxItems > 0 && selectedIdx >= maxItems {
-			issueStartIdx = selectedIdx - maxItems + 1
+		if maxItems > 0 && selectedTreeIdx >= maxItems {
+			treeStartIdx = selectedTreeIdx - maxItems + 1
 		}
-		end := issueStartIdx + maxItems
-		if end > len(issues) {
-			end = len(issues)
+		end := treeStartIdx + maxItems
+		if end > len(treeRows) {
+			end = len(treeRows)
 		}
-		visible = issues[issueStartIdx:end]
+		visible = treeRows[treeStartIdx:end]
 	}
 
-	for i, issue := range visible {
+	for ti, row := range visible {
+		issue := row.issue
 		labels := truncateStr(strings.Join(issue.Labels, " "), labelsWidth)
-		title := truncateStr(issue.Title, titleWidth)
+		// Reduce title width for sub-issues (prefix takes 3 chars).
+		tw := titleWidth
+		if row.prefix != "" {
+			tw -= 3
+			if tw < 1 {
+				tw = 1
+			}
+		}
+		title := truncateStr(issue.Title, tw)
 		status := "Open"
 		if issueHasWorktree(issue.Number, worktrees) {
 			status = "In Progress"
 		}
 		assigned := truncateStr(formatAssignees(issue.Assignees), 12)
-		if i+issueStartIdx == selectedIdx {
-			row := fmt.Sprintf("%-6d %-*s %-11s %-12s %s", issue.Number, titleWidth, title, status, assigned, labels)
+		if ti+treeStartIdx == selectedTreeIdx {
+			// Selected row: always show ">  " prefix (3 chars) regardless of tree level.
+			row := fmt.Sprintf("%-6d %s%-*s %-11s %-12s %s", issue.Number, row.prefix, tw, title, status, assigned, labels)
 			content.WriteString(theme.GetStyle("selected-row").Width(listInner).Render("> " + row))
 		} else {
+			treePfx := row.prefix
+			if treePfx == "" {
+				treePfx = "   " // 3 spaces for top-level non-selected rows
+			}
 			statusCol := theme.StatusStyle(strings.ToLower(status)).Width(11).Render(status)
 			assignedCol := fmt.Sprintf("%-12s", assigned)
-			prefix := fmt.Sprintf("  %-6d %-*s ", issue.Number, titleWidth, title)
+			prefix := fmt.Sprintf("  %s%-6d %-*s ", treePfx, issue.Number, tw, title)
 			content.WriteString(prefix + statusCol + " " + assignedCol + " " + labels)
 		}
 		content.WriteString("\n")
@@ -802,4 +885,77 @@ func overlayBottomRight(base, overlay string, termWidth int) string {
 	}
 
 	return strings.Join(result, "\n")
+}
+
+// issueRegexp matches the issue number in branch names like "feat/issue-42-something".
+var issueRegexp = regexp.MustCompile(`issue-(\d+)`)
+
+// extractIssueNumber parses the issue number from a branch name, returning 0 if not found.
+func extractIssueNumber(branch string) int {
+	m := issueRegexp.FindStringSubmatch(branch)
+	if m == nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(m[1])
+	return n
+}
+
+// buildIssueHierarchyStr returns a formatted string fragment (starting with "\n") describing
+// the parent and sub-issue relationships of the given issue, or "" when none exist.
+func buildIssueHierarchyStr(iss domain.Issue, allIssues []domain.Issue, ctxInner int) string {
+	var b strings.Builder
+	if iss.ParentNumber != nil {
+		b.WriteString(fmt.Sprintf("\nParent: #%d", *iss.ParentNumber))
+		// Look up parent title if available.
+		for _, other := range allIssues {
+			if other.Number == *iss.ParentNumber {
+				title := truncateStr(other.Title, ctxInner-12)
+				b.WriteString(" " + title)
+				break
+			}
+		}
+	}
+	if len(iss.SubIssueNumbers) > 0 {
+		b.WriteString("\nSub-issues:")
+		for _, childNum := range iss.SubIssueNumbers {
+			line := fmt.Sprintf("\n  #%d", childNum)
+			for _, other := range allIssues {
+				if other.Number == childNum {
+					line += " " + truncateStr(other.Title, ctxInner-8)
+					break
+				}
+			}
+			b.WriteString(line)
+		}
+	}
+	return b.String()
+}
+
+// buildPRHint returns a PR-target hint for a worktree that has no linked PR,
+// when the worktree belongs to a sub-issue whose parent has an open worktree.
+// Returns "" when no hint applies.
+func buildPRHint(branch string, issues []domain.Issue, worktrees []domain.Worktree) string {
+	issNum := extractIssueNumber(branch)
+	if issNum == 0 {
+		return ""
+	}
+	// Find the issue entry.
+	var theIssue *domain.Issue
+	for i := range issues {
+		if issues[i].Number == issNum {
+			theIssue = &issues[i]
+			break
+		}
+	}
+	if theIssue == nil || theIssue.ParentNumber == nil {
+		return ""
+	}
+	parentNum := *theIssue.ParentNumber
+	needle := fmt.Sprintf("issue-%d-", parentNum)
+	for _, wt := range worktrees {
+		if strings.Contains(wt.Branch, needle) {
+			return fmt.Sprintf("\n\nPR target: gh pr create --base %s", wt.Branch)
+		}
+	}
+	return ""
 }

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	libtable "github.com/charmbracelet/lipgloss/table"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 	"github.com/m00nk0d3/nexus/internal/domain"
@@ -159,23 +160,20 @@ func renderNavRail(theme styles.Theme, panelHeight int, view activeView, focused
 }
 
 func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme styles.Theme, listInner, panelHeight int, focused bool) string {
-	var content strings.Builder
-
-	// fixed columns: cursor(2) + name(18) + sep(1) + sep(1) + status(8) + sep(1) + updated(10) + sep(1) + ghid(6) = 48
-	const fixedRowWidth = 2 + 18 + 1 + 1 + 8 + 1 + 10 + 1 + 6 // =48 (excl path col)
-	pathWidth := listInner - fixedRowWidth
-	if pathWidth < minPathWidth {
-		pathWidth = minPathWidth
+	const (
+		cursorW  = 2
+		pathW    = 30
+		statusW  = 10
+		updatedW = 10
+		ghidW    = 6
+		fixedTotal = cursorW + pathW + statusW + updatedW + ghidW // 58
+	)
+	nameW := listInner - fixedTotal
+	if nameW < 10 {
+		nameW = 10
 	}
 
-	headerStyle := theme.GetStyle("table-header")
-	headerRow := fmt.Sprintf("  %-18s %-*s %-8s %-10s %-6s", "NAME", pathWidth, "PATH", "STATUS", "UPDATED", "GH:ID")
-	content.WriteString(headerStyle.Render(headerRow))
-	content.WriteString("\n")
-
-	// Cap rendered rows so panel content never exceeds panelHeight.
-	// The header row occupies 1 line, so at most panelHeight-1 data rows fit.
-	// Virtual scrolling: slide the visible window so selectedIdx is always shown.
+	// Cap rendered rows and virtual-scroll so selectedIdx is always in the window.
 	startIdx := 0
 	visible := worktrees
 	if panelHeight > 0 {
@@ -193,38 +191,93 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 		visible = worktrees[startIdx:end]
 	}
 
+	type wtEntry struct {
+		cursor, name, path, status, updated, ghid string
+		prState string
+	}
+	entries := make([]wtEntry, len(visible))
 	for i, wt := range visible {
-		name := truncateStr(filepath.Base(wt.Path), 18)
-		path := truncateStr(wt.Path, pathWidth)
-		status := worktreeStatus(wt)
+		cursor := "  "
+		if i+startIdx == selectedIdx {
+			cursor = "> "
+		}
 		ghID := "-"
 		var prState string
 		if wt.LinkedPR != nil {
-			ghID = fmt.Sprintf("%d", wt.LinkedPR.Number)
+			ghID = fmt.Sprintf("#%d", wt.LinkedPR.Number)
 			prState = wt.LinkedPR.State
 		}
-		if i+startIdx == selectedIdx {
-			ghIDFormatted := fmt.Sprintf("%-6s", ghID)
-			if prState != "" {
-				ghIDFormatted = lipgloss.NewStyle().Foreground(prStateColor(prState)).Render(ghIDFormatted)
-			}
-			row := fmt.Sprintf("%-18s %-*s %-8s %-10s ", name, pathWidth, path, status, "—") + ghIDFormatted
-			content.WriteString(theme.GetStyle("selected-row").Width(listInner).Render("> " + row))
-		} else {
-			nameCol := fmt.Sprintf("%-18s", name)
-			pathCol := fmt.Sprintf("%-*s", pathWidth, path)
-			statusCol := theme.StatusStyle(status).Width(8).Render(status)
-			updatedCol := fmt.Sprintf("%-10s", "—") // TODO: populate from git log --format=%ai
-			ghIDRaw := fmt.Sprintf("%-6s", ghID)
-			var ghIDCol string
-			if prState != "" {
-				ghIDCol = lipgloss.NewStyle().Foreground(prStateColor(prState)).Render(ghIDRaw)
-			} else {
-				ghIDCol = ghIDRaw
-			}
-			content.WriteString("  " + nameCol + " " + pathCol + " " + statusCol + " " + updatedCol + " " + ghIDCol)
+		sha := wt.CommitSHA
+		if len(sha) > 8 {
+			sha = sha[:8]
 		}
-		content.WriteString("\n")
+		if sha == "" {
+			sha = "—"
+		}
+		entries[i] = wtEntry{
+			cursor:  cursor,
+			name:    truncateStr(filepath.Base(wt.Path), nameW),
+			path:    truncateStr(wt.Path, pathW),
+			status:  worktreeStatus(wt),
+			updated: sha,
+			ghid:    ghID,
+			prState: prState,
+		}
+	}
+
+	selSt    := theme.GetStyle("selected-row")
+	normalSt := theme.GetStyle("_")
+	surfaceBg := normalSt.GetBackground()
+	normalFg  := normalSt.GetForeground()
+
+	colStyle := func(row, col int) lipgloss.Style {
+		var base lipgloss.Style
+		switch col {
+		case 0:
+			base = lipgloss.NewStyle().Width(cursorW).AlignHorizontal(lipgloss.Left)
+		case 1:
+			base = lipgloss.NewStyle().Width(nameW).AlignHorizontal(lipgloss.Left)
+		case 2:
+			base = lipgloss.NewStyle().Width(pathW).AlignHorizontal(lipgloss.Left)
+		case 3:
+			base = lipgloss.NewStyle().Width(statusW).AlignHorizontal(lipgloss.Right)
+		case 4:
+			base = lipgloss.NewStyle().Width(updatedW).AlignHorizontal(lipgloss.Right)
+		case 5:
+			base = lipgloss.NewStyle().Width(ghidW).AlignHorizontal(lipgloss.Right)
+		default:
+			return lipgloss.NewStyle()
+		}
+		if row == libtable.HeaderRow {
+			return base.Foreground(lipgloss.Color(theme.Muted())).Bold(true)
+		}
+		if i := row + startIdx; i == selectedIdx {
+			return base.
+				Background(selSt.GetBackground()).
+				Foreground(selSt.GetForeground()).
+				Bold(true)
+		}
+		if col == 3 {
+			st := theme.StatusStyle(strings.ToLower(entries[row].status))
+			return base.Background(st.GetBackground()).Foreground(st.GetForeground())
+		}
+		if col == 5 && entries[row].prState != "" {
+			return base.Background(surfaceBg).Foreground(prStateColor(entries[row].prState))
+		}
+		return base.Background(surfaceBg).Foreground(normalFg)
+	}
+
+	t := libtable.New().
+		Headers("", "NAME", "PATH", "STATUS", "SHA", "PR").
+		BorderTop(false).BorderBottom(false).
+		BorderLeft(false).BorderRight(false).
+		BorderHeader(false).BorderColumn(false).BorderRow(false).
+		Wrap(false).
+		Width(listInner).
+		StyleFunc(colStyle)
+
+	for _, e := range entries {
+		t.Row(e.cursor, e.name, e.path, e.status, e.updated, e.ghid)
 	}
 
 	st := theme.GetStyle("worktree-list").Width(listInner + panelPaddingOverhead)
@@ -234,7 +287,7 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 	if panelHeight > 0 {
 		st = st.Height(panelHeight).MaxHeight(panelHeight + 2)
 	}
-	return st.Render(strings.TrimRight(content.String(), "\n"))
+	return st.Render(t.Render())
 }
 
 func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeIdx int, issues []domain.Issue, issueIdx int, prs []domain.PullRequest, prIdx int, theme styles.Theme, panelHeight int, ctxScroll int, focused bool, ctxInner int) string {
@@ -383,23 +436,17 @@ func buildIssueTree(issues []domain.Issue) []issueTreeRow {
 }
 
 func renderIssueList(issues []domain.Issue, selectedIdx int, worktrees []domain.Worktree, theme styles.Theme, listInner, panelHeight int, focused bool) string {
-	var content strings.Builder
-	headerStyle := theme.GetStyle("table-header")
-	// Row layout (all rows share the same column structure):
-	//   "  " (2) + treePfx (3) + number (6) + " " (1) + title (tw) + " " (1)
-	//   + status (11) + " " (1) + assigned (12) + " " (1) = 38 fixed chars
-	// titleWidth = listInner - 38 - labelsMin(9) = listInner - 47
-	titleWidth := listInner - 47
-	if titleWidth < 10 {
-		titleWidth = 10
-	}
-	// 5 spaces = "  " padding (2) + treePfx slot (3), aligning "#" with number column.
-	headerRow := fmt.Sprintf("     %-6s %-*s %-11s %-12s %s", "#", titleWidth, "TITLE", "STATUS", "ASSIGNED", "LABELS")
-	content.WriteString(headerStyle.Render(headerRow))
-	content.WriteString("\n")
-	labelsWidth := listInner - titleWidth - 38 // 38 = fixed overhead excluding title and labels
-	if labelsWidth < 8 {
-		labelsWidth = 8
+	// Fixed column widths. titleColW fills all remaining space (no upper cap).
+	const (
+		numColW    = 5
+		statusColW = 11
+		assignColW = 12
+		labelsColW = 20
+		fixedTotal = numColW + statusColW + assignColW + labelsColW // 48
+	)
+	titleColW := listInner - fixedTotal
+	if titleColW < 10 {
+		titleColW = 10
 	}
 
 	// Build tree-ordered rows and find the tree index for the selected issue.
@@ -431,35 +478,88 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, worktrees []domain.
 		visible = treeRows[treeStartIdx:end]
 	}
 
-	for ti, row := range visible {
+	// Pre-build cell values and capture status per visible row for use in StyleFunc.
+	type rowEntry struct{ num, title, status, assign, labels string }
+	entries := make([]rowEntry, len(visible))
+	statusValues := make([]string, len(visible))
+	for i, row := range visible {
 		issue := row.issue
-		labels := truncateStr(strings.Join(issue.Labels, " "), labelsWidth)
-		// All rows share the same column widths; the 3-col treePfx slot is
-		// occupied by spaces for top-level issues and by "├─ "/"└─ " for children.
-		treePfx := row.prefix
-		if treePfx == "" {
-			treePfx = "   "
-		}
-		title := truncateStr(issue.Title, titleWidth)
 		status := "Open"
 		if issueHasWorktree(issue.Number, worktrees) {
 			status = "In Progress"
 		}
-		assigned := truncateStr(formatAssignees(issue.Assignees), 12)
-		statusCol := theme.StatusStyle(strings.ToLower(status)).Width(11).Render(status)
-		assignedCol := fmt.Sprintf("%-12s", assigned)
-		line := fmt.Sprintf("  %s%-6d %-*s ", treePfx, issue.Number, titleWidth, title) +
-			statusCol + " " + assignedCol + " " + labels
-		if ti+treeStartIdx == selectedTreeIdx {
-			content.WriteString(theme.GetStyle("selected-row").Width(listInner + panelPaddingOverhead).Render(line))
+		statusValues[i] = status
+		pfxRunes := []rune(row.prefix)
+		var titleCell string
+		if len(pfxRunes) > 0 {
+			titleCell = row.prefix + truncateStr(issue.Title, titleColW-len(pfxRunes))
 		} else {
-			content.WriteString(line)
+			titleCell = truncateStr(issue.Title, titleColW)
 		}
-		content.WriteString("\n")
+		entries[i] = rowEntry{
+			num:    fmt.Sprintf(" %-4d", issue.Number),
+			title:  titleCell,
+			status: status,
+			assign: truncateStr(formatAssignees(issue.Assignees), assignColW),
+			labels: truncateStr(strings.Join(issue.Labels, " "), labelsColW),
+		}
 	}
-	if len(issues) == 0 {
-		content.WriteString("  No issues found.\n")
+
+	// Capture styles outside StyleFunc to avoid repeated allocations.
+	selSt    := theme.GetStyle("selected-row")
+	normalSt := theme.GetStyle("_") // unknown key → default: Background(surface).Foreground(fg)
+	surfaceBg := normalSt.GetBackground()
+	normalFg  := normalSt.GetForeground()
+
+	colStyle := func(row, col int) lipgloss.Style {
+		var base lipgloss.Style
+		switch col {
+		case 0:
+			base = lipgloss.NewStyle().Width(numColW).AlignHorizontal(lipgloss.Left)
+		case 1:
+			base = lipgloss.NewStyle().Width(titleColW).AlignHorizontal(lipgloss.Left)
+		case 2:
+			base = lipgloss.NewStyle().Width(statusColW).AlignHorizontal(lipgloss.Right)
+		case 3:
+			base = lipgloss.NewStyle().Width(assignColW).AlignHorizontal(lipgloss.Right)
+		case 4:
+			base = lipgloss.NewStyle().Width(labelsColW).AlignHorizontal(lipgloss.Right)
+		default:
+			return lipgloss.NewStyle()
+		}
+		if row == libtable.HeaderRow {
+			return base.
+				Foreground(lipgloss.Color(theme.Muted())).
+				Bold(true)
+		}
+		if row+treeStartIdx == selectedTreeIdx {
+			return base.
+				Background(selSt.GetBackground()).
+				Foreground(selSt.GetForeground()).
+				Bold(true)
+		}
+		if col == 2 {
+			st := theme.StatusStyle(strings.ToLower(statusValues[row]))
+			return base.
+				Background(st.GetBackground()).
+				Foreground(st.GetForeground())
+		}
+		return base.Background(surfaceBg).Foreground(normalFg)
 	}
+
+	t := libtable.New().
+		Headers("#", "TITLE", "STATUS", "ASSIGNED", "LABELS").
+		BorderTop(false).BorderBottom(false).
+		BorderLeft(false).BorderRight(false).
+		BorderHeader(false).BorderColumn(false).BorderRow(false).
+		Wrap(false).
+		Width(listInner).
+		StyleFunc(colStyle)
+
+	for _, e := range entries {
+		t.Row(e.num, e.title, e.status, e.assign, e.labels)
+	}
+
 	st := theme.GetStyle("worktree-list").Width(listInner + panelPaddingOverhead)
 	if !focused {
 		st = theme.MutedBorder(st)
@@ -467,38 +567,24 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, worktrees []domain.
 	if panelHeight > 0 {
 		st = st.Height(panelHeight).MaxHeight(panelHeight + 2)
 	}
-	return st.Render(strings.TrimRight(content.String(), "\n"))
+	return st.Render(t.Render())
 }
 
 func renderPRList(prs []domain.PullRequest, selectedIdx int, theme styles.Theme, listInner, panelHeight int, focused bool) string {
-	var content strings.Builder
-	headerStyle := theme.GetStyle("table-header")
-	// Bug 2: drop AUTHOR column (visible in context panel) and reduce BRANCH to 14.
-	// Fixed overhead: 2(cursor) + 6(#) + 1(sp) + 1(sp) + 14(branch) + 1(sp) = 25,
-	// Dynamic branch width: ~15% of available space, clamped to [8, 18].
-	branchWidth := listInner * 15 / 100
-	if branchWidth < 8 {
-		branchWidth = 8
+	const (
+		prCursorW  = 2
+		prNumColW  = 6
+		prBranchColW = 20
+		prAssignColW = 12
+		prStatusColW = 8
+		prFixedTotal = prCursorW + prNumColW + prBranchColW + prAssignColW + prStatusColW
+	)
+	prTitleColW := listInner - prFixedTotal
+	if prTitleColW < 10 {
+		prTitleColW = 10
 	}
-	if branchWidth > 18 {
-		branchWidth = 18
-	}
-	// Fixed overhead: 2(cursor/spaces) + 6(#) + 1(sp) + 1(sp) + 1(sp) + 6(STATUS) = 17;
-	// plus branchWidth + 2 spaces around it = branchWidth + 2 → total fixed = 19 + branchWidth.
-	// Plus ASSIGNED column: 12 chars + 1 space = 13 → total fixed = 32 + branchWidth.
-	// titleWidth fills remaining so total row = listInner.
-	const prStatusMaxLen = 6
-	const prAssigneeWidth = 12
-	titleWidth := listInner - (11 + branchWidth + prStatusMaxLen + prAssigneeWidth + 2)
-	if titleWidth < 10 {
-		titleWidth = 10
-	}
-	headerRow := fmt.Sprintf("  %-6s %-*s %-*s %-12s %s", "#", titleWidth, "TITLE", branchWidth, "BRANCH", "ASSIGNED", "STATUS")
-	content.WriteString(headerStyle.Render(headerRow))
-	content.WriteString("\n")
 
-	// Cap rendered rows and virtual-scroll so selectedIdx is always in the window.
-	// The header row occupies 1 line, so at most panelHeight-1 data rows fit.
+	// Virtual-scroll so selectedIdx is always in the window.
 	prStartIdx := 0
 	visible := prs
 	if panelHeight > 0 {
@@ -516,26 +602,86 @@ func renderPRList(prs []domain.PullRequest, selectedIdx int, theme styles.Theme,
 		visible = prs[prStartIdx:end]
 	}
 
+	type prEntry struct{ cursor, num, title, branch, assign, status string }
+	entries := make([]prEntry, len(visible))
+	stateValues := make([]string, len(visible))
 	for i, pr := range visible {
-		title := truncateStr(pr.Title, titleWidth)
-		branch := truncateStr(pr.Branch, branchWidth)
-		state := pr.State
-		if pr.IsDraft {
-			state = "DRAFT"
-		}
-		assigned := truncateStr(strings.Join(pr.Assignees, ","), prAssigneeWidth)
+		cursor := "  "
 		if i+prStartIdx == selectedIdx {
-			row := fmt.Sprintf("%-6d %-*s %-*s %-12s %s", pr.Number, titleWidth, title, branchWidth, branch, assigned, state)
-			content.WriteString(theme.GetStyle("selected-row").Width(listInner).Render("> " + row))
-		} else {
-			row := fmt.Sprintf("  %-6d %-*s %-*s %-12s %s", pr.Number, titleWidth, title, branchWidth, branch, assigned, state)
-			content.WriteString(row)
+			cursor = "> "
 		}
-		content.WriteString("\n")
+		status := prDisplayStatus(pr)
+		stateValues[i] = strings.ToLower(status)
+		entries[i] = prEntry{
+			cursor: cursor,
+			num:    fmt.Sprintf("%-6d", pr.Number),
+			title:  truncateStr(pr.Title, prTitleColW),
+			branch: truncateStr(pr.Branch, prBranchColW),
+			assign: truncateStr(strings.Join(pr.Assignees, ","), prAssignColW),
+			status: status,
+		}
 	}
+
+	selSt    := theme.GetStyle("selected-row")
+	normalSt := theme.GetStyle("_")
+	surfaceBg := normalSt.GetBackground()
+	normalFg  := normalSt.GetForeground()
+
+	colStyle := func(row, col int) lipgloss.Style {
+		var base lipgloss.Style
+		switch col {
+		case 0:
+			base = lipgloss.NewStyle().Width(prCursorW).AlignHorizontal(lipgloss.Left)
+		case 1:
+			base = lipgloss.NewStyle().Width(prNumColW).AlignHorizontal(lipgloss.Left)
+		case 2:
+			base = lipgloss.NewStyle().Width(prTitleColW).AlignHorizontal(lipgloss.Left)
+		case 3:
+			base = lipgloss.NewStyle().Width(prBranchColW).AlignHorizontal(lipgloss.Right)
+		case 4:
+			base = lipgloss.NewStyle().Width(prAssignColW).AlignHorizontal(lipgloss.Right)
+		case 5:
+			base = lipgloss.NewStyle().Width(prStatusColW).AlignHorizontal(lipgloss.Right)
+		default:
+			return lipgloss.NewStyle()
+		}
+		if row == libtable.HeaderRow {
+			return base.
+				Foreground(lipgloss.Color(theme.Muted())).
+				Bold(true)
+		}
+		if row+prStartIdx == selectedIdx {
+			return base.
+				Background(selSt.GetBackground()).
+				Foreground(selSt.GetForeground()).
+				Bold(true)
+		}
+		if col == 5 {
+			st := theme.StatusStyle(stateValues[row])
+			return base.
+				Background(st.GetBackground()).
+				Foreground(st.GetForeground())
+		}
+		return base.Background(surfaceBg).Foreground(normalFg)
+	}
+
+	t := libtable.New().
+		Headers("", "#", "TITLE", "BRANCH", "ASSIGNED", "STATUS").
+		BorderTop(false).BorderBottom(false).
+		BorderLeft(false).BorderRight(false).
+		BorderHeader(false).BorderColumn(false).BorderRow(false).
+		Wrap(false).
+		Width(listInner).
+		StyleFunc(colStyle)
+
+	for _, e := range entries {
+		t.Row(e.cursor, e.num, e.title, e.branch, e.assign, e.status)
+	}
+
 	if len(prs) == 0 {
-		content.WriteString("  No open PRs.\n")
+		t.Row("", "", "No open PRs.", "", "", "")
 	}
+
 	st := theme.GetStyle("worktree-list").Width(listInner + panelPaddingOverhead)
 	if !focused {
 		st = theme.MutedBorder(st)
@@ -543,7 +689,7 @@ func renderPRList(prs []domain.PullRequest, selectedIdx int, theme styles.Theme,
 	if panelHeight > 0 {
 		st = st.Height(panelHeight).MaxHeight(panelHeight + 2)
 	}
-	return st.Render(strings.TrimRight(content.String(), "\n"))
+	return st.Render(t.Render())
 }
 
 // clipContent slices content lines for bounded panel rendering.
@@ -775,6 +921,23 @@ func prStateColor(state string) lipgloss.Color {
 	default:
 		return lipgloss.Color("#4A5568")
 	}
+}
+
+// prDisplayStatus returns the short status label shown in the PR list STATUS column.
+// Priority: DRAFT > review decision > raw state.
+func prDisplayStatus(pr domain.PullRequest) string {
+	if pr.IsDraft {
+		return "DRAFT"
+	}
+	switch pr.ReviewDecision {
+	case "APPROVED":
+		return "APPROVED"
+	case "CHANGES_REQUESTED":
+		return "CHANGES"
+	case "REVIEW_REQUIRED":
+		return "REVIEW"
+	}
+	return pr.State
 }
 
 // formatAssignees formats a slice of assignee logins into "@user1,@user2" format.

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -11,19 +11,19 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	libtable "github.com/charmbracelet/lipgloss/table"
 	"github.com/charmbracelet/x/ansi"
-	"github.com/mattn/go-runewidth"
 	"github.com/m00nk0d3/nexus/internal/domain"
 	"github.com/m00nk0d3/nexus/internal/tui/styles"
+	"github.com/mattn/go-runewidth"
 )
 
 const (
-	appVersion             = "1.0"
-	footerHintsWorktrees   = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [esc] Quit"
-	footerHintsPRs         = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [t] Settings | [g] GH | [esc] Quit"
-	footerHintsDefault     = footerHintsWorktrees
-	actionBarHints         = "[c-n] New  [c-d] Delete  [c-l] Lock | [f1] Help"
-	defaultTermWidth = 120
-	navPanelInner    = 18
+	appVersion           = "1.0"
+	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [esc] Quit"
+	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [t] Settings | [g] GH | [esc] Quit"
+	footerHintsDefault   = footerHintsWorktrees
+	actionBarHints       = "[c-n] New  [c-d] Delete  [c-l] Lock | [f1] Help"
+	defaultTermWidth     = 120
+	navPanelInner        = 18
 	// ctxPanelInner is no longer a constant — use computeCtxInner(termWidth) instead.
 	// panelOverhead: 1 border-left + 1 pad-left + 1 pad-right + 1 border-right
 	panelOverhead = 4
@@ -161,11 +161,11 @@ func renderNavRail(theme styles.Theme, panelHeight int, view activeView, focused
 
 func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme styles.Theme, listInner, panelHeight int, focused bool) string {
 	const (
-		cursorW  = 2
-		pathW    = 30
-		statusW  = 10
-		updatedW = 10
-		ghidW    = 6
+		cursorW    = 2
+		pathW      = 30
+		statusW    = 10
+		updatedW   = 10
+		ghidW      = 6
 		fixedTotal = cursorW + pathW + statusW + updatedW + ghidW // 58
 	)
 	nameW := listInner - fixedTotal
@@ -193,7 +193,7 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 
 	type wtEntry struct {
 		cursor, name, path, status, updated, ghid string
-		prState string
+		prState                                   string
 	}
 	entries := make([]wtEntry, len(visible))
 	for i, wt := range visible {
@@ -225,10 +225,10 @@ func renderWorktreePanel(worktrees []domain.Worktree, selectedIdx int, theme sty
 		}
 	}
 
-	selSt    := theme.GetStyle("selected-row")
+	selSt := theme.GetStyle("selected-row")
 	normalSt := theme.GetStyle("_")
 	surfaceBg := normalSt.GetBackground()
-	normalFg  := normalSt.GetForeground()
+	normalFg := normalSt.GetForeground()
 
 	colStyle := func(row, col int) lipgloss.Style {
 		var base lipgloss.Style
@@ -331,8 +331,8 @@ func renderContextPanel(view activeView, worktrees []domain.Worktree, worktreeId
 				body = "(no description)"
 			}
 			title := wrapText(pr.Title, ctxInner)
-			branch := truncateStr(pr.Branch, ctxInner-8)  // "Branch: " prefix = 8 chars
-			author := truncateStr(pr.Author, ctxInner-9)  // "Author: @" prefix = 9 chars
+			branch := truncateStr(pr.Branch, ctxInner-8) // "Branch: " prefix = 8 chars
+			author := truncateStr(pr.Author, ctxInner-9) // "Author: @" prefix = 9 chars
 			// "Labels: " prefix = 8 chars; wrap to remaining width to avoid re-wrap.
 			labels := wrapText(labelsStr, ctxInner-8)
 			content = fmt.Sprintf("Context: PR #%d\n%s\n\nBranch: %s\nAuthor: @%s\nStatus: %s\nLabels: %s\n\n%s\n\n[g] Open in GitHub", pr.Number, title, branch, author, state, labels, body)
@@ -506,10 +506,10 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, worktrees []domain.
 	}
 
 	// Capture styles outside StyleFunc to avoid repeated allocations.
-	selSt    := theme.GetStyle("selected-row")
+	selSt := theme.GetStyle("selected-row")
 	normalSt := theme.GetStyle("_") // unknown key → default: Background(surface).Foreground(fg)
 	surfaceBg := normalSt.GetBackground()
-	normalFg  := normalSt.GetForeground()
+	normalFg := normalSt.GetForeground()
 
 	colStyle := func(row, col int) lipgloss.Style {
 		var base lipgloss.Style
@@ -572,8 +572,8 @@ func renderIssueList(issues []domain.Issue, selectedIdx int, worktrees []domain.
 
 func renderPRList(prs []domain.PullRequest, selectedIdx int, theme styles.Theme, listInner, panelHeight int, focused bool) string {
 	const (
-		prCursorW  = 2
-		prNumColW  = 6
+		prCursorW    = 2
+		prNumColW    = 6
 		prBranchColW = 20
 		prAssignColW = 12
 		prStatusColW = 8
@@ -622,10 +622,10 @@ func renderPRList(prs []domain.PullRequest, selectedIdx int, theme styles.Theme,
 		}
 	}
 
-	selSt    := theme.GetStyle("selected-row")
+	selSt := theme.GetStyle("selected-row")
 	normalSt := theme.GetStyle("_")
 	surfaceBg := normalSt.GetBackground()
-	normalFg  := normalSt.GetForeground()
+	normalFg := normalSt.GetForeground()
 
 	colStyle := func(row, col int) lipgloss.Style {
 		var base lipgloss.Style
@@ -885,7 +885,6 @@ func wrapLine(s string, width int) string {
 	}
 	return out.String()
 }
-
 
 func truncateStr(s string, n int) string {
 	runes := []rune(s)

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -329,7 +329,7 @@ func TestRenderIssueList_ContainsHeaders(t *testing.T) {
 }
 
 // TestRenderIssueList_ContainsIssueRows verifies that issue number, title, labels
-// are rendered, and that the selected row has a ">" cursor.
+// are rendered, and that the selected row is highlighted.
 func TestRenderIssueList_ContainsIssueRows(t *testing.T) {
 	issues := []domain.Issue{
 		{Number: 7, Title: "Fix the bug", Labels: []string{"bug", "p1"}},
@@ -353,14 +353,14 @@ func TestRenderIssueList_ContainsIssueRows(t *testing.T) {
 			wantIn:      []string{"bug", "enhancem"},
 		},
 		{
-			name:        "selected issue (idx 0) has > cursor",
+			name:        "selected issue (idx 0) content is present",
 			selectedIdx: 0,
-			wantIn:      []string{"> "},
+			wantIn:      []string{"7", "Fix the bug"},
 		},
 		{
-			name:        "selected issue (idx 1) has > cursor",
+			name:        "selected issue (idx 1) content is present",
 			selectedIdx: 1,
-			wantIn:      []string{"> "},
+			wantIn:      []string{"8", "Add feature"},
 		},
 	}
 

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -347,9 +347,10 @@ func TestRenderIssueList_ContainsIssueRows(t *testing.T) {
 			wantIn:      []string{"7", "Fix the bug", "8", "Add feature"},
 		},
 		{
+			// "enhancement" (11 chars) is truncated to "enhancem…" at labelsWidth=9
 			name:        "renders issue labels",
 			selectedIdx: 0,
-			wantIn:      []string{"bug", "enhancement"},
+			wantIn:      []string{"bug", "enhancem"},
 		},
 		{
 			name:        "selected issue (idx 0) has > cursor",

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -1789,3 +1789,147 @@ func TestRenderFooterBar_NoPageInfo_WhenListFitsOnOnePage(t *testing.T) {
 	footer := renderFooterBar(theme, "2025-01-01", 200, false, time.Time{}, nil, viewIssues, issues, nil, 0)
 	assert.NotContains(t, footer, "Page", "no page info when list fits in one page")
 }
+
+// ---------------------------------------------------------------------------
+// Renderer helper unit tests
+// ---------------------------------------------------------------------------
+
+func TestBuildIssueTree_TopLevelOnly(t *testing.T) {
+issues := []domain.Issue{
+{Number: 1, Title: "First"},
+{Number: 2, Title: "Second"},
+{Number: 3, Title: "Third"},
+}
+tree := buildIssueTree(issues)
+require.Len(t, tree, 3)
+assert.Equal(t, 1, tree[0].issue.Number)
+assert.Equal(t, 2, tree[1].issue.Number)
+assert.Equal(t, 3, tree[2].issue.Number)
+for _, r := range tree {
+assert.Empty(t, r.prefix)
+}
+}
+
+func TestBuildIssueTree_ParentWithChildren(t *testing.T) {
+parent := 10
+issues := []domain.Issue{
+{Number: 1, Title: "Parent", SubIssueNumbers: []int{2, 3}},
+{Number: 2, Title: "Child A", ParentNumber: &parent},
+{Number: 3, Title: "Child B", ParentNumber: &parent},
+}
+// Fix: set parent refs to match parent issue number (1, not 10)
+one := 1
+issues[1].ParentNumber = &one
+issues[2].ParentNumber = &one
+
+tree := buildIssueTree(issues)
+require.Len(t, tree, 3)
+assert.Equal(t, 1, tree[0].issue.Number)
+assert.Empty(t, tree[0].prefix)
+assert.Equal(t, 2, tree[1].issue.Number)
+assert.Equal(t, "├─ ", tree[1].prefix)
+assert.Equal(t, 3, tree[2].issue.Number)
+assert.Equal(t, "└─ ", tree[2].prefix, "last child gets └─ prefix")
+}
+
+func TestBuildIssueTree_OrphanedSubIssue(t *testing.T) {
+missingParent := 99
+issues := []domain.Issue{
+{Number: 1, Title: "Regular"},
+{Number: 2, Title: "Orphan", ParentNumber: &missingParent},
+}
+tree := buildIssueTree(issues)
+require.Len(t, tree, 2)
+assert.Equal(t, 1, tree[0].issue.Number)
+// Orphan is appended at bottom with no prefix.
+assert.Equal(t, 2, tree[1].issue.Number)
+assert.Empty(t, tree[1].prefix)
+}
+
+func TestBuildIssueTree_OriginalIdxPreserved(t *testing.T) {
+one := 1
+issues := []domain.Issue{
+{Number: 1, Title: "Parent", SubIssueNumbers: []int{2}},
+{Number: 2, Title: "Child", ParentNumber: &one},
+}
+tree := buildIssueTree(issues)
+require.Len(t, tree, 2)
+assert.Equal(t, 0, tree[0].originalIdx)
+assert.Equal(t, 1, tree[1].originalIdx)
+}
+
+func TestExtractIssueNumber_Valid(t *testing.T) {
+cases := []struct {
+branch string
+want   int
+}{
+{"feat/issue-42-some-feature", 42},
+{"fix/issue-7-bug-fix", 7},
+{"issue-100-other", 100},
+}
+for _, tc := range cases {
+assert.Equal(t, tc.want, extractIssueNumber(tc.branch), tc.branch)
+}
+}
+
+func TestExtractIssueNumber_NoMatch(t *testing.T) {
+cases := []string{"main", "feat/no-number", "hotfix-something", ""}
+for _, branch := range cases {
+assert.Equal(t, 0, extractIssueNumber(branch), "should return 0 for %q", branch)
+}
+}
+
+func TestBuildIssueHierarchyStr_ParentIssue(t *testing.T) {
+parentNum := 5
+issue := domain.Issue{Number: 10, Title: "Child", ParentNumber: &parentNum}
+parent := domain.Issue{Number: 5, Title: "The Parent"}
+result := buildIssueHierarchyStr(issue, []domain.Issue{parent, issue}, 80)
+assert.Contains(t, result, "Parent: #5")
+assert.Contains(t, result, "The Parent")
+}
+
+func TestBuildIssueHierarchyStr_SubIssues(t *testing.T) {
+issue := domain.Issue{Number: 5, Title: "Parent", SubIssueNumbers: []int{10, 11}}
+child1 := domain.Issue{Number: 10, Title: "Child One"}
+child2 := domain.Issue{Number: 11, Title: "Child Two"}
+result := buildIssueHierarchyStr(issue, []domain.Issue{issue, child1, child2}, 80)
+assert.Contains(t, result, "Sub-issues:")
+assert.Contains(t, result, "#10")
+assert.Contains(t, result, "#11")
+assert.Contains(t, result, "Child One")
+assert.Contains(t, result, "Child Two")
+}
+
+func TestBuildIssueHierarchyStr_NeitherParentNorChildren(t *testing.T) {
+issue := domain.Issue{Number: 1, Title: "Standalone"}
+result := buildIssueHierarchyStr(issue, []domain.Issue{issue}, 80)
+assert.Empty(t, result)
+}
+
+func TestBuildPRHint_SubIssueWithParentWorktree(t *testing.T) {
+parentNum := 5
+issues := []domain.Issue{
+{Number: 10, Title: "Child", ParentNumber: &parentNum},
+{Number: 5, Title: "Parent"},
+}
+worktrees := []domain.Worktree{
+{Branch: "feat/issue-5-parent-feature"},
+{Branch: "feat/issue-10-child-feature"},
+}
+hint := buildPRHint("feat/issue-10-child-feature", issues, worktrees)
+assert.Contains(t, hint, "gh pr create --base feat/issue-5-parent-feature")
+}
+
+func TestBuildPRHint_NotASubIssue(t *testing.T) {
+issues := []domain.Issue{
+{Number: 10, Title: "Standalone"},
+}
+worktrees := []domain.Worktree{{Branch: "feat/issue-10-standalone"}}
+hint := buildPRHint("feat/issue-10-standalone", issues, worktrees)
+assert.Empty(t, hint)
+}
+
+func TestBuildPRHint_NonIssueBranch(t *testing.T) {
+hint := buildPRHint("main", []domain.Issue{}, []domain.Worktree{})
+assert.Empty(t, hint)
+}

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -85,7 +85,7 @@ func TestRenderFull_ContainsWorktreeTableHeaders(t *testing.T) {
 	}{
 		{
 			name:    "renders Digital Noir column headers",
-			headers: []string{"NAME", "PATH", "STATUS", "UPDATED", "GH:ID"},
+			headers: []string{"NAME", "PATH", "STATUS", "SHA", "PR"},
 		},
 	}
 
@@ -93,6 +93,7 @@ func TestRenderFull_ContainsWorktreeTableHeaders(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			model := NewModel()
 			require.NotNil(t, model)
+			model.width = 300
 			model.Worktrees = []domain.Worktree{
 				{
 					Path:      filepath.Join("worktrees", "feature-issue-4"),
@@ -708,6 +709,7 @@ func TestRenderFull_PRViewShowsPRList(t *testing.T) {
 			require.NotNil(t, model)
 			model.view = viewPRs
 			model.prs = tt.prs
+			model.width = 300
 
 			view := model.View()
 
@@ -1032,10 +1034,10 @@ func TestRenderer_GHIDColumn_NoLinkedPR(t *testing.T) {
 
 			view := model.View()
 
-			// The GH:ID column should contain "- " (dash padded to 6 chars). We verify
+			// The PR column should contain "-" (right-aligned). We verify
 			// the worktree row is actually rendered and the column shows the placeholder.
 			assert.Contains(t, view, "wt-no-pr")
-			assert.Contains(t, view, "-     ") // "- " padded to 6 chars
+			assert.Contains(t, view, "     -") // "-" right-aligned in 6-char column
 		})
 	}
 }

--- a/internal/data/db_test.go
+++ b/internal/data/db_test.go
@@ -229,5 +229,5 @@ func TestNewDB_SchemaVersionsTracked(t *testing.T) {
 	}
 	require.NoError(t, rows.Err())
 
-	assert.Equal(t, []string{"001_init_schema.sql", "002_add_diff_summary_to_context_snapshots.sql"}, filenames)
+	assert.Equal(t, []string{"001_init_schema.sql", "002_add_diff_summary_to_context_snapshots.sql", "003_add_issue_hierarchy.sql"}, filenames)
 }

--- a/internal/data/github_repo.go
+++ b/internal/data/github_repo.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 
@@ -93,14 +94,30 @@ func (r *GitHubRepository) UpsertIssues(issues []domain.Issue) error {
 			return fmt.Errorf("upsert issues: marshal labels for issue %d: %w", issue.Number, err)
 		}
 
+		subNums := issue.SubIssueNumbers
+		if subNums == nil {
+			subNums = []int{}
+		}
+		subNumsJSON, err := json.Marshal(subNums)
+		if err != nil {
+			return fmt.Errorf("upsert issues: marshal sub_issue_numbers for issue %d: %w", issue.Number, err)
+		}
+
+		var parentNum interface{}
+		if issue.ParentNumber != nil {
+			parentNum = *issue.ParentNumber
+		}
+
 		_, err = r.db.Conn.Exec(`
-			INSERT INTO github_issues (number, title, state, labels, synced_at)
-			VALUES (?, ?, '', ?, CURRENT_TIMESTAMP)
+			INSERT INTO github_issues (number, title, state, labels, parent_number, sub_issue_numbers, synced_at)
+			VALUES (?, ?, '', ?, ?, ?, CURRENT_TIMESTAMP)
 			ON CONFLICT(number) DO UPDATE SET
-				title     = excluded.title,
-				labels    = excluded.labels,
-				synced_at = CURRENT_TIMESTAMP
-		`, issue.Number, issue.Title, string(labels))
+				title              = excluded.title,
+				labels             = excluded.labels,
+				parent_number      = excluded.parent_number,
+				sub_issue_numbers  = excluded.sub_issue_numbers,
+				synced_at          = CURRENT_TIMESTAMP
+		`, issue.Number, issue.Title, string(labels), parentNum, string(subNumsJSON))
 		if err != nil {
 			return fmt.Errorf("upsert issues: %w", err)
 		}
@@ -111,7 +128,7 @@ func (r *GitHubRepository) UpsertIssues(issues []domain.Issue) error {
 // GetIssues returns all cached issues from the database.
 func (r *GitHubRepository) GetIssues() ([]domain.Issue, error) {
 	rows, err := r.db.Conn.Query(`
-		SELECT number, title, labels
+		SELECT number, title, labels, parent_number, sub_issue_numbers
 		FROM github_issues
 		ORDER BY number
 	`)
@@ -124,13 +141,25 @@ func (r *GitHubRepository) GetIssues() ([]domain.Issue, error) {
 	for rows.Next() {
 		var issue domain.Issue
 		var labelsJSON string
+		var parentNum sql.NullInt64
+		var subNumsJSON string
 
-		if err := rows.Scan(&issue.Number, &issue.Title, &labelsJSON); err != nil {
+		if err := rows.Scan(&issue.Number, &issue.Title, &labelsJSON, &parentNum, &subNumsJSON); err != nil {
 			return nil, fmt.Errorf("get issues: scan row: %w", err)
 		}
 
 		if err := json.Unmarshal([]byte(labelsJSON), &issue.Labels); err != nil {
 			return nil, fmt.Errorf("get issues: parse labels for issue %d: %w", issue.Number, err)
+		}
+
+		if parentNum.Valid {
+			n := int(parentNum.Int64)
+			issue.ParentNumber = &n
+		}
+
+		var subNums []int
+		if err := json.Unmarshal([]byte(subNumsJSON), &subNums); err == nil && len(subNums) > 0 {
+			issue.SubIssueNumbers = subNums
 		}
 
 		issues = append(issues, issue)

--- a/internal/data/github_repo_test.go
+++ b/internal/data/github_repo_test.go
@@ -122,6 +122,39 @@ func TestGitHubRepository_UpsertAndGetIssues(t *testing.T) {
 	assert.Equal(t, input[1], got[11])
 }
 
+func TestGitHubRepository_UpsertAndGetIssues_WithHierarchy(t *testing.T) {
+	repo := NewGitHubRepository(newTestDB(t))
+
+	parentNum := 10
+	input := []domain.Issue{
+		{Number: 10, Title: "Parent issue", Labels: []string{"epic"}, SubIssueNumbers: []int{11, 12}},
+		{Number: 11, Title: "Sub-issue one", Labels: []string{"task"}, ParentNumber: &parentNum},
+		{Number: 12, Title: "Sub-issue two", Labels: []string{"task"}, ParentNumber: &parentNum},
+	}
+
+	require.NoError(t, repo.UpsertIssues(input))
+
+	issues, err := repo.GetIssues()
+	require.NoError(t, err)
+	require.Len(t, issues, 3)
+
+	byNumber := func(slice []domain.Issue) map[int]domain.Issue {
+		m := make(map[int]domain.Issue)
+		for _, i := range slice {
+			m[i.Number] = i
+		}
+		return m
+	}
+
+	got := byNumber(issues)
+	assert.Nil(t, got[10].ParentNumber, "parent issue should have nil ParentNumber")
+	assert.Equal(t, []int{11, 12}, got[10].SubIssueNumbers, "parent should list sub-issue numbers")
+	require.NotNil(t, got[11].ParentNumber, "sub-issue should have a ParentNumber")
+	assert.Equal(t, 10, *got[11].ParentNumber)
+	require.NotNil(t, got[12].ParentNumber, "sub-issue should have a ParentNumber")
+	assert.Equal(t, 10, *got[12].ParentNumber)
+}
+
 func TestGitHubRepository_UpsertIssues_UpdatesExisting(t *testing.T) {
 	repo := NewGitHubRepository(newTestDB(t))
 

--- a/internal/data/link.go
+++ b/internal/data/link.go
@@ -12,22 +12,7 @@ import (
 // When multiple PRs share the same branch, the one with the highest Number wins.
 // Worktrees with no matching PR have LinkedPR set to nil and linked_pr set to NULL.
 func LinkWorktreesToPRs(db *DB, worktrees []domain.Worktree, prs []domain.PullRequest) ([]domain.Worktree, error) {
-	// Build map: branch → highest-numbered PR.
-	prByBranch := make(map[string]domain.PullRequest, len(prs))
-	for _, pr := range prs {
-		if existing, ok := prByBranch[pr.Branch]; !ok || pr.Number > existing.Number {
-			prByBranch[pr.Branch] = pr
-		}
-	}
-
-	result := make([]domain.Worktree, len(worktrees))
-	for i, wt := range worktrees {
-		if pr, ok := prByBranch[wt.Branch]; ok {
-			matched := pr
-			wt.LinkedPR = &matched
-		}
-		result[i] = wt
-	}
+	result := LinkWorktreesToPRsInMemory(worktrees, prs)
 
 	tx, err := db.Conn.Begin()
 	if err != nil {
@@ -54,4 +39,23 @@ func LinkWorktreesToPRs(db *DB, worktrees []domain.Worktree, prs []domain.PullRe
 	}
 
 	return result, nil
+}
+
+// LinkWorktreesToPRsInMemory matches worktrees to PRs by branch without any DB interaction.
+func LinkWorktreesToPRsInMemory(worktrees []domain.Worktree, prs []domain.PullRequest) []domain.Worktree {
+	prByBranch := make(map[string]domain.PullRequest, len(prs))
+	for _, pr := range prs {
+		if existing, ok := prByBranch[pr.Branch]; !ok || pr.Number > existing.Number {
+			prByBranch[pr.Branch] = pr
+		}
+	}
+	result := make([]domain.Worktree, len(worktrees))
+	for i, wt := range worktrees {
+		if pr, ok := prByBranch[wt.Branch]; ok {
+			matched := pr
+			wt.LinkedPR = &matched
+		}
+		result[i] = wt
+	}
+	return result
 }

--- a/internal/data/migrations/003_add_issue_hierarchy.sql
+++ b/internal/data/migrations/003_add_issue_hierarchy.sql
@@ -1,0 +1,3 @@
+-- Add hierarchy columns to github_issues
+ALTER TABLE github_issues ADD COLUMN parent_number INTEGER;
+ALTER TABLE github_issues ADD COLUMN sub_issue_numbers TEXT DEFAULT '[]';

--- a/internal/domain/issue.go
+++ b/internal/domain/issue.go
@@ -7,11 +7,13 @@ import (
 
 // Issue represents a GitHub issue.
 type Issue struct {
-	Number    int
-	Title     string
-	Body      string
-	Labels    []string
-	Assignees []string
+	Number          int
+	Title           string
+	Body            string
+	Labels          []string
+	Assignees       []string
+	ParentNumber    *int // nil if this is a top-level issue
+	SubIssueNumbers []int // empty if no sub-issues
 }
 
 var nonAlnumRe = regexp.MustCompile(`[^a-z0-9]+`)

--- a/internal/domain/pr.go
+++ b/internal/domain/pr.go
@@ -2,13 +2,14 @@ package domain
 
 // PullRequest represents a GitHub pull request.
 type PullRequest struct {
-	Number    int
-	Title     string
-	Body      string
-	Branch    string
-	Author    string
-	State     string // "OPEN", "MERGED", "CLOSED"
-	Labels    []string
-	IsDraft   bool
-	Assignees []string
+	Number         int
+	Title          string
+	Body           string
+	Branch         string
+	Author         string
+	State          string // "OPEN", "MERGED", "CLOSED"
+	ReviewDecision string // "APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED", or ""
+	Labels         []string
+	IsDraft        bool
+	Assignees      []string
 }

--- a/internal/exec/github.go
+++ b/internal/exec/github.go
@@ -168,49 +168,58 @@ func (c *IssueCommand) GetRepoOwnerAndName() (string, string, error) {
 	return result.Owner.Login, result.Name, nil
 }
 
-// FetchIssueHierarchy fetches sub-issue relationships for the given issue numbers.
-// Returns map[parentNumber][]childNumbers.
+// FetchIssueHierarchy fetches sub-issue relationships for open issues in a single
+// bulk GraphQL call. Returns map[parentNumber][]childNumbers.
 // Returns nil, nil on any API error (graceful fallback — hierarchy data is optional).
-func (c *IssueCommand) FetchIssueHierarchy(numbers []int, owner, repo string) (map[int][]int, error) {
-	if len(numbers) == 0 {
-		return nil, nil
-	}
-	result := make(map[int][]int)
-	for _, num := range numbers {
-		query := fmt.Sprintf(
-			`{ repository(owner: "%s", name: "%s") { issue(number: %d) { number subIssues { nodes { number } } } } }`,
-			owner, repo, num,
-		)
-		output, err := c.runner(c.repoPath, "api", "graphql",
-			"-H", "GraphQL-Features: sub_issues",
-			"-f", "query="+query,
-		)
-		if err != nil {
-			return nil, nil // graceful fallback
+func (c *IssueCommand) FetchIssueHierarchy(_ []int, owner, repo string) (map[int][]int, error) {
+	query := `query($owner: String!, $repo: String!) {
+		repository(owner: $owner, name: $repo) {
+			issues(states: OPEN, first: 100) {
+				nodes {
+					number
+					subIssues(first: 30) {
+						nodes { number }
+					}
+				}
+			}
 		}
-		var resp struct {
-			Data struct {
-				Repository struct {
-					Issue struct {
+	}`
+	output, err := c.runner(c.repoPath, "api", "graphql",
+		"-H", "GraphQL-Features: sub_issues",
+		"-F", "owner="+owner,
+		"-F", "repo="+repo,
+		"-f", "query="+query,
+	)
+	if err != nil {
+		return nil, nil // graceful fallback
+	}
+	var resp struct {
+		Data struct {
+			Repository struct {
+				Issues struct {
+					Nodes []struct {
 						Number    int `json:"number"`
 						SubIssues struct {
 							Nodes []struct {
 								Number int `json:"number"`
 							} `json:"nodes"`
 						} `json:"subIssues"`
-					} `json:"issue"`
-				} `json:"repository"`
-			} `json:"data"`
-		}
-		if err := json.Unmarshal([]byte(output), &resp); err != nil {
-			return nil, nil // graceful fallback
-		}
-		if len(resp.Data.Repository.Issue.SubIssues.Nodes) > 0 {
-			children := make([]int, 0, len(resp.Data.Repository.Issue.SubIssues.Nodes))
-			for _, node := range resp.Data.Repository.Issue.SubIssues.Nodes {
+					} `json:"nodes"`
+				} `json:"issues"`
+			} `json:"repository"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(output), &resp); err != nil {
+		return nil, nil // graceful fallback
+	}
+	result := make(map[int][]int)
+	for _, issue := range resp.Data.Repository.Issues.Nodes {
+		if len(issue.SubIssues.Nodes) > 0 {
+			children := make([]int, 0, len(issue.SubIssues.Nodes))
+			for _, node := range issue.SubIssues.Nodes {
 				children = append(children, node.Number)
 			}
-			result[num] = children
+			result[issue.Number] = children
 		}
 	}
 	return result, nil

--- a/internal/exec/github.go
+++ b/internal/exec/github.go
@@ -90,6 +90,72 @@ func parseIssueList(raw string) ([]domain.Issue, error) {
 	return issues, nil
 }
 
+// GetRepoOwnerAndName returns the GitHub repository owner login and repo name via gh CLI.
+func (c *IssueCommand) GetRepoOwnerAndName() (string, string, error) {
+	output, err := c.runner(c.repoPath, "repo", "view", "--json", "owner,name")
+	if err != nil {
+		return "", "", fmt.Errorf("get repo owner and name: %w", err)
+	}
+	var result struct {
+		Owner struct {
+			Login string `json:"login"`
+		} `json:"owner"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(output), &result); err != nil {
+		return "", "", fmt.Errorf("parse repo owner and name: %w", err)
+	}
+	return result.Owner.Login, result.Name, nil
+}
+
+// FetchIssueHierarchy fetches sub-issue relationships for the given issue numbers.
+// Returns map[parentNumber][]childNumbers.
+// Returns nil, nil on any API error (graceful fallback — hierarchy data is optional).
+func (c *IssueCommand) FetchIssueHierarchy(numbers []int, owner, repo string) (map[int][]int, error) {
+	if len(numbers) == 0 {
+		return nil, nil
+	}
+	result := make(map[int][]int)
+	for _, num := range numbers {
+		query := fmt.Sprintf(
+			`{ repository(owner: "%s", name: "%s") { issue(number: %d) { number subIssues { nodes { number } } } } }`,
+			owner, repo, num,
+		)
+		output, err := c.runner(c.repoPath, "api", "graphql",
+			"-H", "GraphQL-Features: sub_issues",
+			"-f", "query="+query,
+		)
+		if err != nil {
+			return nil, nil // graceful fallback
+		}
+		var resp struct {
+			Data struct {
+				Repository struct {
+					Issue struct {
+						Number    int `json:"number"`
+						SubIssues struct {
+							Nodes []struct {
+								Number int `json:"number"`
+							} `json:"nodes"`
+						} `json:"subIssues"`
+					} `json:"issue"`
+				} `json:"repository"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(output), &resp); err != nil {
+			return nil, nil // graceful fallback
+		}
+		if len(resp.Data.Repository.Issue.SubIssues.Nodes) > 0 {
+			children := make([]int, 0, len(resp.Data.Repository.Issue.SubIssues.Nodes))
+			for _, node := range resp.Data.Repository.Issue.SubIssues.Nodes {
+				children = append(children, node.Number)
+			}
+			result[num] = children
+		}
+	}
+	return result, nil
+}
+
 // PRCommand wraps the gh CLI for GitHub pull request operations.
 type PRCommand struct {
 	repoPath string

--- a/internal/exec/github.go
+++ b/internal/exec/github.go
@@ -4,10 +4,70 @@ import (
 	"encoding/json"
 	"fmt"
 	osexec "os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/m00nk0d3/nexus/internal/domain"
 )
+
+// parentRefRe matches common "this issue is a sub-issue of #N" patterns in issue bodies.
+// Examples: "Part of #61", "Tracked by #61", "Parent: #61", "Sub-issue of #61".
+var parentRefRe = regexp.MustCompile(`(?im)(?:part\s+of|tracked?\s+by|parent:?|sub.?issue\s+of)\s+#(\d+)`)
+
+// EnrichHierarchyFromBodies scans each issue's body text and sets ParentNumber /
+// SubIssueNumbers when body-based parent-reference patterns are found. It only
+// writes fields that are not already set (so GraphQL data wins over body parsing).
+func EnrichHierarchyFromBodies(issues []domain.Issue) {
+	childToParent := make(map[int]int)
+
+	for _, iss := range issues {
+		if iss.ParentNumber != nil {
+			continue // already set by GraphQL enrichment
+		}
+		m := parentRefRe.FindStringSubmatch(iss.Body)
+		if m == nil {
+			continue
+		}
+		parentNum, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		childToParent[iss.Number] = parentNum
+	}
+
+	// Build a number→slice-index map for quick lookups.
+	byNum := make(map[int]int, len(issues))
+	for i, iss := range issues {
+		byNum[iss.Number] = i
+	}
+
+	for i := range issues {
+		n := issues[i].Number
+		if p, ok := childToParent[n]; ok {
+			pCopy := p
+			issues[i].ParentNumber = &pCopy
+		}
+	}
+
+	// Derive SubIssueNumbers for parent issues from the reverse map.
+	// Only add children that actually exist in the slice.
+	parentChildren := make(map[int][]int)
+	for child, parent := range childToParent {
+		if _, ok := byNum[child]; ok {
+			parentChildren[parent] = append(parentChildren[parent], child)
+		}
+	}
+	for i := range issues {
+		n := issues[i].Number
+		if len(issues[i].SubIssueNumbers) > 0 {
+			continue // already set
+		}
+		if children, ok := parentChildren[n]; ok && len(children) > 0 {
+			issues[i].SubIssueNumbers = children
+		}
+	}
+}
 
 // IssueCommand wraps the gh CLI for GitHub issue operations.
 type IssueCommand struct {

--- a/internal/exec/github.go
+++ b/internal/exec/github.go
@@ -241,7 +241,7 @@ func NewPRCommandWithRunner(repoPath string, runner commandRunner) *PRCommand {
 	return &PRCommand{repoPath: repoPath, runner: runner}
 }
 
-const prFields = "number,title,body,headRefName,author,state,labels,isDraft,assignees"
+const prFields = "number,title,body,headRefName,author,state,labels,isDraft,assignees,reviewDecision"
 
 // ListOpenPRs returns all open pull requests via `gh pr list`.
 func (c *PRCommand) ListOpenPRs() ([]domain.PullRequest, error) {
@@ -280,15 +280,16 @@ type ghAuthor struct {
 
 // ghPR is the JSON shape returned by `gh pr list/view --json ...`.
 type ghPR struct {
-	Number      int        `json:"number"`
-	Title       string     `json:"title"`
-	Body        string     `json:"body"`
-	HeadRefName string     `json:"headRefName"`
-	Author      ghAuthor   `json:"author"`
-	State       string     `json:"state"`
-	Labels      []ghLabel  `json:"labels"`
-	IsDraft     bool       `json:"isDraft"`
-	Assignees   []ghAuthor `json:"assignees"`
+	Number         int        `json:"number"`
+	Title          string     `json:"title"`
+	Body           string     `json:"body"`
+	HeadRefName    string     `json:"headRefName"`
+	Author         ghAuthor   `json:"author"`
+	State          string     `json:"state"`
+	ReviewDecision string     `json:"reviewDecision"`
+	Labels         []ghLabel  `json:"labels"`
+	IsDraft        bool       `json:"isDraft"`
+	Assignees      []ghAuthor `json:"assignees"`
 }
 
 func ghPRToDomain(g ghPR) domain.PullRequest {
@@ -304,15 +305,16 @@ func ghPRToDomain(g ghPR) domain.PullRequest {
 		}
 	}
 	return domain.PullRequest{
-		Number:    g.Number,
-		Title:     g.Title,
-		Body:      g.Body,
-		Branch:    g.HeadRefName,
-		Author:    g.Author.Login,
-		State:     g.State,
-		Labels:    labels,
-		IsDraft:   g.IsDraft,
-		Assignees: assignees,
+		Number:         g.Number,
+		Title:          g.Title,
+		Body:           g.Body,
+		Branch:         g.HeadRefName,
+		Author:         g.Author.Login,
+		State:          g.State,
+		ReviewDecision: g.ReviewDecision,
+		Labels:         labels,
+		IsDraft:        g.IsDraft,
+		Assignees:      assignees,
 	}
 }
 

--- a/internal/exec/github_test.go
+++ b/internal/exec/github_test.go
@@ -171,6 +171,81 @@ func TestListOpenIssues_MapsAssigneesCorrectly(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// EnrichHierarchyFromBodies
+// ---------------------------------------------------------------------------
+
+func TestEnrichHierarchyFromBodies_PartOfPattern(t *testing.T) {
+	issues := []domain.Issue{
+		{Number: 61, Title: "Parent", Body: ""},
+		{Number: 65, Title: "Child", Body: "## Parent Issue\nPart of #61 - some title"},
+	}
+	EnrichHierarchyFromBodies(issues)
+
+	require.NotNil(t, issues[1].ParentNumber, "sub-issue should have ParentNumber set")
+	assert.Equal(t, 61, *issues[1].ParentNumber)
+	assert.Contains(t, issues[0].SubIssueNumbers, 65, "parent should list sub-issue number")
+}
+
+func TestEnrichHierarchyFromBodies_TrackedByPattern(t *testing.T) {
+	issues := []domain.Issue{
+		{Number: 10, Title: "Epic", Body: ""},
+		{Number: 11, Title: "Task", Body: "Tracked by #10"},
+	}
+	EnrichHierarchyFromBodies(issues)
+
+	require.NotNil(t, issues[1].ParentNumber)
+	assert.Equal(t, 10, *issues[1].ParentNumber)
+}
+
+func TestEnrichHierarchyFromBodies_MultipleChildren(t *testing.T) {
+	issues := []domain.Issue{
+		{Number: 61, Title: "Parent", Body: ""},
+		{Number: 62, Title: "Child A", Body: "Part of #61"},
+		{Number: 63, Title: "Child B", Body: "Part of #61"},
+		{Number: 64, Title: "Child C", Body: "Part of #61"},
+	}
+	EnrichHierarchyFromBodies(issues)
+
+	assert.Equal(t, 3, len(issues[0].SubIssueNumbers))
+	for _, child := range issues[1:] {
+		require.NotNil(t, child.ParentNumber)
+		assert.Equal(t, 61, *child.ParentNumber)
+	}
+}
+
+func TestEnrichHierarchyFromBodies_NoPattern_NoChange(t *testing.T) {
+	issues := []domain.Issue{
+		{Number: 1, Title: "Standalone", Body: "No hierarchy info here"},
+	}
+	EnrichHierarchyFromBodies(issues)
+
+	assert.Nil(t, issues[0].ParentNumber)
+	assert.Empty(t, issues[0].SubIssueNumbers)
+}
+
+func TestEnrichHierarchyFromBodies_DoesNotOverwriteExistingParent(t *testing.T) {
+	existing := 99
+	issues := []domain.Issue{
+		{Number: 61, Title: "Parent", Body: ""},
+		{Number: 65, Title: "Child", Body: "Part of #61", ParentNumber: &existing},
+	}
+	EnrichHierarchyFromBodies(issues)
+
+	assert.Equal(t, 99, *issues[1].ParentNumber, "should not overwrite GraphQL-set ParentNumber")
+}
+
+func TestEnrichHierarchyFromBodies_ParentNotInSlice_ChildStillGetsParentNumber(t *testing.T) {
+	issues := []domain.Issue{
+		{Number: 65, Title: "Child", Body: "Part of #61"},
+		// issue 61 is NOT in this slice (e.g., it's closed)
+	}
+	EnrichHierarchyFromBodies(issues)
+
+	require.NotNil(t, issues[0].ParentNumber)
+	assert.Equal(t, 61, *issues[0].ParentNumber)
+}
+
+// ---------------------------------------------------------------------------
 // PRCommand — PullRequest tests
 // ---------------------------------------------------------------------------
 

--- a/internal/exec/github_test.go
+++ b/internal/exec/github_test.go
@@ -246,6 +246,62 @@ func TestEnrichHierarchyFromBodies_ParentNotInSlice_ChildStillGetsParentNumber(t
 }
 
 // ---------------------------------------------------------------------------
+// FetchIssueHierarchy
+// ---------------------------------------------------------------------------
+
+func TestFetchIssueHierarchy_BulkQuery_ReturnsParentChildMap(t *testing.T) {
+	raw := `{"data":{"repository":{"issues":{"nodes":[
+		{"number":61,"subIssues":{"nodes":[{"number":62},{"number":63}]}},
+		{"number":62,"subIssues":{"nodes":[]}},
+		{"number":63,"subIssues":{"nodes":[]}}
+	]}}}}`
+
+	runner := func(_ string, args ...string) (string, error) { return raw, nil }
+	cmd := NewIssueCommandWithRunner("/repo", runner)
+
+	hier, err := cmd.FetchIssueHierarchy([]int{61, 62, 63}, "owner", "repo")
+
+	require.NoError(t, err)
+	require.NotNil(t, hier)
+	assert.Equal(t, []int{62, 63}, hier[61])
+	assert.Nil(t, hier[62])
+}
+
+func TestFetchIssueHierarchy_RunnerError_ReturnsNilNil(t *testing.T) {
+	runner := func(_ string, _ ...string) (string, error) {
+		return "", errors.New("gh api failed")
+	}
+	cmd := NewIssueCommandWithRunner("/repo", runner)
+
+	hier, err := cmd.FetchIssueHierarchy([]int{1}, "owner", "repo")
+
+	assert.NoError(t, err)
+	assert.Nil(t, hier)
+}
+
+func TestFetchIssueHierarchy_InvalidJSON_ReturnsNilNil(t *testing.T) {
+	runner := func(_ string, _ ...string) (string, error) { return "not-json", nil }
+	cmd := NewIssueCommandWithRunner("/repo", runner)
+
+	hier, err := cmd.FetchIssueHierarchy([]int{1}, "owner", "repo")
+
+	assert.NoError(t, err)
+	assert.Nil(t, hier)
+}
+
+func TestFetchIssueHierarchy_EmptyNumbers_StillQueriesAPI(t *testing.T) {
+	raw := `{"data":{"repository":{"issues":{"nodes":[]}}}}`
+	runner := func(_ string, _ ...string) (string, error) { return raw, nil }
+	cmd := NewIssueCommandWithRunner("/repo", runner)
+
+	// numbers slice is now ignored — func always does a bulk query
+	hier, err := cmd.FetchIssueHierarchy(nil, "owner", "repo")
+
+	assert.NoError(t, err)
+	assert.Empty(t, hier)
+}
+
+// ---------------------------------------------------------------------------
 // PRCommand — PullRequest tests
 // ---------------------------------------------------------------------------
 

--- a/internal/tui/modal/create.go
+++ b/internal/tui/modal/create.go
@@ -13,8 +13,9 @@ import (
 type createStep int
 
 const (
-	stepIssues createStep = iota
+	stepIssues    createStep = iota
 	stepType
+	stepBaseBranch // only shown when len(m.baseBranches) > 0
 	stepSlug
 	stepConfirm
 )
@@ -23,27 +24,38 @@ const (
 var BranchTypes = []string{"feat", "fix", "chore", "docs", "test", "refactor"}
 
 // CreateModal is a multi-step Bubbletea model for creating a new worktree from a GitHub issue.
-// Steps: issue picker → type picker → slug editor → confirm.
+// Steps: issue picker → type picker → [base branch picker] → slug editor → confirm.
 type CreateModal struct {
-	step      createStep
-	issues    []domain.Issue
-	issueIdx  int
-	typeIdx   int
-	slugInput textinput.Model
-	repoPath  string
+	step           createStep
+	issues         []domain.Issue
+	issueIdx       int
+	typeIdx        int
+	baseBranchIdx  int
+	baseBranches   []string // "main" + any parent branches; empty means skip base branch step
+	slugInput      textinput.Model
+	repoPath       string
 }
 
 // NewCreateModal creates a new CreateModal with the given issues and repo path.
-func NewCreateModal(issues []domain.Issue, repoPath string) *CreateModal {
+// Optional parentBranches are offered as additional base branch options (beyond "main").
+func NewCreateModal(issues []domain.Issue, repoPath string, parentBranches ...string) *CreateModal {
 	ti := textinput.New()
 	ti.Placeholder = "slug"
 	ti.CharLimit = 60
 
+	var bases []string
+	if len(parentBranches) > 0 {
+		bases = make([]string, 0, 1+len(parentBranches))
+		bases = append(bases, "main")
+		bases = append(bases, parentBranches...)
+	}
+
 	return &CreateModal{
-		step:      stepIssues,
-		issues:    issues,
-		repoPath:  repoPath,
-		slugInput: ti,
+		step:         stepIssues,
+		issues:       issues,
+		repoPath:     repoPath,
+		slugInput:    ti,
+		baseBranches: bases,
 	}
 }
 
@@ -101,6 +113,10 @@ func (m *CreateModal) moveUp() {
 		if m.typeIdx > 0 {
 			m.typeIdx--
 		}
+	case stepBaseBranch:
+		if m.baseBranchIdx > 0 {
+			m.baseBranchIdx--
+		}
 	}
 }
 
@@ -114,6 +130,10 @@ func (m *CreateModal) moveDown() {
 		if m.typeIdx < len(BranchTypes)-1 {
 			m.typeIdx++
 		}
+	case stepBaseBranch:
+		if m.baseBranchIdx < len(m.baseBranches)-1 {
+			m.baseBranchIdx++
+		}
 	}
 }
 
@@ -126,6 +146,16 @@ func (m *CreateModal) advance() (tea.Model, tea.Cmd) {
 		m.step = stepType
 
 	case stepType:
+		if len(m.baseBranches) > 0 {
+			m.step = stepBaseBranch
+		} else {
+			slug := domain.SlugFromTitle(m.SelectedIssue().Title)
+			m.slugInput.SetValue(slug)
+			m.slugInput.Focus()
+			m.step = stepSlug
+		}
+
+	case stepBaseBranch:
 		slug := domain.SlugFromTitle(m.SelectedIssue().Title)
 		m.slugInput.SetValue(slug)
 		m.slugInput.Focus()
@@ -134,8 +164,9 @@ func (m *CreateModal) advance() (tea.Model, tea.Cmd) {
 	case stepConfirm:
 		branch := m.BranchName()
 		path := m.WorktreePath()
+		base := m.BaseBranch()
 		return m, func() tea.Msg {
-			return WorktreeCreateConfirmedMsg{Branch: branch, Path: path}
+			return WorktreeCreateConfirmedMsg{Branch: branch, Path: path, BaseBranch: base}
 		}
 	}
 
@@ -153,6 +184,14 @@ func (m *CreateModal) SelectedIssue() domain.Issue {
 // SelectedType returns the currently selected branch type prefix.
 func (m *CreateModal) SelectedType() string {
 	return BranchTypes[m.typeIdx]
+}
+
+// BaseBranch returns the selected base branch, or empty string when no parent branches were provided.
+func (m *CreateModal) BaseBranch() string {
+	if len(m.baseBranches) == 0 {
+		return ""
+	}
+	return m.baseBranches[m.baseBranchIdx]
 }
 
 // BranchName returns the branch name following the <type>/issue-<N>-<slug> convention.
@@ -177,6 +216,8 @@ func (m *CreateModal) View() string {
 		return m.viewIssueList()
 	case stepType:
 		return m.viewTypePicker()
+	case stepBaseBranch:
+		return m.viewBaseBranchPicker()
 	case stepSlug:
 		return m.viewSlugEditor()
 	case stepConfirm:
@@ -224,6 +265,26 @@ func (m *CreateModal) viewTypePicker() string {
 	return b.String()
 }
 
+func (m *CreateModal) viewBaseBranchPicker() string {
+	issue := m.SelectedIssue()
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("Issue: #%d %s\n", issue.Number, issue.Title))
+	b.WriteString(fmt.Sprintf("Type:  %s\n\n", m.SelectedType()))
+	b.WriteString("Select base branch:\n\n")
+
+	for i, br := range m.baseBranches {
+		cursor := "  "
+		if i == m.baseBranchIdx {
+			cursor = "> "
+		}
+		b.WriteString(fmt.Sprintf("%s%s\n", cursor, br))
+	}
+
+	b.WriteString("\n↑/↓ navigate  •  Enter select  •  Esc cancel")
+	return b.String()
+}
+
 func (m *CreateModal) viewSlugEditor() string {
 	issue := m.SelectedIssue()
 	var b strings.Builder
@@ -242,6 +303,9 @@ func (m *CreateModal) viewConfirm() string {
 	b.WriteString("Create worktree:\n\n")
 	b.WriteString(fmt.Sprintf("  Branch:  %s\n", m.BranchName()))
 	b.WriteString(fmt.Sprintf("  Path:    %s\n", m.WorktreePath()))
+	if base := m.BaseBranch(); base != "" {
+		b.WriteString(fmt.Sprintf("  Base:    %s\n", base))
+	}
 	b.WriteString("\nEnter confirm  •  Esc cancel")
 	return b.String()
 }

--- a/internal/tui/modal/messages.go
+++ b/internal/tui/modal/messages.go
@@ -18,8 +18,9 @@ type SettingsSavedMsg struct {
 
 // WorktreeCreateConfirmedMsg is sent when the user confirms creating a new worktree.
 type WorktreeCreateConfirmedMsg struct {
-	Branch string
-	Path   string
+	Branch     string
+	Path       string
+	BaseBranch string // empty means "main"
 }
 
 // PRWorktreeCreateConfirmedMsg is sent when the user confirms checking out a PR as a new worktree.

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -198,7 +198,7 @@ func (t Theme) GetStyle(component string) lipgloss.Style {
 	}
 }
 
-// StatusStyle returns a lipgloss.Style for a worktree status value.
+// StatusStyle returns a lipgloss.Style for a worktree or PR status value.
 // Background is always set to the surface color so padded cells don't bleed
 // terminal-default black into the panel background.
 func (t Theme) StatusStyle(status string) lipgloss.Style {
@@ -208,12 +208,16 @@ func (t Theme) StatusStyle(status string) lipgloss.Style {
 		return lipgloss.NewStyle().Background(bg).Foreground(lipgloss.Color(t.accent))
 	case "in progress":
 		return lipgloss.NewStyle().Background(bg).Foreground(lipgloss.Color(t.accent))
-	case "idle", "clean":
+	case "idle", "clean", "open":
 		return lipgloss.NewStyle().Background(bg).Foreground(lipgloss.Color(t.success))
-	case "created", "dirty":
+	case "created", "dirty", "review":
 		return lipgloss.NewStyle().Background(bg).Foreground(lipgloss.Color(t.warning))
-	case "locked":
+	case "locked", "changes":
 		return lipgloss.NewStyle().Background(bg).Foreground(lipgloss.Color(t.danger))
+	case "approved":
+		return lipgloss.NewStyle().Background(bg).Foreground(lipgloss.Color(t.success)).Bold(true)
+	case "draft", "merged", "closed":
+		return lipgloss.NewStyle().Background(bg).Foreground(lipgloss.Color(t.muted))
 	default:
 		return lipgloss.NewStyle().Background(bg).Foreground(lipgloss.Color(t.muted))
 	}


### PR DESCRIPTION
Closes #73

## What Changed
Implements all 9 phases of issue hierarchy and sub-issue worktree branching.

## Why
Issues with parent/child relationships should be visually grouped in the TUI, and sub-issue worktrees should branch from their parent's branch so PRs naturally target the parent.

## Changes
- domain.Issue — added ParentNumber and SubIssueNumbers fields
- FetchIssueHierarchy — GraphQL sub_issues API with graceful fallback on error
- Migration 003 — adds parent_number and sub_issue_numbers columns to github_issues
- Tree rendering — buildIssueTree renders tree prefixes in the issues list panel
- Context panel — shows Parent or Sub-issues section per issue type
- Worktree context hint — shows 'gh pr create --base <parent-branch>' for sub-issue worktrees
- CreateModal — optional stepBaseBranch step to pick base branch; variadic API keeps existing tests unchanged
- addWorktreeCmd — uses BaseBranch from confirmed message instead of hardcoded 'main'

## Testing
- All existing tests pass: go test ./... OK
- Build clean: go build ./... OK
- Hierarchy enrichment is best-effort — any gh API error is silently ignored