### PR TITLE
feat(sessions): spawn new terminal per worktree with PID tracking

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -37,6 +37,12 @@ type worktreeSwitchedMsg struct {
 	err error // Error during switch, if any
 }
 
+// sessionSpawnedMsg carries the result of spawning a new terminal session.
+type sessionSpawnedMsg struct {
+	session domain.Session
+	err     error
+}
+
 // githubSyncedMsg carries the result of a background GitHub PR/issue sync.
 type githubSyncedMsg struct {
 	prs      []domain.PullRequest
@@ -446,8 +452,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "s", "S":
 				if m.view == viewWorktrees {
 					if selected, ok := m.selectedWorktree(); ok {
-						return m, m.switchWorktreeCmd(selected.Path)
+						return m, m.spawnSessionCmd(selected.Path)
 					}
+					m.statusErr = "No worktree selected — select one first"
+					return m, clearErrorCmd()
 				}
 			case "c", "C":
 				if m.view != viewWorktrees {
@@ -547,6 +555,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusErr = ""
 		// Refresh worktrees after switching back
 		return m, m.refreshWorktreesCmd()
+
+	case sessionSpawnedMsg:
+		if msg.err != nil {
+			m.statusErr = fmt.Sprintf("Failed to spawn session: %v", msg.err)
+			return m, clearErrorCmd()
+		}
+		return m, nil
 
 	case worktreesRefreshedMsg:
 		if msg.err == nil {
@@ -1065,6 +1080,60 @@ func getShell() string {
 		return shell
 	}
 	return "/bin/sh"
+}
+
+// buildNewTerminalCmd constructs a platform-specific command that opens a new
+// terminal window rooted at path without blocking the caller.
+//
+//   - Windows: cmd /C start cmd /K "cd /d <path>"
+//   - macOS:   open -a Terminal <path>
+//   - Linux:   $TERMINAL --working-directory=<path>  (fallback: xterm)
+func buildNewTerminalCmd(path, goos string) *exec.Cmd {
+	switch goos {
+	case "windows":
+		return exec.Command("cmd", "/C", "start", "cmd", "/K", fmt.Sprintf(`cd /d %s`, path))
+	case "darwin":
+		return exec.Command("open", "-a", "Terminal", path)
+	default:
+		// Linux: respect the $TERMINAL env var when set.
+		if term := os.Getenv("TERMINAL"); term != "" {
+			return exec.Command(term, "--working-directory="+path)
+		}
+		shell := os.Getenv("SHELL")
+		if shell == "" {
+			shell = "/bin/sh"
+		}
+		return exec.Command("xterm", "-e", fmt.Sprintf("cd %q; %s", path, shell))
+	}
+}
+
+// spawnSessionCmd opens a new terminal window at worktreePath in the background
+// and dispatches a sessionSpawnedMsg with the PID once the process is launched.
+// The PID is persisted in active_sessions when a DB connection is available.
+func (m *Model) spawnSessionCmd(worktreePath string) tea.Cmd {
+	db := m.db
+	return func() tea.Msg {
+		cmd := buildNewTerminalCmd(worktreePath, runtime.GOOS)
+		if err := cmd.Start(); err != nil {
+			return sessionSpawnedMsg{err: fmt.Errorf("spawn session: %w", err)}
+		}
+		pid := cmd.Process.Pid
+		session := domain.Session{
+			WorktreePath: worktreePath,
+			ShellPID:     &pid,
+			Status:       domain.StatusActive,
+			StartedAt:    time.Now(),
+		}
+		if db != nil {
+			id, err := data.UpsertSession(db, session)
+			if err != nil {
+				// Non-fatal: terminal is running but we could not persist the PID.
+				return sessionSpawnedMsg{session: session, err: fmt.Errorf("track session: %w", err)}
+			}
+			session.ID = id
+		}
+		return sessionSpawnedMsg{session: session}
+	}
 }
 
 // worktreesRefreshedMsg carries the result of refreshing the worktree list.

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -91,6 +91,16 @@ func clearErrorCmd() tea.Cmd {
 	})
 }
 
