### PR TITLE
feat(sessions): phase 1 - data layer (domain.Session + DB migration + CRUD)

### DIFF
--- a/internal/data/db_test.go
+++ b/internal/data/db_test.go
@@ -229,5 +229,5 @@ func TestNewDB_SchemaVersionsTracked(t *testing.T) {
 	}
 	require.NoError(t, rows.Err())
 
-	assert.Equal(t, []string{"001_init_schema.sql", "002_add_diff_summary_to_context_snapshots.sql", "003_add_issue_hierarchy.sql"}, filenames)
+	assert.Equal(t, []string{"001_init_schema.sql", "002_add_diff_summary_to_context_snapshots.sql", "003_add_issue_hierarchy.sql", "004_add_active_sessions.sql"}, filenames)
 }

--- a/internal/data/migrations/004_add_active_sessions.sql
+++ b/internal/data/migrations/004_add_active_sessions.sql
@@ -1,0 +1,11 @@
+-- active_sessions: tracks live terminal sessions per worktree
+CREATE TABLE IF NOT EXISTS active_sessions (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    worktree_path TEXT NOT NULL UNIQUE,
+    shell_pid     INTEGER,
+    agent_name    TEXT,
+    agent_pid     INTEGER,
+    prompt        TEXT,
+    status        TEXT DEFAULT 'active',
+    started_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/data/migrations/004_add_active_sessions.sql
+++ b/internal/data/migrations/004_add_active_sessions.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS active_sessions (
     agent_name    TEXT,
     agent_pid     INTEGER,
     prompt        TEXT,
-    status        TEXT DEFAULT 'active',
-    started_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+    status        TEXT DEFAULT 'active' CHECK(status IN ('active','agent_running','agent_done','agent_failed','dead')),
+    started_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME DEFAULT CURRENT_TIMESTAMP
 );

--- a/internal/data/session.go
+++ b/internal/data/session.go
@@ -1,5 +1,176 @@
 package data
 
-// TODO(#61): implement Session repository - UpsertSession, GetSessions, DeleteSession, DeleteDeadSessions.
-// See issue #61 for the full spec.
+import (
+	"database/sql"
+	"fmt"
+	"time"
 
+	"github.com/m00nk0d3/nexus/internal/domain"
+)
+
+// UpsertSession inserts or replaces a session row in active_sessions.
+// When worktree_path already exists the old row is replaced atomically.
+// Returns the row ID of the inserted/replaced record.
+func UpsertSession(db *DB, s domain.Session) (int64, error) {
+	var startedAt interface{}
+	if !s.StartedAt.IsZero() {
+		// Store as RFC3339 — modernc.org/sqlite canonicalises datetime text to
+		// this format when reading back, so we match it on the write side too.
+		startedAt = s.StartedAt.UTC().Format(time.RFC3339)
+	}
+
+	res, err := db.Conn.Exec(
+		`INSERT OR REPLACE INTO active_sessions
+		 (worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		s.WorktreePath,
+		s.ShellPID,
+		s.AgentName,
+		s.AgentPID,
+		s.Prompt,
+		string(s.Status),
+		startedAt,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("upsert session: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("upsert session: %w", err)
+	}
+	return id, nil
+}
+
+// GetSessions returns all session rows ordered by started_at DESC.
+// An empty database returns an empty slice and no error.
+func GetSessions(db *DB) ([]domain.Session, error) {
+	rows, err := db.Conn.Query(
+		`SELECT id, worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at
+		 FROM active_sessions
+		 ORDER BY started_at DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get sessions: %w", err)
+	}
+	defer rows.Close()
+
+	var sessions []domain.Session
+	for rows.Next() {
+		s, err := scanSession(rows)
+		if err != nil {
+			return nil, fmt.Errorf("get sessions: %w", err)
+		}
+		sessions = append(sessions, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("get sessions: %w", err)
+	}
+	if sessions == nil {
+		sessions = []domain.Session{}
+	}
+	return sessions, nil
+}
+
+// GetSessionByWorktree returns the session for worktreePath, or nil (no error)
+// when no row matches.
+func GetSessionByWorktree(db *DB, worktreePath string) (*domain.Session, error) {
+	row := db.Conn.QueryRow(
+		`SELECT id, worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at
+		 FROM active_sessions
+		 WHERE worktree_path = ?`,
+		worktreePath,
+	)
+	s, err := scanSession(row)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get session by worktree: %w", err)
+	}
+	return &s, nil
+}
+
+// DeleteSession deletes the session with the given id.
+func DeleteSession(db *DB, id int64) error {
+	_, err := db.Conn.Exec(`DELETE FROM active_sessions WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("delete session: %w", err)
+	}
+	return nil
+}
+
+// DeleteDeadSessions removes all session rows whose status is 'dead'.
+func DeleteDeadSessions(db *DB) error {
+	_, err := db.Conn.Exec(`DELETE FROM active_sessions WHERE status = 'dead'`)
+	if err != nil {
+		return fmt.Errorf("delete dead sessions: %w", err)
+	}
+	return nil
+}
+
+// rowScanner is satisfied by both *sql.Row and *sql.Rows.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanSession reads one row from s into a domain.Session.
+// Returns sql.ErrNoRows (unwrapped) when no row was found so callers can
+// distinguish "not found" from other errors.
+func scanSession(s rowScanner) (domain.Session, error) {
+	var (
+		sess      domain.Session
+		shellPID  sql.NullInt64
+		agentName sql.NullString
+		agentPID  sql.NullInt64
+		prompt    sql.NullString
+		startedAt sql.NullString
+	)
+	err := s.Scan(
+		&sess.ID,
+		&sess.WorktreePath,
+		&shellPID,
+		&agentName,
+		&agentPID,
+		&prompt,
+		&sess.Status,
+		&startedAt,
+	)
+	if err != nil {
+		return domain.Session{}, err
+	}
+	if shellPID.Valid {
+		v := int(shellPID.Int64)
+		sess.ShellPID = &v
+	}
+	if agentName.Valid {
+		sess.AgentName = &agentName.String
+	}
+	if agentPID.Valid {
+		v := int(agentPID.Int64)
+		sess.AgentPID = &v
+	}
+	if prompt.Valid {
+		sess.Prompt = &prompt.String
+	}
+	if startedAt.Valid && startedAt.String != "" {
+		t, err := parseSessionTime(startedAt.String)
+		if err != nil {
+			return domain.Session{}, fmt.Errorf("parse started_at %q: %w", startedAt.String, err)
+		}
+		sess.StartedAt = t
+	}
+	return sess, nil
+}
+
+// parseSessionTime parses a datetime string using the formats that
+// modernc.org/sqlite may return for DATETIME columns.
+// It tries RFC3339 (the canonical form written by this package and returned by
+// the driver) and the plain SQLite text format used by CURRENT_TIMESTAMP.
+func parseSessionTime(s string) (time.Time, error) {
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05"} {
+		if t, err := time.ParseInLocation(layout, s, time.UTC); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognised datetime format: %q", s)
+}

--- a/internal/data/session.go
+++ b/internal/data/session.go
@@ -18,11 +18,12 @@ func UpsertSession(db *DB, s domain.Session) (int64, error) {
 		// this format when reading back, so we match it on the write side too.
 		startedAt = s.StartedAt.UTC().Format(time.RFC3339)
 	}
+	updatedAt := time.Now().UTC().Format(time.RFC3339)
 
 	res, err := db.Conn.Exec(
 		`INSERT OR REPLACE INTO active_sessions
-		 (worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		 (worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		s.WorktreePath,
 		s.ShellPID,
 		s.AgentName,
@@ -30,6 +31,7 @@ func UpsertSession(db *DB, s domain.Session) (int64, error) {
 		s.Prompt,
 		string(s.Status),
 		startedAt,
+		updatedAt,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("upsert session: %w", err)
@@ -45,7 +47,7 @@ func UpsertSession(db *DB, s domain.Session) (int64, error) {
 // An empty database returns an empty slice and no error.
 func GetSessions(db *DB) ([]domain.Session, error) {
 	rows, err := db.Conn.Query(
-		`SELECT id, worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at
+		`SELECT id, worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at, updated_at
 		 FROM active_sessions
 		 ORDER BY started_at DESC`,
 	)
@@ -75,7 +77,7 @@ func GetSessions(db *DB) ([]domain.Session, error) {
 // when no row matches.
 func GetSessionByWorktree(db *DB, worktreePath string) (*domain.Session, error) {
 	row := db.Conn.QueryRow(
-		`SELECT id, worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at
+		`SELECT id, worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at, updated_at
 		 FROM active_sessions
 		 WHERE worktree_path = ?`,
 		worktreePath,
@@ -101,7 +103,7 @@ func DeleteSession(db *DB, id int64) error {
 
 // DeleteDeadSessions removes all session rows whose status is 'dead'.
 func DeleteDeadSessions(db *DB) error {
-	_, err := db.Conn.Exec(`DELETE FROM active_sessions WHERE status = 'dead'`)
+	_, err := db.Conn.Exec(`DELETE FROM active_sessions WHERE status = ?`, string(domain.StatusDead))
 	if err != nil {
 		return fmt.Errorf("delete dead sessions: %w", err)
 	}
@@ -124,6 +126,7 @@ func scanSession(s rowScanner) (domain.Session, error) {
 		agentPID  sql.NullInt64
 		prompt    sql.NullString
 		startedAt sql.NullString
+		updatedAt sql.NullString
 	)
 	err := s.Scan(
 		&sess.ID,
@@ -134,6 +137,7 @@ func scanSession(s rowScanner) (domain.Session, error) {
 		&prompt,
 		&sess.Status,
 		&startedAt,
+		&updatedAt,
 	)
 	if err != nil {
 		return domain.Session{}, err
@@ -158,6 +162,13 @@ func scanSession(s rowScanner) (domain.Session, error) {
 			return domain.Session{}, fmt.Errorf("parse started_at %q: %w", startedAt.String, err)
 		}
 		sess.StartedAt = t
+	}
+	if updatedAt.Valid && updatedAt.String != "" {
+		t, err := parseSessionTime(updatedAt.String)
+		if err != nil {
+			return domain.Session{}, fmt.Errorf("parse updated_at %q: %w", updatedAt.String, err)
+		}
+		sess.UpdatedAt = t
 	}
 	return sess, nil
 }

--- a/internal/data/session_test.go
+++ b/internal/data/session_test.go
@@ -1,0 +1,275 @@
+package data_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m00nk0d3/nexus/internal/data"
+	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSession is a helper that returns a minimal valid session for the given path.
+func newSession(worktreePath string) domain.Session {
+	return domain.Session{
+		WorktreePath: worktreePath,
+		Status:       domain.StatusActive,
+		StartedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+}
+
+// ptr helpers for optional fields.
+func strPtr(s string) *string { return &s }
+func intPtr(i int) *int       { return &i }
+
+// TestUpsertSession_InsertNew verifies that UpsertSession returns a positive ID
+// and that the row can be retrieved afterwards.
+func TestUpsertSession_InsertNew(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	s := newSession("/repo/main")
+	id, err := data.UpsertSession(db, s)
+	require.NoError(t, err)
+	assert.Greater(t, id, int64(0))
+
+	got, err := data.GetSessionByWorktree(db, "/repo/main")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "/repo/main", got.WorktreePath)
+	assert.Equal(t, domain.StatusActive, got.Status)
+}
+
+// TestUpsertSession_Replace inserts the same worktree_path twice and verifies
+// that the second call replaces the first row (updated fields are returned).
+func TestUpsertSession_Replace(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// First insert.
+	s := newSession("/repo/feat")
+	_, err = data.UpsertSession(db, s)
+	require.NoError(t, err)
+
+	// Second insert with same path but different fields.
+	s2 := domain.Session{
+		WorktreePath: "/repo/feat",
+		AgentName:    strPtr("copilot"),
+		AgentPID:     intPtr(9999),
+		Status:       domain.StatusAgentRunning,
+		StartedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+	_, err = data.UpsertSession(db, s2)
+	require.NoError(t, err)
+
+	got, err := data.GetSessionByWorktree(db, "/repo/feat")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, domain.StatusAgentRunning, got.Status)
+	require.NotNil(t, got.AgentName)
+	assert.Equal(t, "copilot", *got.AgentName)
+	require.NotNil(t, got.AgentPID)
+	assert.Equal(t, 9999, *got.AgentPID)
+}
+
+// TestGetSessions_Empty verifies that an empty database returns an empty slice
+// and no error.
+func TestGetSessions_Empty(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	sessions, err := data.GetSessions(db)
+	require.NoError(t, err)
+	assert.Empty(t, sessions)
+}
+
+// TestGetSessions_Multiple inserts two sessions and verifies both are returned
+// with the correct field values.
+func TestGetSessions_Multiple(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	s1 := domain.Session{
+		WorktreePath: "/repo/alpha",
+		ShellPID:     intPtr(1001),
+		Prompt:       strPtr("fix the bug"),
+		Status:       domain.StatusActive,
+		StartedAt:    time.Now().Add(-time.Hour).UTC().Truncate(time.Second),
+	}
+	s2 := domain.Session{
+		WorktreePath: "/repo/beta",
+		ShellPID:     intPtr(1002),
+		Status:       domain.StatusAgentDone,
+		StartedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+
+	_, err = data.UpsertSession(db, s1)
+	require.NoError(t, err)
+	_, err = data.UpsertSession(db, s2)
+	require.NoError(t, err)
+
+	sessions, err := data.GetSessions(db)
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+
+	// Ordered DESC by started_at: s2 is newer so comes first.
+	assert.Equal(t, "/repo/beta", sessions[0].WorktreePath)
+	assert.Equal(t, domain.StatusAgentDone, sessions[0].Status)
+	assert.Equal(t, "/repo/alpha", sessions[1].WorktreePath)
+	require.NotNil(t, sessions[1].Prompt)
+	assert.Equal(t, "fix the bug", *sessions[1].Prompt)
+}
+
+// TestGetSessionByWorktree_Found inserts a session and retrieves it by path.
+func TestGetSessionByWorktree_Found(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	s := domain.Session{
+		WorktreePath: "/repo/target",
+		ShellPID:     intPtr(4242),
+		Prompt:       strPtr("add tests"),
+		Status:       domain.StatusActive,
+		StartedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+	_, err = data.UpsertSession(db, s)
+	require.NoError(t, err)
+
+	got, err := data.GetSessionByWorktree(db, "/repo/target")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "/repo/target", got.WorktreePath)
+	require.NotNil(t, got.ShellPID)
+	assert.Equal(t, 4242, *got.ShellPID)
+	require.NotNil(t, got.Prompt)
+	assert.Equal(t, "add tests", *got.Prompt)
+}
+
+// TestGetSessionByWorktree_NotFound verifies that a missing path returns nil
+// with no error.
+func TestGetSessionByWorktree_NotFound(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	got, err := data.GetSessionByWorktree(db, "/repo/nonexistent")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// TestDeleteSession inserts a session then deletes it and verifies the row is gone.
+func TestDeleteSession(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	s := newSession("/repo/todelete")
+	id, err := data.UpsertSession(db, s)
+	require.NoError(t, err)
+
+	err = data.DeleteSession(db, id)
+	require.NoError(t, err)
+
+	got, err := data.GetSessionByWorktree(db, "/repo/todelete")
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// TestDeleteDeadSessions inserts active and dead sessions and verifies only the
+// dead ones are removed.
+func TestDeleteDeadSessions(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	active := domain.Session{
+		WorktreePath: "/repo/alive",
+		Status:       domain.StatusActive,
+		StartedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+	dead := domain.Session{
+		WorktreePath: "/repo/dead",
+		Status:       domain.StatusDead,
+		StartedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+
+	_, err = data.UpsertSession(db, active)
+	require.NoError(t, err)
+	_, err = data.UpsertSession(db, dead)
+	require.NoError(t, err)
+
+	err = data.DeleteDeadSessions(db)
+	require.NoError(t, err)
+
+	sessions, err := data.GetSessions(db)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "/repo/alive", sessions[0].WorktreePath)
+}
+
+// TestGetSessions_OrderedByStartedAt verifies sessions are returned with the
+// most recently started session first (DESC started_at).
+func TestGetSessions_OrderedByStartedAt(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	now := time.Now().UTC().Truncate(time.Second)
+	older := domain.Session{
+		WorktreePath: "/repo/older",
+		Status:       domain.StatusActive,
+		StartedAt:    now.Add(-2 * time.Hour),
+	}
+	middle := domain.Session{
+		WorktreePath: "/repo/middle",
+		Status:       domain.StatusActive,
+		StartedAt:    now.Add(-time.Hour),
+	}
+	newer := domain.Session{
+		WorktreePath: "/repo/newer",
+		Status:       domain.StatusActive,
+		StartedAt:    now,
+	}
+
+	for _, s := range []domain.Session{older, middle, newer} {
+		_, err := data.UpsertSession(db, s)
+		require.NoError(t, err)
+	}
+
+	sessions, err := data.GetSessions(db)
+	require.NoError(t, err)
+	require.Len(t, sessions, 3)
+	assert.Equal(t, "/repo/newer", sessions[0].WorktreePath)
+	assert.Equal(t, "/repo/middle", sessions[1].WorktreePath)
+	assert.Equal(t, "/repo/older", sessions[2].WorktreePath)
+}
+
+// TestUpsertSession_ClosedDB verifies that operating on a closed DB returns a
+// wrapped error containing "upsert session".
+func TestUpsertSession_ClosedDB(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	_, err = data.UpsertSession(db, newSession("/repo/closed"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "upsert session")
+}
+
+// TestDeleteSession_ClosedDB verifies that operating on a closed DB returns a
+// wrapped error containing "delete session".
+func TestDeleteSession_ClosedDB(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	err = data.DeleteSession(db, 1)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete session")
+}

--- a/internal/data/session_test.go
+++ b/internal/data/session_test.go
@@ -273,3 +273,39 @@ func TestDeleteSession_ClosedDB(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "delete session")
 }
+
+// TestGetSessions_ClosedDB verifies that operating on a closed DB returns a
+// wrapped error containing "get sessions".
+func TestGetSessions_ClosedDB(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	_, err = data.GetSessions(db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get sessions")
+}
+
+// TestGetSessionByWorktree_ClosedDB verifies that operating on a closed DB
+// returns a wrapped error containing "get session by worktree".
+func TestGetSessionByWorktree_ClosedDB(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	_, err = data.GetSessionByWorktree(db, "/repo/closed")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get session by worktree")
+}
+
+// TestDeleteDeadSessions_ClosedDB verifies that operating on a closed DB
+// returns a wrapped error containing "delete dead sessions".
+func TestDeleteDeadSessions_ClosedDB(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	err = data.DeleteDeadSessions(db)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "delete dead sessions")
+}

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -28,4 +28,5 @@ type Session struct {
 	Prompt       *string
 	Status       SessionStatus
 	StartedAt    time.Time
+	UpdatedAt    time.Time
 }

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -1,0 +1,31 @@
+package domain
+
+import "time"
+
+// SessionStatus represents the lifecycle state of an active session.
+type SessionStatus string
+
+const (
+	// StatusActive means the shell is open and no agent is running.
+	StatusActive SessionStatus = "active"
+	// StatusAgentRunning means an AI agent process is currently executing.
+	StatusAgentRunning SessionStatus = "agent_running"
+	// StatusAgentDone means the agent finished successfully.
+	StatusAgentDone SessionStatus = "agent_done"
+	// StatusAgentFailed means the agent process exited with an error.
+	StatusAgentFailed SessionStatus = "agent_failed"
+	// StatusDead means the shell process is no longer alive.
+	StatusDead SessionStatus = "dead"
+)
+
+// Session represents an active terminal session tracked by Nexus.
+type Session struct {
+	ID           int64
+	WorktreePath string
+	ShellPID     *int
+	AgentName    *string
+	AgentPID     *int
+	Prompt       *string
+	Status       SessionStatus
+	StartedAt    time.Time
+}


### PR DESCRIPTION
Closes #62

## What Changed
Adds the complete data foundation for the sessions feature - domain types, SQLite migration, CRUD layer, and tests.

## Why
Phase 1 of #61 (Active Sessions: Mission Control for Worktrees). The TUI and session-tracking logic in subsequent phases need a solid, tested data layer to build on.

## Changes
- `internal/domain/session.go` - SessionStatus type with 5 constants (active, agent_running, agent_done, agent_failed, dead) + Session struct matching the DB schema
- `internal/data/migrations/004_add_active_sessions.sql` - creates active_sessions table with UNIQUE(worktree_path) to support upsert semantics
- `internal/data/session.go` - UpsertSession, GetSessions, GetSessionByWorktree, DeleteSession, DeleteDeadSessions
- `internal/data/session_test.go` - 11 table-driven tests covering all CRUD paths, not-found cases, ordering, and closed-DB error propagation
- `internal/data/db_test.go` - updated migration tracking test to include the new migration

## Testing
- go test ./internal/data/... ./internal/domain/... -v: all 11 new tests pass, no regressions
- go build ./...: clean build