### PR TITLE
feat(app): add q as quit key binding alongside ESC

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -402,6 +402,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, clearErrorCmd()
 		case tea.KeyRunes:
 			switch msg.String() {
+			case "q":
+				return m, tea.Quit
 			case " ":
 				// Spacebar can arrive as KeyRunes " " on some terminals (e.g. Windows).
 				// Mirror the KeySpace handler above.

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -2375,3 +2375,49 @@ func TestPagination_PrevPageClampsAtZero(t *testing.T) {
 	assert.Equal(t, 0, m2.selectedIssueIdx, "selectedIssueIdx unchanged when already at first page")
 }
 
+// ---------------------------------------------------------------------------
+// Issue #77: q as quit key binding tests
+// ---------------------------------------------------------------------------
+
+// TestModel_QKey_QuitsApp verifies that pressing q from the root view quits the app.
+func TestModel_QKey_QuitsApp(t *testing.T) {
+	m := NewModel()
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	require.NotNil(t, cmd, "q should return a Cmd")
+
+	// Execute the command and verify it produces tea.Quit.
+	msg := cmd()
+	assert.Equal(t, tea.Quit(), msg, "q should produce tea.Quit")
+}
+
+// TestModel_QKey_SuppressedWhenCopilotPromptActive verifies that q does NOT quit
+// when the copilot text input is focused — it should be routed to the input instead.
+func TestModel_QKey_SuppressedWhenCopilotPromptActive(t *testing.T) {
+	model := NewModel()
+	model.copilotPromptActive = true
+	model.Worktrees = []domain.Worktree{{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"}}
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.True(t, updatedModel.copilotPromptActive,
+		"q should not quit when copilot prompt is active")
+}
+
+// TestModel_QKey_SuppressedWhenClaudePromptActive verifies that q does NOT quit
+// when the Claude text input is focused — it should be routed to the input instead.
+func TestModel_QKey_SuppressedWhenClaudePromptActive(t *testing.T) {
+	model := NewModel()
+	model.claudePromptActive = true
+	model.Worktrees = []domain.Worktree{{Path: "/tmp/wt", Branch: "main", CommitSHA: "abc"}}
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.True(t, updatedModel.claudePromptActive,
+		"q should not quit when claude prompt is active")
+}
+

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -18,8 +18,8 @@ import (
 
 const (
 	appVersion           = "1.0"
-	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [esc] Quit"
-	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [t] Settings | [g] GH | [esc] Quit"
+	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [q/esc] Quit"
+	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [t] Settings | [g] GH | [q/esc] Quit"
 	footerHintsDefault   = footerHintsWorktrees
 	actionBarHints       = "[c-n] New  [c-d] Delete  [c-l] Lock | [f1] Help"
 	defaultTermWidth     = 120

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -142,7 +142,7 @@ func TestRenderFull_ContainsFooterKeyHints(t *testing.T) {
 	}{
 		{
 			name:   "footer contains navigation and action hints",
-			wantIn: []string{"[Enter] Select", "[t] Settings", "[esc] Quit"},
+			wantIn: []string{"[Enter] Select", "[t] Settings", "[q/esc] Quit"},
 		},
 		{
 			name:   "action bar contains worktree commands",
@@ -1176,7 +1176,7 @@ func TestRenderFull_FooterContainsTabAndJKHints(t *testing.T) {
 	assert.Contains(t, view, "[j/k]")
 	// Old hints must still be present
 	assert.Contains(t, view, "[Enter] Select")
-	assert.Contains(t, view, "[esc] Quit")
+	assert.Contains(t, view, "[q/esc] Quit")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tui/modal/help.go
+++ b/internal/tui/modal/help.go
@@ -73,7 +73,7 @@ var keybindingGroups = []bindingGroup{
 		bindings: [][2]string{
 			{"f1 / ?", "Open this help modal"},
 			{"g", "Open selected item in GitHub"},
-			{"Esc / Ctrl+C", "Quit"},
+			{"Esc / q / Ctrl+C", "Quit"},
 		},
 	},
 }


### PR DESCRIPTION
Closes #77

## What Changed
Added `q` as an alternative quit/exit key binding that behaves identically to `ESC` from the root view.

## Why Changed
Vim-style navigation convention — `q` is a widely expected quit key. Users coming from vim/tmux/lazygit muscle memory expect it to work. Currently only `ESC` and `Ctrl+C` quit the app.

## Changes
- `q` in the root view triggers `tea.Quit` (same as `ESC`/`Ctrl+C`)
- `q` is suppressed when the copilot or claude text input is active, so typing `q` in a prompt won't exit the app
- Footer hints updated: `[esc] Quit` to `[q/esc] Quit`
- Help modal keybindings table updated to show `Esc / q / Ctrl+C`

## Testing
- 3 new unit tests covering quit path and both input suppression scenarios
- Updated 2 existing renderer tests to expect `[q/esc] Quit` in footer
- Full test suite passes: `go test ./...`

## Notes
The active-sessions confirmation prompt (from issue #61) is not yet implemented. When that lands, both ESC and q will hook into the same confirmation flow.