### PR TITLE
feat(sessions): phase 3 - session polling (PID health checks, dead session cleanup)

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -54,6 +54,12 @@ type githubSyncedMsg struct {
 // syncTickMsg triggers the next periodic GitHub sync.
 type syncTickMsg struct{}
 
+// sessionTickMsg triggers the next periodic session health check.
+type sessionTickMsg struct{}
+
+// sessionStatusUpdatedMsg carries the updated sessions list after a health check.
+type sessionStatusUpdatedMsg struct{ sessions []domain.Session }
+
 // debouncedRenderMsg fires after the debounce delay to apply pending sync data.
 type debouncedRenderMsg struct{}
 
@@ -88,6 +94,13 @@ type clearErrorMsg struct{}
 func clearErrorCmd() tea.Cmd {
 	return tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
 		return clearErrorMsg{}
+	})
+}
+
+// sessionTickCmd schedules a sessionTickMsg after 3 seconds.
+func sessionTickCmd() tea.Cmd {
+	return tea.Tick(3*time.Second, func(t time.Time) tea.Msg {
+		return sessionTickMsg{}
 	})
 }
 
@@ -186,6 +199,9 @@ type Model struct {
 	// DB is optional; when non-nil, agent runs are logged to agent_history.
 	db *data.DB
 
+	// sessions holds the last-known list of active terminal sessions.
+	sessions []domain.Session
+
 	// issueTree caches the depth-first-ordered tree built from m.issues.
 	// Rebuilt whenever m.issues is updated (debouncedRenderMsg handler).
 	issueTree []issueTreeRow
@@ -228,7 +244,7 @@ func NewModel() *Model {
 // Init initializes the model and triggers an initial worktree list load and GitHub sync.
 func (m *Model) Init() tea.Cmd {
 	m.syncing = true
-	return tea.Batch(m.refreshWorktreesCmd(), m.syncGitHubCmd())
+	return tea.Batch(m.refreshWorktreesCmd(), m.syncGitHubCmd(), sessionTickCmd())
 }
 
 // Update handles incoming messages and returns an updated model and command.
@@ -689,6 +705,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case syncTickMsg:
 		m.syncing = true
 		return m, m.syncGitHubCmd()
+
+	case sessionTickMsg:
+		return m, m.checkSessionsCmd()
+
+	case sessionStatusUpdatedMsg:
+		m.sessions = msg.sessions
+		return m, sessionTickCmd()
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -1182,7 +1205,53 @@ func (m *Model) spawnSessionCmd(worktreePath string) tea.Cmd {
 	}
 }
 
-// worktreesRefreshedMsg carries the result of refreshing the worktree list.
+// checkSessionsCmd reads all tracked sessions from the DB, checks whether each
+// PID is still alive, updates session status for agent-only survivors, and
+// removes fully dead sessions. Returns sessionStatusUpdatedMsg with the updated list.
+// When db is nil it is a no-op that returns the current sessions unchanged.
+func (m *Model) checkSessionsCmd() tea.Cmd {
+	db := m.db
+	current := m.sessions
+	return func() tea.Msg {
+		if db == nil {
+			return sessionStatusUpdatedMsg{sessions: current}
+		}
+		all, err := data.GetSessions(db)
+		if err != nil {
+			return sessionStatusUpdatedMsg{sessions: current}
+		}
+		var alive []domain.Session
+		for _, s := range all {
+			if s.ShellPID == nil {
+				// No PID to check — keep as-is.
+				alive = append(alive, s)
+				continue
+			}
+			shellAlive := pidAlive(*s.ShellPID)
+			agentAlive := s.AgentPID != nil && pidAlive(*s.AgentPID)
+
+			if shellAlive {
+				alive = append(alive, s)
+				continue
+			}
+			// Shell is dead.
+			if agentAlive {
+				// Agent is still running — transition to agent_running.
+				s.Status = domain.StatusAgentRunning
+				_, _ = data.UpsertSession(db, s)
+				alive = append(alive, s)
+				continue
+			}
+			// Both are dead — remove from DB.
+			_ = data.DeleteSession(db, s.ID)
+		}
+		if alive == nil {
+			alive = []domain.Session{}
+		}
+		return sessionStatusUpdatedMsg{sessions: alive}
+	}
+}
+
 type worktreesRefreshedMsg struct {
 	worktrees []domain.Worktree
 	err       error

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -244,7 +244,11 @@ func NewModel() *Model {
 // Init initializes the model and triggers an initial worktree list load and GitHub sync.
 func (m *Model) Init() tea.Cmd {
 	m.syncing = true
-	return tea.Batch(m.refreshWorktreesCmd(), m.syncGitHubCmd(), sessionTickCmd())
+	cmds := []tea.Cmd{m.refreshWorktreesCmd(), m.syncGitHubCmd()}
+	if m.db != nil {
+		cmds = append(cmds, sessionTickCmd())
+	}
+	return tea.Batch(cmds...)
 }
 
 // Update handles incoming messages and returns an updated model and command.
@@ -1218,6 +1222,7 @@ func (m *Model) checkSessionsCmd() tea.Cmd {
 		}
 		all, err := data.GetSessions(db)
 		if err != nil {
+			slog.Warn("session health check: failed to read sessions from DB", "err", err)
 			return sessionStatusUpdatedMsg{sessions: current}
 		}
 		var alive []domain.Session
@@ -1238,12 +1243,16 @@ func (m *Model) checkSessionsCmd() tea.Cmd {
 			if agentAlive {
 				// Agent is still running — transition to agent_running.
 				s.Status = domain.StatusAgentRunning
-				_, _ = data.UpsertSession(db, s)
+				if _, err := data.UpsertSession(db, s); err != nil {
+					slog.Warn("session health check: failed to update session status", "id", s.ID, "err", err)
+				}
 				alive = append(alive, s)
 				continue
 			}
 			// Both are dead — remove from DB.
-			_ = data.DeleteSession(db, s.ID)
+			if err := data.DeleteSession(db, s.ID); err != nil {
+				slog.Warn("session health check: failed to delete dead session", "id", s.ID, "err", err)
+			}
 		}
 		if alive == nil {
 			alive = []domain.Session{}

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -2553,3 +2554,76 @@ func TestModel_EnterKey_StillUsesSwitchWorktreeCmd(t *testing.T) {
 	assert.NotNil(t, cmd, "Enter key must still return a Cmd (switchWorktreeCmd)")
 }
 
+
+// TestSessionTickMsg verifies that sessionTickMsg dispatches checkSessionsCmd.
+func TestSessionTickMsg(t *testing.T) {
+m := NewModel()
+_, cmd := m.Update(sessionTickMsg{})
+assert.NotNil(t, cmd, "sessionTickMsg should return a non-nil command (checkSessionsCmd)")
+}
+
+// TestSessionStatusUpdatedMsg verifies that sessionStatusUpdatedMsg updates m.sessions
+// and schedules the next tick.
+func TestSessionStatusUpdatedMsg(t *testing.T) {
+m := NewModel()
+sessions := []domain.Session{
+{ID: 1, WorktreePath: "/repo/test", Status: domain.StatusActive},
+}
+updated, cmd := m.Update(sessionStatusUpdatedMsg{sessions: sessions})
+m2 := updated.(*Model)
+require.Len(t, m2.sessions, 1)
+assert.Equal(t, "/repo/test", m2.sessions[0].WorktreePath)
+assert.NotNil(t, cmd, "sessionStatusUpdatedMsg should schedule next tick")
+}
+
+// TestSessionStatusUpdatedMsg_Empty verifies that empty sessions list is stored correctly.
+func TestSessionStatusUpdatedMsg_Empty(t *testing.T) {
+m := NewModel()
+m.sessions = []domain.Session{{ID: 1, WorktreePath: "/repo/old"}}
+updated, _ := m.Update(sessionStatusUpdatedMsg{sessions: []domain.Session{}})
+m2 := updated.(*Model)
+assert.Empty(t, m2.sessions)
+}
+
+// TestCheckSessionsCmd_NilDB verifies that checkSessionsCmd is a no-op when db is nil.
+func TestCheckSessionsCmd_NilDB(t *testing.T) {
+m := NewModel()
+m.sessions = []domain.Session{
+{ID: 1, WorktreePath: "/repo/existing", Status: domain.StatusActive},
+}
+cmd := m.checkSessionsCmd()
+require.NotNil(t, cmd)
+msg := cmd()
+result, ok := msg.(sessionStatusUpdatedMsg)
+require.True(t, ok, "expected sessionStatusUpdatedMsg, got %T", msg)
+require.Len(t, result.sessions, 1)
+assert.Equal(t, "/repo/existing", result.sessions[0].WorktreePath)
+}
+
+// TestCheckSessionsCmd_EmptyDB verifies that checkSessionsCmd returns empty sessions when DB is empty.
+func TestCheckSessionsCmd_EmptyDB(t *testing.T) {
+db, err := data.NewDB(":memory:")
+require.NoError(t, err)
+t.Cleanup(func() { _ = db.Close() })
+
+m := NewModel()
+m.db = db
+cmd := m.checkSessionsCmd()
+require.NotNil(t, cmd)
+msg := cmd()
+result, ok := msg.(sessionStatusUpdatedMsg)
+require.True(t, ok)
+assert.Empty(t, result.sessions)
+}
+
+// TestPidAlive_CurrentProcess verifies that pidAlive returns true for the current process.
+func TestPidAlive_CurrentProcess(t *testing.T) {
+assert.True(t, pidAlive(os.Getpid()), "current process should be alive")
+}
+
+// TestPidAlive_InvalidPID verifies that pidAlive returns false for an invalid PID.
+func TestPidAlive_InvalidPID(t *testing.T) {
+// PID 0 is the idle process on Windows and typically reserved on Unix.
+// A very high PID is extremely unlikely to exist.
+assert.False(t, pidAlive(999999999), "PID 999999999 should not be alive")
+}

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -892,13 +892,13 @@ func TestModel_G_Key_OpensInBrowser(t *testing.T) {
 // the new list bounds so openInBrowserCmd never panics.
 func TestModel_GithubSync_ClampsIssueAndPRIdx(t *testing.T) {
 	tests := []struct {
-		name             string
-		initialIssueIdx  int
-		initialPRIdx     int
-		syncIssues       []domain.Issue
-		syncPRs          []domain.PullRequest
-		wantIssueIdx     int
-		wantPRIdx        int
+		name            string
+		initialIssueIdx int
+		initialPRIdx    int
+		syncIssues      []domain.Issue
+		syncPRs         []domain.PullRequest
+		wantIssueIdx    int
+		wantPRIdx       int
 	}{
 		{
 			name:            "issue idx clamped when sync shrinks list",
@@ -1165,55 +1165,54 @@ func TestModel_WindowSizeMsg_StoresDimensions(t *testing.T) {
 	}
 }
 
-
 // TestModelUpdate_SKeyOpensShellInWorktreeverifies that pressing "s" in
 // viewWorktrees with a selected worktree triggers spawnSessionCmd.
 func TestModelUpdate_SKeyOpensShellInWorktree(t *testing.T) {
-tests := []struct {
-name       string
-view       activeView
-worktrees  []domain.Worktree
-wantCmdNil bool
-}{
-{
-name: "s key triggers spawnSessionCmd when in worktrees view",
-view: viewWorktrees,
-worktrees: []domain.Worktree{
-{Path: "/tmp/my-wt", Branch: "feat/my-branch", IsClean: true},
-},
-wantCmdNil: false,
-},
-{
-name:       "s key returns clearErrorCmd when worktree list is empty",
-view:       viewWorktrees,
-worktrees:  nil,
-wantCmdNil: false, // clearErrorCmd is returned with the "no worktree selected" error
-},
-{
-name: "s key does nothing in issues view",
-view: viewIssues,
-worktrees: []domain.Worktree{
-{Path: "/tmp/my-wt", Branch: "feat/my-branch", IsClean: true},
-},
-wantCmdNil: true,
-},
-}
+	tests := []struct {
+		name       string
+		view       activeView
+		worktrees  []domain.Worktree
+		wantCmdNil bool
+	}{
+		{
+			name: "s key triggers spawnSessionCmd when in worktrees view",
+			view: viewWorktrees,
+			worktrees: []domain.Worktree{
+				{Path: "/tmp/my-wt", Branch: "feat/my-branch", IsClean: true},
+			},
+			wantCmdNil: false,
+		},
+		{
+			name:       "s key returns clearErrorCmd when worktree list is empty",
+			view:       viewWorktrees,
+			worktrees:  nil,
+			wantCmdNil: false, // clearErrorCmd is returned with the "no worktree selected" error
+		},
+		{
+			name: "s key does nothing in issues view",
+			view: viewIssues,
+			worktrees: []domain.Worktree{
+				{Path: "/tmp/my-wt", Branch: "feat/my-branch", IsClean: true},
+			},
+			wantCmdNil: true,
+		},
+	}
 
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-model := NewModel()
-require.NotNil(t, model)
-model.view = tt.view
-model.Worktrees = tt.worktrees
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := NewModel()
+			require.NotNil(t, model)
+			model.view = tt.view
+			model.Worktrees = tt.worktrees
 
-_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
-if tt.wantCmdNil {
-assert.Nil(t, cmd)
-} else {
-assert.NotNil(t, cmd, "expected a non-nil cmd from spawnSessionCmd or clearErrorCmd")
-}
-})
-}
+			_, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+			if tt.wantCmdNil {
+				assert.Nil(t, cmd)
+			} else {
+				assert.NotNil(t, cmd, "expected a non-nil cmd from spawnSessionCmd or clearErrorCmd")
+			}
+		})
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -2554,76 +2553,75 @@ func TestModel_EnterKey_StillUsesSwitchWorktreeCmd(t *testing.T) {
 	assert.NotNil(t, cmd, "Enter key must still return a Cmd (switchWorktreeCmd)")
 }
 
-
 // TestSessionTickMsg verifies that sessionTickMsg dispatches checkSessionsCmd.
 func TestSessionTickMsg(t *testing.T) {
-m := NewModel()
-_, cmd := m.Update(sessionTickMsg{})
-assert.NotNil(t, cmd, "sessionTickMsg should return a non-nil command (checkSessionsCmd)")
+	m := NewModel()
+	_, cmd := m.Update(sessionTickMsg{})
+	assert.NotNil(t, cmd, "sessionTickMsg should return a non-nil command (checkSessionsCmd)")
 }
 
 // TestSessionStatusUpdatedMsg verifies that sessionStatusUpdatedMsg updates m.sessions
 // and schedules the next tick.
 func TestSessionStatusUpdatedMsg(t *testing.T) {
-m := NewModel()
-sessions := []domain.Session{
-{ID: 1, WorktreePath: "/repo/test", Status: domain.StatusActive},
-}
-updated, cmd := m.Update(sessionStatusUpdatedMsg{sessions: sessions})
-m2 := updated.(*Model)
-require.Len(t, m2.sessions, 1)
-assert.Equal(t, "/repo/test", m2.sessions[0].WorktreePath)
-assert.NotNil(t, cmd, "sessionStatusUpdatedMsg should schedule next tick")
+	m := NewModel()
+	sessions := []domain.Session{
+		{ID: 1, WorktreePath: "/repo/test", Status: domain.StatusActive},
+	}
+	updated, cmd := m.Update(sessionStatusUpdatedMsg{sessions: sessions})
+	m2 := updated.(*Model)
+	require.Len(t, m2.sessions, 1)
+	assert.Equal(t, "/repo/test", m2.sessions[0].WorktreePath)
+	assert.NotNil(t, cmd, "sessionStatusUpdatedMsg should schedule next tick")
 }
 
 // TestSessionStatusUpdatedMsg_Empty verifies that empty sessions list is stored correctly.
 func TestSessionStatusUpdatedMsg_Empty(t *testing.T) {
-m := NewModel()
-m.sessions = []domain.Session{{ID: 1, WorktreePath: "/repo/old"}}
-updated, _ := m.Update(sessionStatusUpdatedMsg{sessions: []domain.Session{}})
-m2 := updated.(*Model)
-assert.Empty(t, m2.sessions)
+	m := NewModel()
+	m.sessions = []domain.Session{{ID: 1, WorktreePath: "/repo/old"}}
+	updated, _ := m.Update(sessionStatusUpdatedMsg{sessions: []domain.Session{}})
+	m2 := updated.(*Model)
+	assert.Empty(t, m2.sessions)
 }
 
 // TestCheckSessionsCmd_NilDB verifies that checkSessionsCmd is a no-op when db is nil.
 func TestCheckSessionsCmd_NilDB(t *testing.T) {
-m := NewModel()
-m.sessions = []domain.Session{
-{ID: 1, WorktreePath: "/repo/existing", Status: domain.StatusActive},
-}
-cmd := m.checkSessionsCmd()
-require.NotNil(t, cmd)
-msg := cmd()
-result, ok := msg.(sessionStatusUpdatedMsg)
-require.True(t, ok, "expected sessionStatusUpdatedMsg, got %T", msg)
-require.Len(t, result.sessions, 1)
-assert.Equal(t, "/repo/existing", result.sessions[0].WorktreePath)
+	m := NewModel()
+	m.sessions = []domain.Session{
+		{ID: 1, WorktreePath: "/repo/existing", Status: domain.StatusActive},
+	}
+	cmd := m.checkSessionsCmd()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	result, ok := msg.(sessionStatusUpdatedMsg)
+	require.True(t, ok, "expected sessionStatusUpdatedMsg, got %T", msg)
+	require.Len(t, result.sessions, 1)
+	assert.Equal(t, "/repo/existing", result.sessions[0].WorktreePath)
 }
 
 // TestCheckSessionsCmd_EmptyDB verifies that checkSessionsCmd returns empty sessions when DB is empty.
 func TestCheckSessionsCmd_EmptyDB(t *testing.T) {
-db, err := data.NewDB(":memory:")
-require.NoError(t, err)
-t.Cleanup(func() { _ = db.Close() })
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
 
-m := NewModel()
-m.db = db
-cmd := m.checkSessionsCmd()
-require.NotNil(t, cmd)
-msg := cmd()
-result, ok := msg.(sessionStatusUpdatedMsg)
-require.True(t, ok)
-assert.Empty(t, result.sessions)
+	m := NewModel()
+	m.db = db
+	cmd := m.checkSessionsCmd()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	result, ok := msg.(sessionStatusUpdatedMsg)
+	require.True(t, ok)
+	assert.Empty(t, result.sessions)
 }
 
 // TestPidAlive_CurrentProcess verifies that pidAlive returns true for the current process.
 func TestPidAlive_CurrentProcess(t *testing.T) {
-assert.True(t, pidAlive(os.Getpid()), "current process should be alive")
+	assert.True(t, pidAlive(os.Getpid()), "current process should be alive")
 }
 
 // TestPidAlive_InvalidPID verifies that pidAlive returns false for an invalid PID.
 func TestPidAlive_InvalidPID(t *testing.T) {
-// PID 0 is the idle process on Windows and typically reserved on Unix.
-// A very high PID is extremely unlikely to exist.
-assert.False(t, pidAlive(999999999), "PID 999999999 should not be alive")
+	// PID 0 is the idle process on Windows and typically reserved on Unix.
+	// A very high PID is extremely unlikely to exist.
+	assert.False(t, pidAlive(999999999), "PID 999999999 should not be alive")
 }

--- a/cmd/nexus/pid_unix.go
+++ b/cmd/nexus/pid_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package main
+
+import "syscall"
+
+// pidAlive reports whether the process with the given PID is currently running.
+// On Unix, it sends signal 0, which does not kill the process but returns an
+// error if the process does not exist. EPERM means the process exists but we
+// cannot signal it (still alive).
+func pidAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}

--- a/cmd/nexus/pid_windows.go
+++ b/cmd/nexus/pid_windows.go
@@ -5,14 +5,21 @@ package main
 import "golang.org/x/sys/windows"
 
 // pidAlive reports whether the process with the given PID is currently running.
-// On Windows, it attempts to open the process with PROCESS_QUERY_LIMITED_INFORMATION.
-// A successful open means the process exists; any error means it is gone.
+// On Windows, OpenProcess can succeed even for processes that have already exited
+// if their object handle is still held open elsewhere (zombie-like). We follow up
+// with GetExitCodeProcess: exit code STILL_ACTIVE (259) means the process is
+// genuinely running; any other code means it has terminated.
 func pidAlive(pid int) bool {
 	const processQueryLimitedInformation = 0x1000
 	h, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
 	if err != nil {
 		return false
 	}
-	_ = windows.CloseHandle(h)
-	return true
+	defer windows.CloseHandle(h)
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		return false
+	}
+	const stillActive = 259 // STILL_ACTIVE / STATUS_PENDING
+	return code == stillActive
 }

--- a/cmd/nexus/pid_windows.go
+++ b/cmd/nexus/pid_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package main
+
+import "golang.org/x/sys/windows"
+
+// pidAlive reports whether the process with the given PID is currently running.
+// On Windows, it attempts to open the process with PROCESS_QUERY_LIMITED_INFORMATION.
+// A successful open means the process exists; any error means it is gone.
+func pidAlive(pid int) bool {
+	const processQueryLimitedInformation = 0x1000
+	h, err := windows.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	_ = windows.CloseHandle(h)
+	return true
+}


### PR DESCRIPTION
Closes #64

## What Changed
Adds a periodic session health check that runs every 3 seconds, polling whether tracked shell/agent PIDs are still alive and cleaning up dead sessions in the DB.

## Why Changed
Phase 3 of the Active Sessions feature (#61). Without this, stale session rows accumulate in the DB indefinitely — there's no mechanism to detect when a terminal window was closed or an agent process died.

## Implementation
- **Cross-platform pidAlive()**: Windows uses OpenProcess (PROCESS_QUERY_LIMITED_INFORMATION), Unix uses syscall.Kill(pid, 0) (EPERM = process exists but no permission = still alive)
- **sessionTickMsg** fires every 3s starting from Init()
- **checkSessionsCmd()** reads all sessions from DB, checks each PID:
  - Shell alive -> keep as-is
  - Shell dead + agent alive -> transition to StatusAgentRunning, upsert
  - Both dead -> DeleteSession from DB
- **Model.sessions** updated on every tick via sessionStatusUpdatedMsg

## New files
- cmd/nexus/pid_windows.go — Windows PID check
- cmd/nexus/pid_unix.go — Unix PID check

## Testing
- 7 new tests: tick dispatch, status update, nil-DB no-op, empty-DB, current PID alive, invalid PID dead
- All 9 test packages pass (go test ./...)
- Build clean (go build ./...)