+// clearMsgMsg is dispatched after the 3-second success-notification timer fires.
+type clearMsgMsg struct{}
+
+// clearMsgCmd returns a Cmd that fires clearMsgMsg after 3 seconds.
+func clearMsgCmd() tea.Cmd {
+	return tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+		return clearMsgMsg{}
+	})
+}
+
 // debouncedRenderCmd schedules a debouncedRenderMsg after delay.
 func debouncedRenderCmd(delay time.Duration) tea.Cmd {
 	return tea.Tick(delay, func(t time.Time) tea.Msg {
@@ -148,6 +158,7 @@ type Model struct {
 	selectedIdx      int                  // Currently selected worktree index
 	activeModal      modal.Modal          // Currently open modal (if any)
 	statusErr        string               // Error message to display (if any)
+	statusMsg        string               // Success/info message to display (if any)
 	themeIdx         int                  // Index into styles.Themes for the active theme
 	view             activeView           // Currently active main panel view
 	width            int                  // Terminal width in columns; 0 means use default
@@ -561,7 +572,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusErr = fmt.Sprintf("Failed to spawn session: %v", msg.err)
 			return m, clearErrorCmd()
 		}
-		return m, nil
+		pid := 0
+		if msg.session.ShellPID != nil {
+			pid = *msg.session.ShellPID
+		}
+		m.statusMsg = fmt.Sprintf("Session spawned for %s (PID %d)", msg.session.WorktreePath, pid)
+		return m, clearMsgCmd()
 
 	case worktreesRefreshedMsg:
 		if msg.err == nil {
@@ -658,6 +674,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case clearErrorMsg:
 		m.statusErr = ""
 
+	case clearMsgMsg:
+		m.statusMsg = ""
+
 	case syncTickMsg:
 		m.syncing = true
 		return m, m.syncGitHubCmd()
@@ -711,6 +730,10 @@ func (m *Model) View() string {
 
 	if m.statusErr != "" {
 		return renderErrorModal(m.statusErr, w, h, baseView)
+	}
+
+	if m.statusMsg != "" {
+		return renderInfoModal(m.statusMsg, w, h, baseView)
 	}
 
 	return baseView
@@ -1087,7 +1110,7 @@ func getShell() string {
 //
 //   - Windows: cmd /C start cmd /K "cd /d <path>"
 //   - macOS:   open -a Terminal <path>
-//   - Linux:   $TERMINAL --working-directory=<path>  (fallback: xterm)
+//   - Linux:   $TERMINAL --working-directory=<path>  (fallback: x-terminal-emulator, then xterm)
 func buildNewTerminalCmd(path, goos string) *exec.Cmd {
 	switch goos {
 	case "windows":
@@ -1103,6 +1126,15 @@ func buildNewTerminalCmd(path, goos string) *exec.Cmd {
 		if shell == "" {
 			shell = "/bin/sh"
 		}
+		// Try common terminal emulators in order; x-terminal-emulator is the
+		// Debian/Ubuntu update-alternatives symlink that works on most distros.
+		for _, candidate := range []string{"x-terminal-emulator", "xterm"} {
+			if _, err := exec.LookPath(candidate); err == nil {
+				return exec.Command(candidate, "-e", fmt.Sprintf("cd %q; %s", path, shell))
+			}
+		}
+		// Last resort: return an xterm cmd; Start() will surface the error if
+		// xterm is not installed either.
 		return exec.Command("xterm", "-e", fmt.Sprintf("cd %q; %s", path, shell))
 	}
 }

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -569,6 +569,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sessionSpawnedMsg:
 		if msg.err != nil {
+			if msg.session.ShellPID != nil {
+				// Terminal launched but PID tracking failed — non-fatal.
+				m.statusMsg = fmt.Sprintf("Session spawned for %s (PID %d) — tracking failed: %v", msg.session.WorktreePath, *msg.session.ShellPID, msg.err)
+				return m, clearMsgCmd()
+			}
 			m.statusErr = fmt.Sprintf("Failed to spawn session: %v", msg.err)
 			return m, clearErrorCmd()
 		}
@@ -1154,7 +1159,7 @@ func (m *Model) spawnSessionCmd(worktreePath string) tea.Cmd {
 			WorktreePath: worktreePath,
 			ShellPID:     &pid,
 			Status:       domain.StatusActive,
-			StartedAt:    time.Now(),
+			StartedAt:    time.Now().UTC().Truncate(time.Second),
 		}
 		if db != nil {
 			id, err := data.UpsertSession(db, session)

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -91,12 +91,16 @@ func clearErrorCmd() tea.Cmd {
 	})
 }
 
-// clearMsgMsg is dispatched after the 3-second success-notification timer fires.
+// msgAutoDismissDuration is how long the success/info toast stays visible before
+// being cleared by clearMsgCmd. Must stay in sync with the label in renderInfoModal.
+const msgAutoDismissDuration = 3 * time.Second
+
+// clearMsgMsg is dispatched after the success-notification timer fires.
 type clearMsgMsg struct{}
 
-// clearMsgCmd returns a Cmd that fires clearMsgMsg after 3 seconds.
+// clearMsgCmd returns a Cmd that fires clearMsgMsg after msgAutoDismissDuration.
 func clearMsgCmd() tea.Cmd {
-	return tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+	return tea.Tick(msgAutoDismissDuration, func(t time.Time) tea.Msg {
 		return clearMsgMsg{}
 	})
 }
@@ -1119,7 +1123,8 @@ func getShell() string {
 func buildNewTerminalCmd(path, goos string) *exec.Cmd {
 	switch goos {
 	case "windows":
-		return exec.Command("cmd", "/C", "start", "cmd", "/K", fmt.Sprintf(`cd /d %s`, path))
+		// Quote the path so worktree paths that contain spaces are handled correctly.
+		return exec.Command("cmd", "/C", "start", "cmd", "/K", fmt.Sprintf(`cd /d "%s"`, path))
 	case "darwin":
 		return exec.Command("open", "-a", "Terminal", path)
 	default:
@@ -1157,7 +1162,11 @@ func (m *Model) spawnSessionCmd(worktreePath string) tea.Cmd {
 		pid := cmd.Process.Pid
 		session := domain.Session{
 			WorktreePath: worktreePath,
-			ShellPID:     &pid,
+			// NOTE: on Windows (cmd /C start) and macOS (open -a Terminal) the
+			// launcher process exits almost immediately, so this PID is best-effort
+			// — it will be dead by the time Mission Control queries it.
+			// On Linux the terminal emulator process stays alive, so PID is reliable.
+			ShellPID:  &pid,
 			Status:       domain.StatusActive,
 			StartedAt:    time.Now().UTC().Truncate(time.Second),
 		}

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -1166,7 +1166,7 @@ func TestModel_WindowSizeMsg_StoresDimensions(t *testing.T) {
 
 
 // TestModelUpdate_SKeyOpensShellInWorktreeverifies that pressing "s" in
-// viewWorktrees with a selected worktree triggers switchWorktreeCmd.
+// viewWorktrees with a selected worktree triggers spawnSessionCmd.
 func TestModelUpdate_SKeyOpensShellInWorktree(t *testing.T) {
 tests := []struct {
 name       string
@@ -1175,7 +1175,7 @@ worktrees  []domain.Worktree
 wantCmdNil bool
 }{
 {
-name: "s key triggers switchWorktreeCmd when in worktrees view",
+name: "s key triggers spawnSessionCmd when in worktrees view",
 view: viewWorktrees,
 worktrees: []domain.Worktree{
 {Path: "/tmp/my-wt", Branch: "feat/my-branch", IsClean: true},
@@ -1183,10 +1183,10 @@ worktrees: []domain.Worktree{
 wantCmdNil: false,
 },
 {
-name:       "s key does nothing when worktree list is empty",
+name:       "s key returns clearErrorCmd when worktree list is empty",
 view:       viewWorktrees,
 worktrees:  nil,
-wantCmdNil: true,
+wantCmdNil: false, // clearErrorCmd is returned with the "no worktree selected" error
 },
 {
 name: "s key does nothing in issues view",
@@ -1209,7 +1209,7 @@ _, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
 if tt.wantCmdNil {
 assert.Nil(t, cmd)
 } else {
-assert.NotNil(t, cmd, "expected a non-nil cmd from switchWorktreeCmd")
+assert.NotNil(t, cmd, "expected a non-nil cmd from spawnSessionCmd or clearErrorCmd")
 }
 })
 }
@@ -2373,5 +2373,167 @@ func TestPagination_PrevPageClampsAtZero(t *testing.T) {
 	m2 := updated.(*Model)
 	assert.Equal(t, 0, m2.currentPage, "PageUp on first page stays at page 0")
 	assert.Equal(t, 0, m2.selectedIssueIdx, "selectedIssueIdx unchanged when already at first page")
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 (sessions): buildNewTerminalCmd and sessionSpawnedMsg tests
+// ---------------------------------------------------------------------------
+
+// TestBuildNewTerminalCmd verifies that buildNewTerminalCmd returns the correct
+// command shape for each supported platform.
+func TestBuildNewTerminalCmd(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		goos        string
+		terminalEnv string
+		wantExe     string
+		wantArgs    []string
+	}{
+		{
+			name:     "windows launches cmd /C start cmd /K",
+			path:     `C:\repo\wt-feature`,
+			goos:     "windows",
+			wantExe:  "cmd",
+			wantArgs: []string{"cmd", "/C", "start", "cmd", "/K", `cd /d C:\repo\wt-feature`},
+		},
+		{
+			name:     "darwin uses open -a Terminal",
+			path:     "/Users/dev/repo/wt",
+			goos:     "darwin",
+			wantExe:  "open",
+			wantArgs: []string{"open", "-a", "Terminal", "/Users/dev/repo/wt"},
+		},
+		{
+			name:        "linux with TERMINAL env uses --working-directory",
+			path:        "/home/dev/repo/wt",
+			goos:        "linux",
+			terminalEnv: "kitty",
+			wantExe:     "kitty",
+			wantArgs:    []string{"kitty", "--working-directory=/home/dev/repo/wt"},
+		},
+		{
+			name:    "linux without TERMINAL env falls back to xterm",
+			path:    "/home/dev/repo/wt",
+			goos:    "linux",
+			wantExe: "xterm",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TERMINAL", tt.terminalEnv)
+
+			cmd := buildNewTerminalCmd(tt.path, tt.goos)
+			require.NotNil(t, cmd)
+			require.NotEmpty(t, cmd.Args)
+
+			// The first arg is the executable path — check it contains the expected name.
+			assert.Contains(t, cmd.Args[0], tt.wantExe,
+				"command executable should contain %q", tt.wantExe)
+
+			if tt.wantArgs != nil {
+				assert.Equal(t, tt.wantArgs, cmd.Args)
+			}
+		})
+	}
+}
+
+// TestModelUpdate_SessionSpawnedMsg_ErrorSetsStatusErr verifies that when
+// sessionSpawnedMsg carries an error, Update sets statusErr and returns a
+// non-nil Cmd (clearErrorCmd).
+func TestModelUpdate_SessionSpawnedMsg_ErrorSetsStatusErr(t *testing.T) {
+	tests := []struct {
+		name      string
+		msg       sessionSpawnedMsg
+		wantError string
+	}{
+		{
+			name:      "spawn error sets statusErr",
+			msg:       sessionSpawnedMsg{err: errors.New("spawn session: exec: no such file")},
+			wantError: "Failed to spawn session: spawn session: exec: no such file",
+		},
+		{
+			name:      "track error sets statusErr",
+			msg:       sessionSpawnedMsg{err: errors.New("track session: db closed")},
+			wantError: "Failed to spawn session: track session: db closed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewModel()
+			require.NotNil(t, m)
+
+			updated, cmd := m.Update(tt.msg)
+			next, ok := updated.(*Model)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.wantError, next.statusErr)
+			assert.NotNil(t, cmd, "clearErrorCmd should be returned on spawn error")
+		})
+	}
+}
+
+// TestModelUpdate_SessionSpawnedMsg_SuccessReturnsNilCmd verifies that a
+// successful sessionSpawnedMsg returns a nil Cmd (no further actions needed).
+func TestModelUpdate_SessionSpawnedMsg_SuccessReturnsNilCmd(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+
+	updated, cmd := m.Update(sessionSpawnedMsg{
+		session: domain.Session{ID: 1, WorktreePath: "/repo/feat", PID: 9999},
+	})
+	_, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Nil(t, cmd, "no clearErrorCmd on success")
+}
+
+// TestModel_SKey_InWorktreeView_WithSelection_ReturnsSpawnCmd verifies that
+// pressing s in the worktrees view with a selection returns a non-nil Cmd.
+func TestModel_SKey_InWorktreeView_WithSelection_ReturnsSpawnCmd(t *testing.T) {
+	m := NewModel()
+	m.view = viewWorktrees
+	m.Worktrees = []domain.Worktree{
+		{Path: "/repos/nexus", Branch: "main"},
+	}
+	m.selectedIdx = 0
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	next, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.NotNil(t, cmd, "s key on selected worktree should return a spawn Cmd")
+	assert.Empty(t, next.statusErr, "no error when a worktree is selected")
+}
+
+// TestModel_SKey_InWorktreeView_NoSelection_SetsError verifies that pressing s
+// in the worktrees view with no selection sets statusErr.
+func TestModel_SKey_InWorktreeView_NoSelection_SetsError(t *testing.T) {
+	m := NewModel()
+	m.view = viewWorktrees
+	m.Worktrees = nil
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	next, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.NotEmpty(t, next.statusErr, "statusErr should be set when no worktree is selected")
+	assert.NotNil(t, cmd, "clearErrorCmd should be returned")
+}
+
+// TestModel_EnterKey_StillUsesSwitchWorktreeCmd verifies that pressing Enter
+// still triggers switchWorktreeCmd (i.e. s-key rebind did not affect Enter).
+func TestModel_EnterKey_StillUsesSwitchWorktreeCmd(t *testing.T) {
+	m := NewModel()
+	m.view = viewWorktrees
+	m.Worktrees = []domain.Worktree{
+		{Path: "/repos/nexus", Branch: "main"},
+	}
+	m.selectedIdx = 0
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	assert.NotNil(t, cmd, "Enter key must still return a Cmd (switchWorktreeCmd)")
 }
 

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -2387,15 +2387,23 @@ func TestBuildNewTerminalCmd(t *testing.T) {
 		path        string
 		goos        string
 		terminalEnv string
+		shellEnv    string
 		wantExe     string
 		wantArgs    []string
 	}{
 		{
-			name:     "windows launches cmd /C start cmd /K",
+			name:     "windows launches cmd /C start cmd /K with quoted path",
 			path:     `C:\repo\wt-feature`,
 			goos:     "windows",
 			wantExe:  "cmd",
-			wantArgs: []string{"cmd", "/C", "start", "cmd", "/K", `cd /d C:\repo\wt-feature`},
+			wantArgs: []string{"cmd", "/C", "start", "cmd", "/K", `cd /d "C:\repo\wt-feature"`},
+		},
+		{
+			name:     "windows quotes path containing spaces",
+			path:     `C:\My Projects\nexus`,
+			goos:     "windows",
+			wantExe:  "cmd",
+			wantArgs: []string{"cmd", "/C", "start", "cmd", "/K", `cd /d "C:\My Projects\nexus"`},
 		},
 		{
 			name:     "darwin uses open -a Terminal",
@@ -2413,16 +2421,19 @@ func TestBuildNewTerminalCmd(t *testing.T) {
 			wantArgs:    []string{"kitty", "--working-directory=/home/dev/repo/wt"},
 		},
 		{
-			name:    "linux without TERMINAL env falls back to xterm",
-			path:    "/home/dev/repo/wt",
-			goos:    "linux",
-			wantExe: "xterm",
+			name:     "linux without TERMINAL env falls back to xterm",
+			path:     "/home/dev/repo/wt",
+			goos:     "linux",
+			shellEnv: "/bin/bash",
+			wantExe:  "xterm",
+			wantArgs: []string{"xterm", "-e", `cd "/home/dev/repo/wt"; /bin/bash`},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("TERMINAL", tt.terminalEnv)
+			t.Setenv("SHELL", tt.shellEnv)
 
 			cmd := buildNewTerminalCmd(tt.path, tt.goos)
 			require.NotNil(t, cmd)

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -2439,40 +2439,41 @@ func TestBuildNewTerminalCmd(t *testing.T) {
 	}
 }
 
-// TestModelUpdate_SessionSpawnedMsg_ErrorSetsStatusErr verifies that when
-// sessionSpawnedMsg carries an error, Update sets statusErr and returns a
-// non-nil Cmd (clearErrorCmd).
-func TestModelUpdate_SessionSpawnedMsg_ErrorSetsStatusErr(t *testing.T) {
-	tests := []struct {
-		name      string
-		msg       sessionSpawnedMsg
-		wantError string
-	}{
-		{
-			name:      "spawn error sets statusErr",
-			msg:       sessionSpawnedMsg{err: errors.New("spawn session: exec: no such file")},
-			wantError: "Failed to spawn session: spawn session: exec: no such file",
-		},
-		{
-			name:      "track error sets statusErr",
-			msg:       sessionSpawnedMsg{err: errors.New("track session: db closed")},
-			wantError: "Failed to spawn session: track session: db closed",
-		},
-	}
+// TestModelUpdate_SessionSpawnedMsg_SpawnErrorSetsStatusErr verifies that when
+// the terminal itself failed to launch (PID == 0), Update sets statusErr.
+func TestModelUpdate_SessionSpawnedMsg_SpawnErrorSetsStatusErr(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			m := NewModel()
-			require.NotNil(t, m)
+	updated, cmd := m.Update(sessionSpawnedMsg{err: errors.New("spawn session: exec: no such file")})
+	next, ok := updated.(*Model)
+	require.True(t, ok)
 
-			updated, cmd := m.Update(tt.msg)
-			next, ok := updated.(*Model)
-			require.True(t, ok)
+	assert.Equal(t, "Failed to spawn session: spawn session: exec: no such file", next.statusErr)
+	assert.Empty(t, next.statusMsg, "statusMsg must be empty on a hard spawn failure")
+	assert.NotNil(t, cmd, "clearErrorCmd should be returned on spawn error")
+}
 
-			assert.Equal(t, tt.wantError, next.statusErr)
-			assert.NotNil(t, cmd, "clearErrorCmd should be returned on spawn error")
-		})
-	}
+// TestModelUpdate_SessionSpawnedMsg_TrackErrorSetsStatusMsg verifies that when
+// the terminal launched (PID != 0) but PID tracking failed, Update sets statusMsg
+// (not statusErr) so the user sees a non-fatal warning.
+func TestModelUpdate_SessionSpawnedMsg_TrackErrorSetsStatusMsg(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+
+	pid5678 := 5678
+	updated, cmd := m.Update(sessionSpawnedMsg{
+		session: domain.Session{WorktreePath: "/repo/wt", ShellPID: &pid5678},
+		err:     errors.New("track session: db closed"),
+	})
+	next, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Empty(t, next.statusErr, "statusErr must be empty when terminal did launch")
+	assert.Contains(t, next.statusMsg, "/repo/wt", "statusMsg should include the worktree path")
+	assert.Contains(t, next.statusMsg, "5678", "statusMsg should include the PID")
+	assert.Contains(t, next.statusMsg, "tracking failed", "statusMsg should indicate tracking failed")
+	assert.NotNil(t, cmd, "clearMsgCmd should be returned on a non-fatal tracking error")
 }
 
 // TestModelUpdate_SessionSpawnedMsg_SuccessSetsStatusMsg verifies that a
@@ -2481,8 +2482,9 @@ func TestModelUpdate_SessionSpawnedMsg_SuccessSetsStatusMsg(t *testing.T) {
 	m := NewModel()
 	require.NotNil(t, m)
 
+	pid9999 := 9999
 	updated, cmd := m.Update(sessionSpawnedMsg{
-		session: domain.Session{ID: 1, WorktreePath: "/repo/feat", PID: 9999},
+		session: domain.Session{ID: 1, WorktreePath: "/repo/feat", ShellPID: &pid9999},
 	})
 	next, ok := updated.(*Model)
 	require.True(t, ok)

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -2475,19 +2475,22 @@ func TestModelUpdate_SessionSpawnedMsg_ErrorSetsStatusErr(t *testing.T) {
 	}
 }
 
-// TestModelUpdate_SessionSpawnedMsg_SuccessReturnsNilCmd verifies that a
-// successful sessionSpawnedMsg returns a nil Cmd (no further actions needed).
-func TestModelUpdate_SessionSpawnedMsg_SuccessReturnsNilCmd(t *testing.T) {
+// TestModelUpdate_SessionSpawnedMsg_SuccessSetsStatusMsg verifies that a
+// successful sessionSpawnedMsg sets statusMsg with PID info and returns clearMsgCmd.
+func TestModelUpdate_SessionSpawnedMsg_SuccessSetsStatusMsg(t *testing.T) {
 	m := NewModel()
 	require.NotNil(t, m)
 
 	updated, cmd := m.Update(sessionSpawnedMsg{
 		session: domain.Session{ID: 1, WorktreePath: "/repo/feat", PID: 9999},
 	})
-	_, ok := updated.(*Model)
+	next, ok := updated.(*Model)
 	require.True(t, ok)
 
-	assert.Nil(t, cmd, "no clearErrorCmd on success")
+	assert.NotNil(t, cmd, "clearMsgCmd should be returned on success")
+	assert.Contains(t, next.statusMsg, "/repo/feat", "statusMsg should include the worktree path")
+	assert.Contains(t, next.statusMsg, "9999", "statusMsg should include the PID")
+	assert.Empty(t, next.statusErr, "no error on success")
 }
 
 // TestModel_SKey_InWorktreeView_WithSelection_ReturnsSpawnCmd verifies that

--- a/cmd/nexus/main.go
+++ b/cmd/nexus/main.go
@@ -41,6 +41,8 @@ func run() error {
 	if db, err := data.NewDB(dbPath); err == nil {
 		m.db = db
 		defer db.Close()
+		// Best-effort cleanup: remove sessions whose processes are no longer alive.
+		_ = data.DeleteDeadSessions(db)
 	}
 
 	opts := []tea.ProgramOption{tea.WithAltScreen()}

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -995,6 +995,26 @@ func renderErrorModal(msg string, termWidth, termHeight int, baseView string) st
 	return overlayBottomRight(baseView, box, termWidth)
 }
 
+// renderInfoModal renders a floating success/info notification box anchored to the
+// bottom-right corner of the terminal viewport, overlaid on top of the base view.
+func renderInfoModal(msg string, termWidth, termHeight int, baseView string) string {
+	if termWidth <= 0 {
+		termWidth = defaultTermWidth
+	}
+	if termHeight <= 0 {
+		termHeight = 24
+	}
+
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("#00FF88")).
+		Padding(0, 1).
+		MaxWidth(60).
+		Render("✓ " + msg + "\n\nAuto-dismisses in 3s")
+
+	return overlayBottomRight(baseView, box, termWidth)
+}
+
 // overlayBottomRight places the overlay string at the bottom-right corner of the
 // base string. ANSI escape codes in both strings are handled correctly via
 // charmbracelet/x/ansi. base is assumed to be a multi-line string filling the

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -1001,16 +1001,14 @@ func renderInfoModal(msg string, termWidth, termHeight int, baseView string) str
 	if termWidth <= 0 {
 		termWidth = defaultTermWidth
 	}
-	if termHeight <= 0 {
-		termHeight = 24
-	}
+	_ = termHeight // reserved for future height-capping logic
 
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color("#00FF88")).
 		Padding(0, 1).
 		MaxWidth(60).
-		Render("✓ " + msg + "\n\nAuto-dismisses in 3s")
+		Render(fmt.Sprintf("✓ %s\n\nAuto-dismisses in %.0fs", msg, msgAutoDismissDuration.Seconds()))
 
 	return overlayBottomRight(baseView, box, termWidth)
 }

--- a/internal/exec/git.go
+++ b/internal/exec/git.go
@@ -74,9 +74,14 @@ func (g *GitCommand) isWorktreeClean(path string) (bool, error) {
 	return strings.TrimSpace(output) == "", nil
 }
 
-// AddWorktreeNewBranch creates a new worktree and branch: git worktree add -b <branch> <path> <baseBranch>.
+// AddWorktreeNewBranch fetches the latest state of baseBranch from origin, then
+// creates a new worktree and branch rooted at origin/<baseBranch> so the
+// worktree always starts from the most recent remote commit.
 func (g *GitCommand) AddWorktreeNewBranch(path, branchName, baseBranch string) error {
-	return g.runNoOutput("add worktree new branch", "worktree", "add", "-b", branchName, path, baseBranch)
+	if err := g.FetchRemoteBranch(baseBranch); err != nil {
+		return err
+	}
+	return g.runNoOutput("add worktree new branch", "worktree", "add", "-b", branchName, path, "origin/"+baseBranch)
 }
 
 // AddWorktree adds a new worktree at path for branch.

--- a/internal/exec/git_test.go
+++ b/internal/exec/git_test.go
@@ -340,48 +340,77 @@ func TestGitCommand_AddWorktree(t *testing.T) {
 
 func TestGitCommand_AddWorktreeNewBranch(t *testing.T) {
 	tests := []struct {
-		name       string
-		repoPath   string
-		path       string
-		branchName string
-		baseBranch string
-		runErr     error
-		wantArgs   []string
-		expectErr  string
+		name         string
+		repoPath     string
+		path         string
+		branchName   string
+		baseBranch   string
+		fetchErr     error
+		worktreeErr  error
+		wantCallSeq  [][]string
+		expectErr    string
 	}{
 		{
-			name:       "invokes git worktree add with -b flag",
+			name:       "fetches base branch then creates worktree from origin/<base>",
 			repoPath:   "/repo/main",
 			path:       "/repo/worktrees/feat-issue-5-modals",
 			branchName: "feat/issue-5-modals",
 			baseBranch: "main",
-			wantArgs:   []string{"worktree", "add", "-b", "feat/issue-5-modals", "/repo/worktrees/feat-issue-5-modals", "main"},
+			wantCallSeq: [][]string{
+				{"fetch", "origin", "main"},
+				{"worktree", "add", "-b", "feat/issue-5-modals", "/repo/worktrees/feat-issue-5-modals", "origin/main"},
+			},
 		},
 		{
-			name:       "returns runner error",
+			name:       "fetches feature base branch then creates worktree from origin/<base>",
+			repoPath:   "/repo/main",
+			path:       "/repo/worktrees/feat-issue-63",
+			branchName: "feat/issue-63-my-feature",
+			baseBranch: "feat/issue-61-base",
+			wantCallSeq: [][]string{
+				{"fetch", "origin", "feat/issue-61-base"},
+				{"worktree", "add", "-b", "feat/issue-63-my-feature", "/repo/worktrees/feat-issue-63", "origin/feat/issue-61-base"},
+			},
+		},
+		{
+			name:       "returns error when fetch fails",
 			repoPath:   "/repo/main",
 			path:       "/repo/worktrees/feat-issue-5-modals",
 			branchName: "feat/issue-5-modals",
 			baseBranch: "main",
-			runErr:     errors.New("git failed"),
-			wantArgs:   []string{"worktree", "add", "-b", "feat/issue-5-modals", "/repo/worktrees/feat-issue-5-modals", "main"},
-			expectErr:  "git failed",
+			fetchErr:   errors.New("network error"),
+			expectErr:  "network error",
+		},
+		{
+			name:        "returns error when worktree add fails",
+			repoPath:    "/repo/main",
+			path:        "/repo/worktrees/feat-issue-5-modals",
+			branchName:  "feat/issue-5-modals",
+			baseBranch:  "main",
+			worktreeErr: errors.New("branch already exists"),
+			expectErr:   "branch already exists",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var calledArgs []string
+			var callSeq [][]string
 
 			runner := func(repoPath string, args ...string) (string, error) {
-				calledArgs = append([]string{}, args...)
-				return "", tt.runErr
+				call := append([]string{}, args...)
+				callSeq = append(callSeq, call)
+				// First call is fetch, second is worktree add.
+				if len(callSeq) == 1 && tt.fetchErr != nil {
+					return "", tt.fetchErr
+				}
+				if len(callSeq) == 2 && tt.worktreeErr != nil {
+					return "", tt.worktreeErr
+				}
+				return "", nil
 			}
 
 			cmd := NewGitCommandWithRunner(tt.repoPath, runner)
 			err := cmd.AddWorktreeNewBranch(tt.path, tt.branchName, tt.baseBranch)
-
-			assert.Equal(t, tt.wantArgs, calledArgs)
 
 			if tt.expectErr != "" {
 				require.Error(t, err)
@@ -390,6 +419,7 @@ func TestGitCommand_AddWorktreeNewBranch(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			assert.Equal(t, tt.wantCallSeq, callSeq)
 		})
 	}
 }


### PR DESCRIPTION
Closes #63

## What Changed
Implements spawnSessionCmd(worktreePath) that opens a new terminal window (non-blocking) for the selected worktree and stores the spawned shell PID in the ctive_sessions SQLite table.

## Why
Phase 2 of the Active Sessions feature (#61). The worktrees view needs to spawn dedicated terminals per worktree and track their PIDs so the Mission Control screen (Phase 3) can display and manage live sessions.

## Changes
- domain.Session type added
- Migration 