### PR TITLE
feat(sessions): phase 6 - simplify session model and record shell PID on spawn

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -1104,6 +1104,7 @@ func buildCopilotCmd(worktreePath, prompt string) *exec.Cmd {
 // The TUI is not suspended — nexus keeps running in the current terminal.
 func (m *Model) spawnCopilotCmd(worktreePath, prompt string) tea.Cmd {
 	startedAt := time.Now()
+	db := m.db
 	var shellCmd string
 	if prompt != "" {
 		shellCmd = "gh copilot -i " + shellQuote(prompt)
@@ -1111,10 +1112,13 @@ func (m *Model) spawnCopilotCmd(worktreePath, prompt string) tea.Cmd {
 		shellCmd = "gh copilot"
 	}
 	return func() tea.Msg {
-		_, spawnErr := spawnAgentInTerminalWindow(worktreePath, shellCmd)
+		pid, spawnErr := spawnAgentInTerminalWindow(worktreePath, shellCmd)
 		exitCode := 0
 		if spawnErr != nil {
 			exitCode = 1
+		}
+		if spawnErr == nil && pid != 0 && db != nil {
+			updateSessionAgentPID(db, worktreePath, "copilot", pid)
 		}
 		return agentDoneMsg{
 			agentName: "copilot",
@@ -1171,6 +1175,7 @@ func (m *Model) spawnClaudeCmd(worktreePath, prompt string) tea.Cmd {
 		return clearErrorCmd()
 	}
 	startedAt := time.Now()
+	db := m.db
 	var shellCmd string
 	if prompt != "" {
 		shellCmd = binaryPath + " " + shellQuote(prompt)
@@ -1178,10 +1183,13 @@ func (m *Model) spawnClaudeCmd(worktreePath, prompt string) tea.Cmd {
 		shellCmd = binaryPath
 	}
 	return func() tea.Msg {
-		_, spawnErr := spawnAgentInTerminalWindow(worktreePath, shellCmd)
+		pid, spawnErr := spawnAgentInTerminalWindow(worktreePath, shellCmd)
 		exitCode := 0
 		if spawnErr != nil {
 			exitCode = 1
+		}
+		if spawnErr == nil && pid != 0 && db != nil {
+			updateSessionAgentPID(db, worktreePath, "claude", pid)
 		}
 		return agentDoneMsg{
 			agentName: "claude",
@@ -1220,6 +1228,7 @@ func (m *Model) spawnAiderCmd(worktreePath string, files []string) tea.Cmd {
 		return clearErrorCmd()
 	}
 	startedAt := time.Now()
+	db := m.db
 	parts := make([]string, 0, len(files)+1)
 	parts = append(parts, binaryPath)
 	for _, f := range files {
@@ -1227,10 +1236,13 @@ func (m *Model) spawnAiderCmd(worktreePath string, files []string) tea.Cmd {
 	}
 	shellCmd := strings.Join(parts, " ")
 	return func() tea.Msg {
-		_, spawnErr := spawnAgentInTerminalWindow(worktreePath, shellCmd)
+		pid, spawnErr := spawnAgentInTerminalWindow(worktreePath, shellCmd)
 		exitCode := 0
 		if spawnErr != nil {
 			exitCode = 1
+		}
+		if spawnErr == nil && pid != 0 && db != nil {
+			updateSessionAgentPID(db, worktreePath, "aider", pid)
 		}
 		return agentDoneMsg{
 			agentName: "aider",
@@ -1585,6 +1597,27 @@ func (m *Model) focusSessionCmd(session domain.Session) tea.Cmd {
 		}
 		err := focusSessionWindow(pid)
 		return sessionFocusedMsg{worktreePath: session.WorktreePath, err: err}
+	}
+}
+
+// updateSessionAgentPID looks up the active session for worktreePath and sets
+// the AgentPID and AgentName fields, then persists the update via UpsertSession.
+// Errors are logged as warnings — the agent terminal is already running so this
+// is non-fatal.
+func updateSessionAgentPID(db *data.DB, worktreePath, agentName string, pid int) {
+	sess, err := data.GetSessionByWorktree(db, worktreePath)
+	if err != nil {
+		slog.Warn("update session agent pid: lookup failed", "worktree", worktreePath, "err", err)
+		return
+	}
+	if sess == nil {
+		slog.Warn("update session agent pid: session not found", "worktree", worktreePath)
+		return
+	}
+	sess.AgentName = &agentName
+	sess.AgentPID = &pid
+	if _, err := data.UpsertSession(db, *sess); err != nil {
+		slog.Warn("update session agent pid: upsert failed", "worktree", worktreePath, "err", err)
 	}
 }
 

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -79,6 +79,7 @@ type agentDoneMsg struct {
 	prompt    string
 	exitCode  int
 	startedAt time.Time
+	session   domain.Session // non-zero WorktreePath means a session was recorded
 }
 
 // aiderFilesFetchedMsg carries the result of listing modified files for the Aider file picker.
@@ -451,10 +452,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 							continue
 						}
 						if s.ShellPID != nil && !pidAlive(*s.ShellPID) {
-							agentAlive := s.AgentPID != nil && pidAlive(*s.AgentPID)
-							if !agentAlive {
-								break // stale — fall through to spawn
-							}
+							break // stale — fall through to spawn
 						}
 						return m, m.focusSessionCmd(s)
 					}
@@ -725,6 +723,20 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			if err := data.LogAgentRun(m.db, entry); err != nil {
 				m.statusErr = fmt.Sprintf("failed to log agent run: %v", err)
+			}
+		}
+		// Sync the recorded session into m.sessions so the badge appears immediately.
+		if msg.session.WorktreePath != "" {
+			updated := false
+			for i := range m.sessions {
+				if pathsEqual(m.sessions[i].WorktreePath, msg.session.WorktreePath) {
+					m.sessions[i] = msg.session
+					updated = true
+					break
+				}
+			}
+			if !updated {
+				m.sessions = append(m.sessions, msg.session)
 			}
 		}
 		if msg.exitCode > 1 {
@@ -1117,14 +1129,37 @@ func (m *Model) spawnCopilotCmd(worktreePath, prompt string) tea.Cmd {
 		if spawnErr != nil {
 			exitCode = 1
 		}
-		if spawnErr == nil && pid != 0 && db != nil {
-			updateSessionAgentPID(db, worktreePath, "copilot", pid)
+		var sess domain.Session
+		if spawnErr == nil {
+			agentNameVal := "copilot"
+			var shellPID *int
+			if pid != 0 {
+				shellPID = &pid
+			}
+			sess = domain.Session{
+				WorktreePath: worktreePath,
+				ShellPID:     shellPID,
+				AgentName:    &agentNameVal,
+				Status:       domain.StatusActive,
+				StartedAt:    startedAt.UTC().Truncate(time.Second),
+			}
+			if prompt != "" {
+				promptVal := prompt
+				sess.Prompt = &promptVal
+			}
+			if db != nil {
+				id, err := data.UpsertSession(db, sess)
+				if err == nil {
+					sess.ID = id
+				}
+			}
 		}
 		return agentDoneMsg{
 			agentName: "copilot",
 			prompt:    prompt,
 			exitCode:  exitCode,
 			startedAt: startedAt,
+			session:   sess,
 		}
 	}
 }
@@ -1188,14 +1223,37 @@ func (m *Model) spawnClaudeCmd(worktreePath, prompt string) tea.Cmd {
 		if spawnErr != nil {
 			exitCode = 1
 		}
-		if spawnErr == nil && pid != 0 && db != nil {
-			updateSessionAgentPID(db, worktreePath, "claude", pid)
+		var sess domain.Session
+		if spawnErr == nil {
+			agentNameVal := "claude"
+			var shellPID *int
+			if pid != 0 {
+				shellPID = &pid
+			}
+			sess = domain.Session{
+				WorktreePath: worktreePath,
+				ShellPID:     shellPID,
+				AgentName:    &agentNameVal,
+				Status:       domain.StatusActive,
+				StartedAt:    startedAt.UTC().Truncate(time.Second),
+			}
+			if prompt != "" {
+				promptVal := prompt
+				sess.Prompt = &promptVal
+			}
+			if db != nil {
+				id, err := data.UpsertSession(db, sess)
+				if err == nil {
+					sess.ID = id
+				}
+			}
 		}
 		return agentDoneMsg{
 			agentName: "claude",
 			prompt:    prompt,
 			exitCode:  exitCode,
 			startedAt: startedAt,
+			session:   sess,
 		}
 	}
 }
@@ -1241,13 +1299,32 @@ func (m *Model) spawnAiderCmd(worktreePath string, files []string) tea.Cmd {
 		if spawnErr != nil {
 			exitCode = 1
 		}
-		if spawnErr == nil && pid != 0 && db != nil {
-			updateSessionAgentPID(db, worktreePath, "aider", pid)
+		var sess domain.Session
+		if spawnErr == nil {
+			agentNameVal := "aider"
+			var shellPID *int
+			if pid != 0 {
+				shellPID = &pid
+			}
+			sess = domain.Session{
+				WorktreePath: worktreePath,
+				ShellPID:     shellPID,
+				AgentName:    &agentNameVal,
+				Status:       domain.StatusActive,
+				StartedAt:    startedAt.UTC().Truncate(time.Second),
+			}
+			if db != nil {
+				id, err := data.UpsertSession(db, sess)
+				if err == nil {
+					sess.ID = id
+				}
+			}
 		}
 		return agentDoneMsg{
 			agentName: "aider",
 			exitCode:  exitCode,
 			startedAt: startedAt,
+			session:   sess,
 		}
 	}
 }
@@ -1575,9 +1652,6 @@ func (m *Model) killSessionCmd(session domain.Session) tea.Cmd {
 		if session.ShellPID != nil {
 			gracefulKillPID(*session.ShellPID)
 		}
-		if session.AgentPID != nil {
-			gracefulKillPID(*session.AgentPID)
-		}
 		if db != nil && session.ID != 0 {
 			if err := data.DeleteSession(db, session.ID); err != nil {
 				return sessionKilledMsg{worktreePath: session.WorktreePath, err: err}
@@ -1600,39 +1674,6 @@ func (m *Model) focusSessionCmd(session domain.Session) tea.Cmd {
 	}
 }
 
-// updateSessionAgentPID looks up the active session for worktreePath and sets
-// the AgentPID and AgentName fields, then persists the update via UpsertSession.
-// If no session exists for the worktree (agent spawned without a prior terminal),
-// a new agent-only session is created with StatusAgentRunning and no ShellPID.
-// Errors are logged as warnings — the agent terminal is already running so this
-// is non-fatal.
-func updateSessionAgentPID(db *data.DB, worktreePath, agentName string, pid int) {
-	sess, err := data.GetSessionByWorktree(db, worktreePath)
-	if err != nil {
-		slog.Warn("update session agent pid: lookup failed", "worktree", worktreePath, "err", err)
-		return
-	}
-	if sess == nil {
-		// No terminal session exists — create an agent-only session so the badge
-		// appears in the sessions view and the health-check poller can track it.
-		newSess := domain.Session{
-			WorktreePath: worktreePath,
-			AgentName:    &agentName,
-			AgentPID:     &pid,
-			Status:       domain.StatusAgentRunning,
-			StartedAt:    time.Now().UTC().Truncate(time.Second),
-		}
-		if _, err := data.UpsertSession(db, newSess); err != nil {
-			slog.Warn("update session agent pid: create session failed", "worktree", worktreePath, "err", err)
-		}
-		return
-	}
-	sess.AgentName = &agentName
-	sess.AgentPID = &pid
-	if _, err := data.UpsertSession(db, *sess); err != nil {
-		slog.Warn("update session agent pid: upsert failed", "worktree", worktreePath, "err", err)
-	}
-}
 
 // checkSessionsCmd reads all tracked sessions from the nexus DB and checks
 // whether each PID is still alive. Returns sessionStatusUpdatedMsg with the
@@ -1643,35 +1684,24 @@ func (m *Model) checkSessionsCmd() tea.Cmd {
 	return func() tea.Msg {
 		var alive []domain.Session
 
-		// Part 1: reconcile nexus-spawned shell sessions from the nexus DB.
 		if db == nil {
-			// No nexus DB — perform PID health checks on in-memory sessions so
-			// that terminals the user has closed are removed rather than kept
-			// as stale badges that block re-spawning.
+			// No nexus DB — perform PID health checks on in-memory sessions.
 			for _, s := range current {
+				if s.Status == domain.StatusDead {
+					continue
+				}
 				if s.ShellPID == nil {
-					if s.Status == domain.StatusDead || time.Since(s.StartedAt) > 24*time.Hour {
-						continue
-					}
-					// Agent-only session: prune once the agent process exits.
-					if s.AgentPID != nil && !pidAlive(*s.AgentPID) {
+					// No PID — keep alive up to 24 hours.
+					if time.Since(s.StartedAt) > 24*time.Hour {
 						continue
 					}
 					alive = append(alive, s)
 					continue
 				}
-				shellAlive := pidAlive(*s.ShellPID)
-				agentAlive := s.AgentPID != nil && pidAlive(*s.AgentPID)
-				if shellAlive {
+				if pidAlive(*s.ShellPID) {
 					alive = append(alive, s)
-					continue
 				}
-				if agentAlive {
-					s.Status = domain.StatusAgentRunning
-					alive = append(alive, s)
-					continue
-				}
-				// Both dead — drop from alive (prunes the stale in-memory entry).
+				// Shell dead — drop from alive.
 			}
 		} else {
 			all, err := data.GetSessions(db)
@@ -1684,54 +1714,32 @@ func (m *Model) checkSessionsCmd() tea.Cmd {
 				}
 			} else {
 				for _, s := range all {
-				if s.ShellPID == nil {
-					// No shell PID to check. This covers two cases:
-					// 1. Windows Terminal tab spawns where the launcher exits immediately.
-					// 2. Agent-only sessions created by updateSessionAgentPID.
-					if s.Status == domain.StatusDead {
-						if err := data.DeleteSession(db, s.ID); err != nil {
-							slog.Warn("session health check: failed to delete dead session", "id", s.ID, "err", err)
-						}
-						continue
+				if s.Status == domain.StatusDead {
+					if err := data.DeleteSession(db, s.ID); err != nil {
+						slog.Warn("session health check: failed to delete dead session", "id", s.ID, "err", err)
 					}
+					continue
+				}
+				if s.ShellPID == nil {
+					// No PID — keep alive up to 24 hours (e.g. WT tabs without PID tracking).
 					if time.Since(s.StartedAt) > 24*time.Hour {
 						if err := data.DeleteSession(db, s.ID); err != nil {
 							slog.Warn("session health check: failed to delete stale session", "id", s.ID, "err", err)
 						}
 						continue
 					}
-					// Agent-only session: prune once the agent process exits.
-					if s.AgentPID != nil && !pidAlive(*s.AgentPID) {
-						if err := data.DeleteSession(db, s.ID); err != nil {
-							slog.Warn("session health check: failed to delete finished agent session", "id", s.ID, "err", err)
-						}
-						continue
-					}
 					alive = append(alive, s)
 					continue
 				}
-					shellAlive := pidAlive(*s.ShellPID)
-					agentAlive := s.AgentPID != nil && pidAlive(*s.AgentPID)
-
-					if shellAlive {
-						alive = append(alive, s)
-						continue
-					}
-					// Shell is dead.
-					if agentAlive {
-						// Agent is still running — transition to agent_running.
-						s.Status = domain.StatusAgentRunning
-						if _, err := data.UpsertSession(db, s); err != nil {
-							slog.Warn("session health check: failed to update session status", "id", s.ID, "err", err)
-						}
-						alive = append(alive, s)
-						continue
-					}
-					// Both are dead — remove from DB.
+				if pidAlive(*s.ShellPID) {
+					alive = append(alive, s)
+				} else {
+					// Shell is dead — remove from DB.
 					if err := data.DeleteSession(db, s.ID); err != nil {
 						slog.Warn("session health check: failed to delete dead session", "id", s.ID, "err", err)
 					}
 				}
+			}
 			}
 		}
 

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -1602,6 +1602,8 @@ func (m *Model) focusSessionCmd(session domain.Session) tea.Cmd {
 
 // updateSessionAgentPID looks up the active session for worktreePath and sets
 // the AgentPID and AgentName fields, then persists the update via UpsertSession.
+// If no session exists for the worktree (agent spawned without a prior terminal),
+// a new agent-only session is created with StatusAgentRunning and no ShellPID.
 // Errors are logged as warnings — the agent terminal is already running so this
 // is non-fatal.
 func updateSessionAgentPID(db *data.DB, worktreePath, agentName string, pid int) {
@@ -1611,7 +1613,18 @@ func updateSessionAgentPID(db *data.DB, worktreePath, agentName string, pid int)
 		return
 	}
 	if sess == nil {
-		slog.Warn("update session agent pid: session not found", "worktree", worktreePath)
+		// No terminal session exists — create an agent-only session so the badge
+		// appears in the sessions view and the health-check poller can track it.
+		newSess := domain.Session{
+			WorktreePath: worktreePath,
+			AgentName:    &agentName,
+			AgentPID:     &pid,
+			Status:       domain.StatusAgentRunning,
+			StartedAt:    time.Now().UTC().Truncate(time.Second),
+		}
+		if _, err := data.UpsertSession(db, newSess); err != nil {
+			slog.Warn("update session agent pid: create session failed", "worktree", worktreePath, "err", err)
+		}
 		return
 	}
 	sess.AgentName = &agentName
@@ -1638,6 +1651,10 @@ func (m *Model) checkSessionsCmd() tea.Cmd {
 			for _, s := range current {
 				if s.ShellPID == nil {
 					if s.Status == domain.StatusDead || time.Since(s.StartedAt) > 24*time.Hour {
+						continue
+					}
+					// Agent-only session: prune once the agent process exits.
+					if s.AgentPID != nil && !pidAlive(*s.AgentPID) {
 						continue
 					}
 					alive = append(alive, s)
@@ -1667,25 +1684,32 @@ func (m *Model) checkSessionsCmd() tea.Cmd {
 				}
 			} else {
 				for _, s := range all {
-					if s.ShellPID == nil {
-						// No PID to check (e.g. Windows Terminal tab spawns where the
-						// launcher exits immediately). Prune dead rows and sessions older
-						// than 24 h; keep everything else so the badge stays visible.
-						if s.Status == domain.StatusDead {
-							if err := data.DeleteSession(db, s.ID); err != nil {
-								slog.Warn("session health check: failed to delete dead session", "id", s.ID, "err", err)
-							}
-							continue
+				if s.ShellPID == nil {
+					// No shell PID to check. This covers two cases:
+					// 1. Windows Terminal tab spawns where the launcher exits immediately.
+					// 2. Agent-only sessions created by updateSessionAgentPID.
+					if s.Status == domain.StatusDead {
+						if err := data.DeleteSession(db, s.ID); err != nil {
+							slog.Warn("session health check: failed to delete dead session", "id", s.ID, "err", err)
 						}
-						if time.Since(s.StartedAt) > 24*time.Hour {
-							if err := data.DeleteSession(db, s.ID); err != nil {
-								slog.Warn("session health check: failed to delete stale session", "id", s.ID, "err", err)
-							}
-							continue
-						}
-						alive = append(alive, s)
 						continue
 					}
+					if time.Since(s.StartedAt) > 24*time.Hour {
+						if err := data.DeleteSession(db, s.ID); err != nil {
+							slog.Warn("session health check: failed to delete stale session", "id", s.ID, "err", err)
+						}
+						continue
+					}
+					// Agent-only session: prune once the agent process exits.
+					if s.AgentPID != nil && !pidAlive(*s.AgentPID) {
+						if err := data.DeleteSession(db, s.ID); err != nil {
+							slog.Warn("session health check: failed to delete finished agent session", "id", s.ID, "err", err)
+						}
+						continue
+					}
+					alive = append(alive, s)
+					continue
+				}
 					shellAlive := pidAlive(*s.ShellPID)
 					agentAlive := s.AgentPID != nil && pidAlive(*s.AgentPID)
 

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -445,8 +445,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if selected, ok := m.selectedWorktree(); ok {
 					// If a live session already exists for this worktree, focus it
 					// instead of spawning a new one. Skip any stale entry whose
-					// shell PID is confirmed dead (and whose agent PID is also
-					// gone), so that closed terminals don't block re-spawning.
+					// shell PID is confirmed dead so that closed terminals don't
+					// block re-spawning. We no longer track AgentPID, so we accept
+					// the small risk of a duplicate spawn if the agent outlived its
+					// terminal window.
 					for _, s := range m.sessions {
 						if !pathsEqual(s.WorktreePath, selected.Path) {
 							continue
@@ -1111,12 +1113,40 @@ func buildCopilotCmd(worktreePath, prompt string) *exec.Cmd {
 	return cmd
 }
 
+// buildSpawnSession constructs a domain.Session for a newly-launched agent
+// terminal and persists it to db when db is non-nil. prompt may be empty
+// (Aider does not take a pre-loaded prompt).
+func buildSpawnSession(db *data.DB, worktreePath, agentName string, pid int, prompt string, startedAt time.Time) domain.Session {
+	agentNameVal := agentName
+	var shellPID *int
+	if pid != 0 {
+		shellPID = &pid
+	}
+	sess := domain.Session{
+		WorktreePath: worktreePath,
+		ShellPID:     shellPID,
+		AgentName:    &agentNameVal,
+		Status:       domain.StatusActive,
+		StartedAt:    startedAt.UTC().Truncate(time.Second),
+	}
+	if prompt != "" {
+		promptVal := prompt
+		sess.Prompt = &promptVal
+	}
+	if db != nil {
+		id, err := data.UpsertSession(db, sess)
+		if err == nil {
+			sess.ID = id
+		}
+	}
+	return sess
+}
 // spawnCopilotCmd opens a new terminal tab/window running gh copilot at
 // worktreePath and dispatches agentDoneMsg once the launch completes.
 // The TUI is not suspended — nexus keeps running in the current terminal.
 func (m *Model) spawnCopilotCmd(worktreePath, prompt string) tea.Cmd {
 	startedAt := time.Now()
-	db := m.db
+	db := m.db // capture m.db so the closure does not close over m (data race)
 	var shellCmd string
 	if prompt != "" {
 		shellCmd = "gh copilot -i " + shellQuote(prompt)
@@ -1131,28 +1161,7 @@ func (m *Model) spawnCopilotCmd(worktreePath, prompt string) tea.Cmd {
 		}
 		var sess domain.Session
 		if spawnErr == nil {
-			agentNameVal := "copilot"
-			var shellPID *int
-			if pid != 0 {
-				shellPID = &pid
-			}
-			sess = domain.Session{
-				WorktreePath: worktreePath,
-				ShellPID:     shellPID,
-				AgentName:    &agentNameVal,
-				Status:       domain.StatusActive,
-				StartedAt:    startedAt.UTC().Truncate(time.Second),
-			}
-			if prompt != "" {
-				promptVal := prompt
-				sess.Prompt = &promptVal
-			}
-			if db != nil {
-				id, err := data.UpsertSession(db, sess)
-				if err == nil {
-					sess.ID = id
-				}
-			}
+			sess = buildSpawnSession(db, worktreePath, "copilot", pid, prompt, startedAt)
 		}
 		return agentDoneMsg{
 			agentName: "copilot",
@@ -1210,7 +1219,7 @@ func (m *Model) spawnClaudeCmd(worktreePath, prompt string) tea.Cmd {
 		return clearErrorCmd()
 	}
 	startedAt := time.Now()
-	db := m.db
+	db := m.db // capture m.db so the closure does not close over m (data race)
 	var shellCmd string
 	if prompt != "" {
 		shellCmd = binaryPath + " " + shellQuote(prompt)
@@ -1225,28 +1234,7 @@ func (m *Model) spawnClaudeCmd(worktreePath, prompt string) tea.Cmd {
 		}
 		var sess domain.Session
 		if spawnErr == nil {
-			agentNameVal := "claude"
-			var shellPID *int
-			if pid != 0 {
-				shellPID = &pid
-			}
-			sess = domain.Session{
-				WorktreePath: worktreePath,
-				ShellPID:     shellPID,
-				AgentName:    &agentNameVal,
-				Status:       domain.StatusActive,
-				StartedAt:    startedAt.UTC().Truncate(time.Second),
-			}
-			if prompt != "" {
-				promptVal := prompt
-				sess.Prompt = &promptVal
-			}
-			if db != nil {
-				id, err := data.UpsertSession(db, sess)
-				if err == nil {
-					sess.ID = id
-				}
-			}
+			sess = buildSpawnSession(db, worktreePath, "claude", pid, prompt, startedAt)
 		}
 		return agentDoneMsg{
 			agentName: "claude",
@@ -1286,7 +1274,7 @@ func (m *Model) spawnAiderCmd(worktreePath string, files []string) tea.Cmd {
 		return clearErrorCmd()
 	}
 	startedAt := time.Now()
-	db := m.db
+	db := m.db // capture m.db so the closure does not close over m (data race)
 	parts := make([]string, 0, len(files)+1)
 	parts = append(parts, binaryPath)
 	for _, f := range files {
@@ -1301,24 +1289,7 @@ func (m *Model) spawnAiderCmd(worktreePath string, files []string) tea.Cmd {
 		}
 		var sess domain.Session
 		if spawnErr == nil {
-			agentNameVal := "aider"
-			var shellPID *int
-			if pid != 0 {
-				shellPID = &pid
-			}
-			sess = domain.Session{
-				WorktreePath: worktreePath,
-				ShellPID:     shellPID,
-				AgentName:    &agentNameVal,
-				Status:       domain.StatusActive,
-				StartedAt:    startedAt.UTC().Truncate(time.Second),
-			}
-			if db != nil {
-				id, err := data.UpsertSession(db, sess)
-				if err == nil {
-					sess.ID = id
-				}
-			}
+			sess = buildSpawnSession(db, worktreePath, "aider", pid, "", startedAt)
 		}
 		return agentDoneMsg{
 			agentName: "aider",
@@ -1673,7 +1644,6 @@ func (m *Model) focusSessionCmd(session domain.Session) tea.Cmd {
 		return sessionFocusedMsg{worktreePath: session.WorktreePath, err: err}
 	}
 }
-
 
 // checkSessionsCmd reads all tracked sessions from the nexus DB and checks
 // whether each PID is still alive. Returns sessionStatusUpdatedMsg with the

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -2852,3 +2852,179 @@ func TestModel_SessionFocusedMsg_Error_ShowsBestEffortMsg(t *testing.T) {
 	assert.Contains(t, m2.statusMsg, "/wt/a")
 	assert.NotNil(t, cmd, "should return clearMsgCmd even on error")
 }
+
+// ---------------------------------------------------------------------------
+// Phase 6: Non-blocking agents — agent PID persistence (issue #67)
+// ---------------------------------------------------------------------------
+
+// TestUpdateSessionAgentPID_UpdatesSession verifies that updateSessionAgentPID
+// sets AgentPID and AgentName on an existing session row in the DB.
+func TestUpdateSessionAgentPID_UpdatesSession(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	sess := domain.Session{
+		WorktreePath: "/repo/wt1",
+		Status:       domain.StatusActive,
+		StartedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+	_, err = data.UpsertSession(db, sess)
+	require.NoError(t, err)
+
+	updateSessionAgentPID(db, "/repo/wt1", "copilot", 12345)
+
+	got, err := data.GetSessionByWorktree(db, "/repo/wt1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotNil(t, got.AgentPID, "AgentPID must be set after updateSessionAgentPID")
+	assert.Equal(t, 12345, *got.AgentPID)
+	require.NotNil(t, got.AgentName, "AgentName must be set after updateSessionAgentPID")
+	assert.Equal(t, "copilot", *got.AgentName)
+}
+
+// TestUpdateSessionAgentPID_NoSession_NoError verifies that updateSessionAgentPID
+// does not panic when no session exists for the given worktree path.
+func TestUpdateSessionAgentPID_NoSession_NoError(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Should not panic — just logs a warning.
+	assert.NotPanics(t, func() {
+		updateSessionAgentPID(db, "/repo/nonexistent", "copilot", 42)
+	})
+}
+
+// TestCheckSessionsCmd_NilDB_DeadShellAliveAgent_KeepsSession verifies that an
+// in-memory session with a dead shell PID but a live agent PID is preserved
+// and transitions to StatusAgentRunning.
+func TestCheckSessionsCmd_NilDB_DeadShellAliveAgent_KeepsSession(t *testing.T) {
+	deadPID := 999999999
+	alivePID := os.Getpid()
+
+	m := NewModel()
+	m.sessions = []domain.Session{
+		{
+			ID:           1,
+			WorktreePath: "/repo/agent-running",
+			ShellPID:     &deadPID,
+			AgentPID:     &alivePID,
+			Status:       domain.StatusActive,
+			StartedAt:    time.Now().UTC(),
+		},
+	}
+
+	cmd := m.checkSessionsCmd()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	result, ok := msg.(sessionStatusUpdatedMsg)
+	require.True(t, ok, "expected sessionStatusUpdatedMsg, got %T", msg)
+	require.Len(t, result.sessions, 1, "session with alive agent PID must be kept")
+	assert.Equal(t, domain.StatusAgentRunning, result.sessions[0].Status,
+		"session must transition to StatusAgentRunning when shell is dead but agent is alive")
+}
+
+// TestCheckSessionsCmd_NilDB_BothDeadPruned verifies that an in-memory session
+// with both shell and agent PIDs dead is removed from the alive list.
+func TestCheckSessionsCmd_NilDB_BothDeadPruned(t *testing.T) {
+	deadPID := 999999999
+	anotherDeadPID := 999999998
+
+	m := NewModel()
+	m.sessions = []domain.Session{
+		{
+			ID:           1,
+			WorktreePath: "/repo/both-dead",
+			ShellPID:     &deadPID,
+			AgentPID:     &anotherDeadPID,
+			Status:       domain.StatusActive,
+			StartedAt:    time.Now().UTC(),
+		},
+	}
+
+	cmd := m.checkSessionsCmd()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	result, ok := msg.(sessionStatusUpdatedMsg)
+	require.True(t, ok)
+	assert.Empty(t, result.sessions, "session with both dead PIDs must be pruned")
+}
+
+// TestCheckSessionsCmd_DB_DeadShellAliveAgent_KeepsSession verifies that a
+// DB-backed session with a dead shell but a live agent PID is preserved and
+// transitioned to StatusAgentRunning.
+func TestCheckSessionsCmd_DB_DeadShellAliveAgent_KeepsSession(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	deadPID := 999999999
+	alivePID := os.Getpid()
+
+	sess := domain.Session{
+		WorktreePath: "/repo/agent-running",
+		ShellPID:     &deadPID,
+		AgentPID:     &alivePID,
+		Status:       domain.StatusActive,
+		StartedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+	_, err = data.UpsertSession(db, sess)
+	require.NoError(t, err)
+
+	m := NewModel()
+	m.db = db
+
+	cmd := m.checkSessionsCmd()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	result, ok := msg.(sessionStatusUpdatedMsg)
+	require.True(t, ok)
+	require.Len(t, result.sessions, 1, "session with alive agent PID must be kept")
+	assert.Equal(t, domain.StatusAgentRunning, result.sessions[0].Status,
+		"session must transition to StatusAgentRunning when shell is dead but agent is alive")
+
+	// Confirm status was persisted to DB.
+	got, err := data.GetSessionByWorktree(db, "/repo/agent-running")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, domain.StatusAgentRunning, got.Status,
+		"StatusAgentRunning must be written back to the DB")
+}
+
+// TestCheckSessionsCmd_DB_BothDeadPruned verifies that a DB-backed session
+// with both shell and agent PIDs dead is deleted from the DB and excluded from
+// the returned session list.
+func TestCheckSessionsCmd_DB_BothDeadPruned(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	deadPID := 999999999
+	anotherDeadPID := 999999998
+
+	sess := domain.Session{
+		WorktreePath: "/repo/both-dead",
+		ShellPID:     &deadPID,
+		AgentPID:     &anotherDeadPID,
+		Status:       domain.StatusActive,
+		StartedAt:    time.Now().UTC().Truncate(time.Second),
+	}
+	_, err = data.UpsertSession(db, sess)
+	require.NoError(t, err)
+
+	m := NewModel()
+	m.db = db
+
+	cmd := m.checkSessionsCmd()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	result, ok := msg.(sessionStatusUpdatedMsg)
+	require.True(t, ok)
+	assert.Empty(t, result.sessions, "session with both dead PIDs must be pruned")
+
+	// Confirm it was deleted from the DB.
+	got, err := data.GetSessionByWorktree(db, "/repo/both-dead")
+	require.NoError(t, err)
+	assert.Nil(t, got, "session with both dead PIDs must be deleted from the DB")
+}

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -2854,98 +2854,20 @@ func TestModel_SessionFocusedMsg_Error_ShowsBestEffortMsg(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Phase 6: Non-blocking agents — agent PID persistence (issue #67)
+// Phase 6: Non-blocking agents — session detection (issue #67)
 // ---------------------------------------------------------------------------
 
-// TestUpdateSessionAgentPID_UpdatesSession verifies that updateSessionAgentPID
-// sets AgentPID and AgentName on an existing session row in the DB.
-func TestUpdateSessionAgentPID_UpdatesSession(t *testing.T) {
-	db, err := data.NewDB(":memory:")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-
-	sess := domain.Session{
-		WorktreePath: "/repo/wt1",
-		Status:       domain.StatusActive,
-		StartedAt:    time.Now().UTC().Truncate(time.Second),
-	}
-	_, err = data.UpsertSession(db, sess)
-	require.NoError(t, err)
-
-	updateSessionAgentPID(db, "/repo/wt1", "copilot", 12345)
-
-	got, err := data.GetSessionByWorktree(db, "/repo/wt1")
-	require.NoError(t, err)
-	require.NotNil(t, got)
-	require.NotNil(t, got.AgentPID, "AgentPID must be set after updateSessionAgentPID")
-	assert.Equal(t, 12345, *got.AgentPID)
-	require.NotNil(t, got.AgentName, "AgentName must be set after updateSessionAgentPID")
-	assert.Equal(t, "copilot", *got.AgentName)
-}
-
-// TestUpdateSessionAgentPID_NoSession_CreatesAgentOnlySession verifies that
-// updateSessionAgentPID creates a new agent-only session when no session exists
-// for the given worktree path (agent spawned without a prior terminal session).
-func TestUpdateSessionAgentPID_NoSession_CreatesAgentOnlySession(t *testing.T) {
-	db, err := data.NewDB(":memory:")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-
-	updateSessionAgentPID(db, "/repo/agent-only", "copilot", 99)
-
-	got, err := data.GetSessionByWorktree(db, "/repo/agent-only")
-	require.NoError(t, err)
-	require.NotNil(t, got, "agent-only session must be created when no session exists")
-	assert.Nil(t, got.ShellPID, "ShellPID must be nil for agent-only session")
-	require.NotNil(t, got.AgentPID)
-	assert.Equal(t, 99, *got.AgentPID)
-	require.NotNil(t, got.AgentName)
-	assert.Equal(t, "copilot", *got.AgentName)
-	assert.Equal(t, domain.StatusAgentRunning, got.Status)
-}
-
-// TestCheckSessionsCmd_NilDB_DeadShellAliveAgent_KeepsSession verifies that an
-// in-memory session with a dead shell PID but a live agent PID is preserved
-// and transitions to StatusAgentRunning.
-func TestCheckSessionsCmd_NilDB_DeadShellAliveAgent_KeepsSession(t *testing.T) {
+// TestCheckSessionsCmd_NilDB_DeadShellPruned verifies that an in-memory session
+// with a dead shell PID is removed from the alive list.
+func TestCheckSessionsCmd_NilDB_DeadShellPruned(t *testing.T) {
 	deadPID := 999999999
-	alivePID := os.Getpid()
 
 	m := NewModel()
 	m.sessions = []domain.Session{
 		{
 			ID:           1,
-			WorktreePath: "/repo/agent-running",
+			WorktreePath: "/repo/dead-shell",
 			ShellPID:     &deadPID,
-			AgentPID:     &alivePID,
-			Status:       domain.StatusActive,
-			StartedAt:    time.Now().UTC(),
-		},
-	}
-
-	cmd := m.checkSessionsCmd()
-	require.NotNil(t, cmd)
-	msg := cmd()
-	result, ok := msg.(sessionStatusUpdatedMsg)
-	require.True(t, ok, "expected sessionStatusUpdatedMsg, got %T", msg)
-	require.Len(t, result.sessions, 1, "session with alive agent PID must be kept")
-	assert.Equal(t, domain.StatusAgentRunning, result.sessions[0].Status,
-		"session must transition to StatusAgentRunning when shell is dead but agent is alive")
-}
-
-// TestCheckSessionsCmd_NilDB_BothDeadPruned verifies that an in-memory session
-// with both shell and agent PIDs dead is removed from the alive list.
-func TestCheckSessionsCmd_NilDB_BothDeadPruned(t *testing.T) {
-	deadPID := 999999999
-	anotherDeadPID := 999999998
-
-	m := NewModel()
-	m.sessions = []domain.Session{
-		{
-			ID:           1,
-			WorktreePath: "/repo/both-dead",
-			ShellPID:     &deadPID,
-			AgentPID:     &anotherDeadPID,
 			Status:       domain.StatusActive,
 			StartedAt:    time.Now().UTC(),
 		},
@@ -2956,24 +2878,20 @@ func TestCheckSessionsCmd_NilDB_BothDeadPruned(t *testing.T) {
 	msg := cmd()
 	result, ok := msg.(sessionStatusUpdatedMsg)
 	require.True(t, ok)
-	assert.Empty(t, result.sessions, "session with both dead PIDs must be pruned")
+	assert.Empty(t, result.sessions, "session with dead shell PID must be pruned")
 }
 
-// TestCheckSessionsCmd_DB_DeadShellAliveAgent_KeepsSession verifies that a
-// DB-backed session with a dead shell but a live agent PID is preserved and
-// transitioned to StatusAgentRunning.
-func TestCheckSessionsCmd_DB_DeadShellAliveAgent_KeepsSession(t *testing.T) {
+// TestCheckSessionsCmd_DB_DeadShellPruned verifies that a DB-backed session
+// with a dead shell PID is deleted from the DB and excluded from the returned list.
+func TestCheckSessionsCmd_DB_DeadShellPruned(t *testing.T) {
 	db, err := data.NewDB(":memory:")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
 	deadPID := 999999999
-	alivePID := os.Getpid()
-
 	sess := domain.Session{
-		WorktreePath: "/repo/agent-running",
+		WorktreePath: "/repo/dead-shell",
 		ShellPID:     &deadPID,
-		AgentPID:     &alivePID,
 		Status:       domain.StatusActive,
 		StartedAt:    time.Now().UTC().Truncate(time.Second),
 	}
@@ -2988,119 +2906,9 @@ func TestCheckSessionsCmd_DB_DeadShellAliveAgent_KeepsSession(t *testing.T) {
 	msg := cmd()
 	result, ok := msg.(sessionStatusUpdatedMsg)
 	require.True(t, ok)
-	require.Len(t, result.sessions, 1, "session with alive agent PID must be kept")
-	assert.Equal(t, domain.StatusAgentRunning, result.sessions[0].Status,
-		"session must transition to StatusAgentRunning when shell is dead but agent is alive")
+	assert.Empty(t, result.sessions, "session with dead shell PID must be pruned")
 
-	// Confirm status was persisted to DB.
-	got, err := data.GetSessionByWorktree(db, "/repo/agent-running")
+	got, err := data.GetSessionByWorktree(db, "/repo/dead-shell")
 	require.NoError(t, err)
-	require.NotNil(t, got)
-	assert.Equal(t, domain.StatusAgentRunning, got.Status,
-		"StatusAgentRunning must be written back to the DB")
-}
-
-// TestCheckSessionsCmd_DB_BothDeadPruned verifies that a DB-backed session
-// with both shell and agent PIDs dead is deleted from the DB and excluded from
-// the returned session list.
-func TestCheckSessionsCmd_DB_BothDeadPruned(t *testing.T) {
-	db, err := data.NewDB(":memory:")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-
-	deadPID := 999999999
-	anotherDeadPID := 999999998
-
-	sess := domain.Session{
-		WorktreePath: "/repo/both-dead",
-		ShellPID:     &deadPID,
-		AgentPID:     &anotherDeadPID,
-		Status:       domain.StatusActive,
-		StartedAt:    time.Now().UTC().Truncate(time.Second),
-	}
-	_, err = data.UpsertSession(db, sess)
-	require.NoError(t, err)
-
-	m := NewModel()
-	m.db = db
-
-	cmd := m.checkSessionsCmd()
-	require.NotNil(t, cmd)
-	msg := cmd()
-	result, ok := msg.(sessionStatusUpdatedMsg)
-	require.True(t, ok)
-	assert.Empty(t, result.sessions, "session with both dead PIDs must be pruned")
-
-	// Confirm it was deleted from the DB.
-	got, err := data.GetSessionByWorktree(db, "/repo/both-dead")
-	require.NoError(t, err)
-	assert.Nil(t, got, "session with both dead PIDs must be deleted from the DB")
-}
-
-// TestCheckSessionsCmd_DB_AgentOnlySession_PrunedWhenAgentDies verifies that a
-// DB-backed agent-only session (no ShellPID) is removed when the agent exits.
-func TestCheckSessionsCmd_DB_AgentOnlySession_PrunedWhenAgentDies(t *testing.T) {
-	db, err := data.NewDB(":memory:")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-
-	deadPID := 999999999
-	agentName := "copilot"
-	sess := domain.Session{
-		WorktreePath: "/repo/agent-only",
-		ShellPID:     nil,
-		AgentPID:     &deadPID,
-		AgentName:    &agentName,
-		Status:       domain.StatusAgentRunning,
-		StartedAt:    time.Now().UTC(),
-	}
-	_, err = data.UpsertSession(db, sess)
-	require.NoError(t, err)
-
-	m := NewModel()
-	m.db = db
-
-	cmd := m.checkSessionsCmd()
-	require.NotNil(t, cmd)
-	msg := cmd()
-	result, ok := msg.(sessionStatusUpdatedMsg)
-	require.True(t, ok)
-	assert.Empty(t, result.sessions, "agent-only session must be pruned when agent exits")
-
-	got, err := data.GetSessionByWorktree(db, "/repo/agent-only")
-	require.NoError(t, err)
-	assert.Nil(t, got, "agent-only session must be deleted from DB when agent exits")
-}
-
-// TestCheckSessionsCmd_DB_AgentOnlySession_KeptWhileAgentAlive verifies that a
-// DB-backed agent-only session is kept alive while the agent process is running.
-func TestCheckSessionsCmd_DB_AgentOnlySession_KeptWhileAgentAlive(t *testing.T) {
-	db, err := data.NewDB(":memory:")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-
-	alivePID := os.Getpid()
-	agentName := "copilot"
-	sess := domain.Session{
-		WorktreePath: "/repo/agent-alive",
-		ShellPID:     nil,
-		AgentPID:     &alivePID,
-		AgentName:    &agentName,
-		Status:       domain.StatusAgentRunning,
-		StartedAt:    time.Now().UTC(),
-	}
-	_, err = data.UpsertSession(db, sess)
-	require.NoError(t, err)
-
-	m := NewModel()
-	m.db = db
-
-	cmd := m.checkSessionsCmd()
-	require.NotNil(t, cmd)
-	msg := cmd()
-	result, ok := msg.(sessionStatusUpdatedMsg)
-	require.True(t, ok)
-	require.Len(t, result.sessions, 1, "agent-only session must be kept while agent is alive")
-	assert.Nil(t, result.sessions[0].ShellPID)
-	assert.Equal(t, alivePID, *result.sessions[0].AgentPID)
+	assert.Nil(t, got, "session with dead shell PID must be deleted from the DB")
 }

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -2883,17 +2883,25 @@ func TestUpdateSessionAgentPID_UpdatesSession(t *testing.T) {
 	assert.Equal(t, "copilot", *got.AgentName)
 }
 
-// TestUpdateSessionAgentPID_NoSession_NoError verifies that updateSessionAgentPID
-// does not panic when no session exists for the given worktree path.
-func TestUpdateSessionAgentPID_NoSession_NoError(t *testing.T) {
+// TestUpdateSessionAgentPID_NoSession_CreatesAgentOnlySession verifies that
+// updateSessionAgentPID creates a new agent-only session when no session exists
+// for the given worktree path (agent spawned without a prior terminal session).
+func TestUpdateSessionAgentPID_NoSession_CreatesAgentOnlySession(t *testing.T) {
 	db, err := data.NewDB(":memory:")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	// Should not panic — just logs a warning.
-	assert.NotPanics(t, func() {
-		updateSessionAgentPID(db, "/repo/nonexistent", "copilot", 42)
-	})
+	updateSessionAgentPID(db, "/repo/agent-only", "copilot", 99)
+
+	got, err := data.GetSessionByWorktree(db, "/repo/agent-only")
+	require.NoError(t, err)
+	require.NotNil(t, got, "agent-only session must be created when no session exists")
+	assert.Nil(t, got.ShellPID, "ShellPID must be nil for agent-only session")
+	require.NotNil(t, got.AgentPID)
+	assert.Equal(t, 99, *got.AgentPID)
+	require.NotNil(t, got.AgentName)
+	assert.Equal(t, "copilot", *got.AgentName)
+	assert.Equal(t, domain.StatusAgentRunning, got.Status)
 }
 
 // TestCheckSessionsCmd_NilDB_DeadShellAliveAgent_KeepsSession verifies that an
@@ -3027,4 +3035,72 @@ func TestCheckSessionsCmd_DB_BothDeadPruned(t *testing.T) {
 	got, err := data.GetSessionByWorktree(db, "/repo/both-dead")
 	require.NoError(t, err)
 	assert.Nil(t, got, "session with both dead PIDs must be deleted from the DB")
+}
+
+// TestCheckSessionsCmd_DB_AgentOnlySession_PrunedWhenAgentDies verifies that a
+// DB-backed agent-only session (no ShellPID) is removed when the agent exits.
+func TestCheckSessionsCmd_DB_AgentOnlySession_PrunedWhenAgentDies(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	deadPID := 999999999
+	agentName := "copilot"
+	sess := domain.Session{
+		WorktreePath: "/repo/agent-only",
+		ShellPID:     nil,
+		AgentPID:     &deadPID,
+		AgentName:    &agentName,
+		Status:       domain.StatusAgentRunning,
+		StartedAt:    time.Now().UTC(),
+	}
+	_, err = data.UpsertSession(db, sess)
+	require.NoError(t, err)
+
+	m := NewModel()
+	m.db = db
+
+	cmd := m.checkSessionsCmd()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	result, ok := msg.(sessionStatusUpdatedMsg)
+	require.True(t, ok)
+	assert.Empty(t, result.sessions, "agent-only session must be pruned when agent exits")
+
+	got, err := data.GetSessionByWorktree(db, "/repo/agent-only")
+	require.NoError(t, err)
+	assert.Nil(t, got, "agent-only session must be deleted from DB when agent exits")
+}
+
+// TestCheckSessionsCmd_DB_AgentOnlySession_KeptWhileAgentAlive verifies that a
+// DB-backed agent-only session is kept alive while the agent process is running.
+func TestCheckSessionsCmd_DB_AgentOnlySession_KeptWhileAgentAlive(t *testing.T) {
+	db, err := data.NewDB(":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	alivePID := os.Getpid()
+	agentName := "copilot"
+	sess := domain.Session{
+		WorktreePath: "/repo/agent-alive",
+		ShellPID:     nil,
+		AgentPID:     &alivePID,
+		AgentName:    &agentName,
+		Status:       domain.StatusAgentRunning,
+		StartedAt:    time.Now().UTC(),
+	}
+	_, err = data.UpsertSession(db, sess)
+	require.NoError(t, err)
+
+	m := NewModel()
+	m.db = db
+
+	cmd := m.checkSessionsCmd()
+	require.NotNil(t, cmd)
+	msg := cmd()
+	result, ok := msg.(sessionStatusUpdatedMsg)
+	require.True(t, ok)
+	require.Len(t, result.sessions, 1, "agent-only session must be kept while agent is alive")
+	assert.Nil(t, result.sessions[0].ShellPID)
+	assert.Equal(t, alivePID, *result.sessions[0].AgentPID)
 }

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -107,7 +107,7 @@ func renderSessionBlock(s *domain.Session) string {
 		b.WriteString("  Shell:   none\n")
 	}
 	if s.AgentName != nil {
-		b.WriteString(fmt.Sprintf("  Agent:   %s %s\n", *s.AgentName, s.Status))
+		b.WriteString(fmt.Sprintf("  Agent:   %s\n", *s.AgentName))
 	}
 	if s.Prompt != nil && *s.Prompt != "" {
 		b.WriteString(fmt.Sprintf("  Prompt:  %s\n", *s.Prompt))

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -1959,37 +1959,6 @@ func TestSessionBadge_AllStates(t *testing.T) {
 			want:    "[session open]",
 		},
 		{
-			name: "StatusAgentRunning returns [session open]",
-			session: &domain.Session{
-				Status:    domain.StatusAgentRunning,
-				AgentName: ptr("copilot"),
-			},
-			want: "[session open]",
-		},
-		{
-			name: "StatusAgentRunning with no agent name returns [session open]",
-			session: &domain.Session{
-				Status: domain.StatusAgentRunning,
-			},
-			want: "[session open]",
-		},
-		{
-			name: "StatusAgentDone returns [session open]",
-			session: &domain.Session{
-				Status:    domain.StatusAgentDone,
-				AgentName: ptr("claude"),
-			},
-			want: "[session open]",
-		},
-		{
-			name: "StatusAgentFailed returns [session open]",
-			session: &domain.Session{
-				Status:    domain.StatusAgentFailed,
-				AgentName: ptr("aider"),
-			},
-			want: "[session open]",
-		},
-		{
 			name:    "StatusDead returns empty string",
 			session: &domain.Session{Status: domain.StatusDead},
 			want:    "",
@@ -2008,11 +1977,9 @@ func TestSessionBadge_AllStates(t *testing.T) {
 func TestCountActiveSessions(t *testing.T) {
 	sessions := []domain.Session{
 		{Status: domain.StatusActive},
-		{Status: domain.StatusAgentRunning},
-		{Status: domain.StatusAgentDone},
 		{Status: domain.StatusDead},
 	}
-	assert.Equal(t, 3, countActiveSessions(sessions))
+	assert.Equal(t, 1, countActiveSessions(sessions))
 	assert.Equal(t, 0, countActiveSessions(nil))
 }
 
@@ -2029,10 +1996,9 @@ func TestRenderFull_SessionCountInHeader(t *testing.T) {
 			name: "header shows session count when sessions are active",
 			sessions: []domain.Session{
 				{WorktreePath: "/tmp/wt1", Status: domain.StatusActive},
-				{WorktreePath: "/tmp/wt2", Status: domain.StatusAgentRunning, AgentName: ptr("copilot")},
 				{WorktreePath: "/tmp/wt3", Status: domain.StatusDead},
 			},
-			wantIn:  []string{"2 active session(s)"},
+			wantIn:  []string{"1 active session(s)"},
 			wantOut: []string{},
 		},
 		{
@@ -2092,33 +2058,6 @@ func TestRenderFull_SessionBadgesInWorktreeRow(t *testing.T) {
 			wantIn:  "[session open]",
 		},
 		{
-			name: "agent running shows [session open]",
-			session: &domain.Session{
-				WorktreePath: "/tmp/feat-work",
-				Status:       domain.StatusAgentRunning,
-				AgentName:    ptr("copilot"),
-			},
-			wantIn: "[session open]",
-		},
-		{
-			name: "agent done shows [session open]",
-			session: &domain.Session{
-				WorktreePath: "/tmp/feat-work",
-				Status:       domain.StatusAgentDone,
-				AgentName:    ptr("claude"),
-			},
-			wantIn: "[session open]",
-		},
-		{
-			name: "agent failed shows [session open]",
-			session: &domain.Session{
-				WorktreePath: "/tmp/feat-work",
-				Status:       domain.StatusAgentFailed,
-				AgentName:    ptr("aider"),
-			},
-			wantIn: "[session open]",
-		},
-		{
 			name:    "dead session shows no badge",
 			session: &domain.Session{WorktreePath: "/tmp/feat-work", Status: domain.StatusDead},
 			wantIn:  "feat-work",
@@ -2169,7 +2108,7 @@ func TestRenderFull_SessionBlockInContextPanel(t *testing.T) {
 			name: "session block shows agent name and prompt",
 			session: domain.Session{
 				WorktreePath: "/tmp/wt-session",
-				Status:       domain.StatusAgentRunning,
+				Status:       domain.StatusActive,
 				ShellPID:     &pid,
 				AgentName:    ptr("Copilot"),
 				Prompt:       &prompt,
@@ -2221,7 +2160,7 @@ func TestSessionForWorktree_PathNormalisation(t *testing.T) {
 	sessions := []domain.Session{
 		{
 			WorktreePath: filepath.FromSlash("/repo/feat-work"),
-			Status:       domain.StatusAgentRunning,
+			Status:       domain.StatusActive,
 			AgentName:    &agentName,
 		},
 	}
@@ -2229,7 +2168,7 @@ func TestSessionForWorktree_PathNormalisation(t *testing.T) {
 	// Same path with opposite separator style — must still match.
 	got := sessionForWorktree(sessions, filepath.ToSlash(filepath.FromSlash("/repo/feat-work")))
 	require.NotNil(t, got, "expected a session match despite different separators")
-	assert.Equal(t, domain.StatusAgentRunning, got.Status)
+	assert.Equal(t, domain.StatusActive, got.Status)
 }
 
 // TestPathsEqual_NormalisedComparison verifies the pathsEqual helper handles

--- a/cmd/nexus/terminal_windows.go
+++ b/cmd/nexus/terminal_windows.go
@@ -94,6 +94,28 @@ func spawnTerminalWindow(path string) (int, error) {
 // current terminal emulator when possible, falling back to a new cmd.exe window.
 // The TUI is not suspended — nexus keeps running in the original terminal.
 func spawnAgentInTerminalWindow(path, agentCmd string) (int, error) {
+	// Windows Terminal: use the PID-file trick to capture the real PowerShell PID
+	// (wt.exe exits immediately after launching the tab, so tabCmd.Process.Pid
+	// would be dead by the time the health-check poller runs).
+	if os.Getenv("WT_SESSION") != "" {
+		pidFile := filepath.Join(os.TempDir(), fmt.Sprintf("nexus-agent-%d.pid", time.Now().UnixNano()))
+		psCmd := fmt.Sprintf(
+			`[System.Diagnostics.Process]::GetCurrentProcess().Id | Set-Content -LiteralPath '%s'; %s`,
+			pidFile, agentCmd,
+		)
+		cmd := exec.Command("wt", "-w", "0", "new-tab", "--startingDirectory", path,
+			"powershell", "-NoExit", "-Command", psCmd)
+		if err := cmd.Start(); err == nil {
+			pid := pollPIDFile(pidFile, 3*time.Second)
+			os.Remove(pidFile)
+			if pid > 0 {
+				return pid, nil
+			}
+		}
+		os.Remove(pidFile)
+		// Fall through to standalone window on error.
+	}
+
 	// Prefer a new tab when the running terminal supports it.
 	if tabCmd, ok := buildNewTabWithCmdCmd(path, agentCmd, "", "windows"); ok {
 		if err := tabCmd.Start(); err == nil {

--- a/cmd/nexus/terminal_windows.go
+++ b/cmd/nexus/terminal_windows.go
@@ -108,9 +108,7 @@ func spawnAgentInTerminalWindow(path, agentCmd string) (int, error) {
 		if err := cmd.Start(); err == nil {
 			pid := pollPIDFile(pidFile, 3*time.Second)
 			os.Remove(pidFile)
-			if pid > 0 {
-				return pid, nil
-			}
+			return pid, nil
 		}
 		os.Remove(pidFile)
 		// Fall through to standalone window on error.

--- a/cmd/nexus/terminal_windows.go
+++ b/cmd/nexus/terminal_windows.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,12 +12,27 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unicode/utf16"
 )
 
 // agentPIDPollTimeout is the maximum time to wait for the PID-file written by
 // the PowerShell process before giving up. 3 s is generous for a local spawn;
 // increase if slow machines miss the window under load.
 const agentPIDPollTimeout = 3 * time.Second
+
+// encodePSCommand encodes a PowerShell command string as UTF-16LE base64,
+// suitable for the powershell.exe -EncodedCommand flag. This sidesteps Windows
+// Terminal's own argument parser, which treats unquoted ';' characters as
+// tab-command separators even when they appear inside a quoted -Command value.
+func encodePSCommand(s string) string {
+	words := utf16.Encode([]rune(s))
+	b := make([]byte, len(words)*2)
+	for i, w := range words {
+		b[2*i] = byte(w)
+		b[2*i+1] = byte(w >> 8)
+	}
+	return base64.StdEncoding.EncodeToString(b)
+}
 
 // setWindowsCmdLine overrides the raw Windows command line for the new-terminal
 // command so that cmd.exe receives an unescaped string.
@@ -109,7 +125,7 @@ func spawnAgentInTerminalWindow(path, agentCmd string) (int, error) {
 			pidFile, agentCmd,
 		)
 		cmd := exec.Command("wt", "-w", "0", "new-tab", "--startingDirectory", path,
-			"powershell", "-NoExit", "-Command", psCmd)
+			"powershell", "-NoExit", "-EncodedCommand", encodePSCommand(psCmd))
 		if err := cmd.Start(); err == nil {
 			pid := pollPIDFile(pidFile, agentPIDPollTimeout)
 			os.Remove(pidFile)

--- a/cmd/nexus/terminal_windows.go
+++ b/cmd/nexus/terminal_windows.go
@@ -13,6 +13,11 @@ import (
 	"time"
 )
 
+// agentPIDPollTimeout is the maximum time to wait for the PID-file written by
+// the PowerShell process before giving up. 3 s is generous for a local spawn;
+// increase if slow machines miss the window under load.
+const agentPIDPollTimeout = 3 * time.Second
+
 // setWindowsCmdLine overrides the raw Windows command line for the new-terminal
 // command so that cmd.exe receives an unescaped string.
 //
@@ -49,7 +54,7 @@ func spawnTerminalWindow(path string) (int, error) {
 		cmd := exec.Command("wt", "-w", "0", "new-tab", "--startingDirectory", path,
 			"powershell", "-NoExit", "-Command", psCmd)
 		if err := cmd.Start(); err == nil {
-			pid := pollPIDFile(pidFile, 3*time.Second)
+			pid := pollPIDFile(pidFile, agentPIDPollTimeout)
 			os.Remove(pidFile)
 			return pid, nil
 		}
@@ -61,7 +66,7 @@ func spawnTerminalWindow(path string) (int, error) {
 	pidFile := filepath.Join(os.TempDir(), fmt.Sprintf("nexus-session-%d.pid", time.Now().UnixNano()))
 	if tabCmd, ok := buildNewTabWithCmdCmd(path, "", pidFile, "windows"); ok {
 		if err := tabCmd.Start(); err == nil {
-			pid := pollPIDFile(pidFile, 3*time.Second)
+			pid := pollPIDFile(pidFile, agentPIDPollTimeout)
 			os.Remove(pidFile)
 			return pid, nil
 		}
@@ -106,7 +111,7 @@ func spawnAgentInTerminalWindow(path, agentCmd string) (int, error) {
 		cmd := exec.Command("wt", "-w", "0", "new-tab", "--startingDirectory", path,
 			"powershell", "-NoExit", "-Command", psCmd)
 		if err := cmd.Start(); err == nil {
-			pid := pollPIDFile(pidFile, 3*time.Second)
+			pid := pollPIDFile(pidFile, agentPIDPollTimeout)
 			os.Remove(pidFile)
 			return pid, nil
 		}

--- a/internal/data/db_test.go
+++ b/internal/data/db_test.go
@@ -229,5 +229,5 @@ func TestNewDB_SchemaVersionsTracked(t *testing.T) {
 	}
 	require.NoError(t, rows.Err())
 
-	assert.Equal(t, []string{"001_init_schema.sql", "002_add_diff_summary_to_context_snapshots.sql", "003_add_issue_hierarchy.sql", "004_add_active_sessions.sql", "005_recreate_active_sessions.sql"}, filenames)
+	assert.Equal(t, []string{"001_init_schema.sql", "002_add_diff_summary_to_context_snapshots.sql", "003_add_issue_hierarchy.sql", "004_add_active_sessions.sql", "005_recreate_active_sessions.sql", "006_simplify_active_sessions.sql"}, filenames)
 }

--- a/internal/data/migrations/006_simplify_active_sessions.sql
+++ b/internal/data/migrations/006_simplify_active_sessions.sql
@@ -1,0 +1,14 @@
+-- Simplify active_sessions: drop agent_pid, reduce status set to active/dead.
+-- Session tracking is now purely "is a terminal open at this worktree?" —
+-- agent process health is not tracked separately.
+DROP TABLE IF EXISTS active_sessions;
+CREATE TABLE active_sessions (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    worktree_path TEXT NOT NULL UNIQUE,
+    shell_pid     INTEGER,
+    agent_name    TEXT,
+    prompt        TEXT,
+    status        TEXT DEFAULT 'active' CHECK(status IN ('active','dead')),
+    started_at    DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at    DATETIME DEFAULT CURRENT_TIMESTAMP
+);

--- a/internal/data/migrations/006_simplify_active_sessions.sql
+++ b/internal/data/migrations/006_simplify_active_sessions.sql
@@ -1,6 +1,10 @@
 -- Simplify active_sessions: drop agent_pid, reduce status set to active/dead.
 -- Session tracking is now purely "is a terminal open at this worktree?" —
 -- agent process health is not tracked separately.
+--
+-- NOTE: this migration intentionally drops and recreates the table, which
+-- destroys any existing session rows. Sessions are ephemeral runtime state
+-- (PIDs become stale after a restart anyway), so data loss is acceptable here.
 DROP TABLE IF EXISTS active_sessions;
 CREATE TABLE active_sessions (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/internal/data/session.go
+++ b/internal/data/session.go
@@ -22,12 +22,11 @@ func UpsertSession(db *DB, s domain.Session) (int64, error) {
 
 	res, err := db.Conn.Exec(
 		`INSERT OR REPLACE INTO active_sessions
-		 (worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at, updated_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		 (worktree_path, shell_pid, agent_name, prompt, status, started_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		s.WorktreePath,
 		s.ShellPID,
 		s.AgentName,
-		s.AgentPID,
 		s.Prompt,
 		string(s.Status),
 		startedAt,
@@ -47,7 +46,7 @@ func UpsertSession(db *DB, s domain.Session) (int64, error) {
 // An empty database returns an empty slice and no error.
 func GetSessions(db *DB) ([]domain.Session, error) {
 	rows, err := db.Conn.Query(
-		`SELECT id, worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at, updated_at
+		`SELECT id, worktree_path, shell_pid, agent_name, prompt, status, started_at, updated_at
 		 FROM active_sessions
 		 ORDER BY started_at DESC`,
 	)
@@ -77,7 +76,7 @@ func GetSessions(db *DB) ([]domain.Session, error) {
 // when no row matches.
 func GetSessionByWorktree(db *DB, worktreePath string) (*domain.Session, error) {
 	row := db.Conn.QueryRow(
-		`SELECT id, worktree_path, shell_pid, agent_name, agent_pid, prompt, status, started_at, updated_at
+		`SELECT id, worktree_path, shell_pid, agent_name, prompt, status, started_at, updated_at
 		 FROM active_sessions
 		 WHERE worktree_path = ?`,
 		worktreePath,
@@ -123,7 +122,6 @@ func scanSession(s rowScanner) (domain.Session, error) {
 		sess      domain.Session
 		shellPID  sql.NullInt64
 		agentName sql.NullString
-		agentPID  sql.NullInt64
 		prompt    sql.NullString
 		startedAt sql.NullString
 		updatedAt sql.NullString
@@ -133,7 +131,6 @@ func scanSession(s rowScanner) (domain.Session, error) {
 		&sess.WorktreePath,
 		&shellPID,
 		&agentName,
-		&agentPID,
 		&prompt,
 		&sess.Status,
 		&startedAt,
@@ -148,10 +145,6 @@ func scanSession(s rowScanner) (domain.Session, error) {
 	}
 	if agentName.Valid {
 		sess.AgentName = &agentName.String
-	}
-	if agentPID.Valid {
-		v := int(agentPID.Int64)
-		sess.AgentPID = &v
 	}
 	if prompt.Valid {
 		sess.Prompt = &prompt.String

--- a/internal/data/session_test.go
+++ b/internal/data/session_test.go
@@ -58,8 +58,7 @@ func TestUpsertSession_Replace(t *testing.T) {
 	s2 := domain.Session{
 		WorktreePath: "/repo/feat",
 		AgentName:    strPtr("copilot"),
-		AgentPID:     intPtr(9999),
-		Status:       domain.StatusAgentRunning,
+		Status:       domain.StatusActive,
 		StartedAt:    time.Now().UTC().Truncate(time.Second),
 	}
 	_, err = data.UpsertSession(db, s2)
@@ -68,11 +67,9 @@ func TestUpsertSession_Replace(t *testing.T) {
 	got, err := data.GetSessionByWorktree(db, "/repo/feat")
 	require.NoError(t, err)
 	require.NotNil(t, got)
-	assert.Equal(t, domain.StatusAgentRunning, got.Status)
+	assert.Equal(t, domain.StatusActive, got.Status)
 	require.NotNil(t, got.AgentName)
 	assert.Equal(t, "copilot", *got.AgentName)
-	require.NotNil(t, got.AgentPID)
-	assert.Equal(t, 9999, *got.AgentPID)
 }
 
 // TestGetSessions_Empty verifies that an empty database returns an empty slice
@@ -104,7 +101,7 @@ func TestGetSessions_Multiple(t *testing.T) {
 	s2 := domain.Session{
 		WorktreePath: "/repo/beta",
 		ShellPID:     intPtr(1002),
-		Status:       domain.StatusAgentDone,
+		Status:       domain.StatusActive,
 		StartedAt:    time.Now().UTC().Truncate(time.Second),
 	}
 
@@ -119,7 +116,7 @@ func TestGetSessions_Multiple(t *testing.T) {
 
 	// Ordered DESC by started_at: s2 is newer so comes first.
 	assert.Equal(t, "/repo/beta", sessions[0].WorktreePath)
-	assert.Equal(t, domain.StatusAgentDone, sessions[0].Status)
+	assert.Equal(t, domain.StatusActive, sessions[0].Status)
 	assert.Equal(t, "/repo/alpha", sessions[1].WorktreePath)
 	require.NotNil(t, sessions[1].Prompt)
 	assert.Equal(t, "fix the bug", *sessions[1].Prompt)

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -6,15 +6,9 @@ import "time"
 type SessionStatus string
 
 const (
-	// StatusActive means the shell is open and no agent is running.
+	// StatusActive means the terminal is open at this worktree.
 	StatusActive SessionStatus = "active"
-	// StatusAgentRunning means an AI agent process is currently executing.
-	StatusAgentRunning SessionStatus = "agent_running"
-	// StatusAgentDone means the agent finished successfully.
-	StatusAgentDone SessionStatus = "agent_done"
-	// StatusAgentFailed means the agent process exited with an error.
-	StatusAgentFailed SessionStatus = "agent_failed"
-	// StatusDead means the shell process is no longer alive.
+	// StatusDead means the terminal process is no longer alive.
 	StatusDead SessionStatus = "dead"
 )
 
@@ -24,7 +18,6 @@ type Session struct {
 	WorktreePath string
 	ShellPID     *int
 	AgentName    *string
-	AgentPID     *int
 	Prompt       *string
 	Status       SessionStatus
 	StartedAt    time.Time


### PR DESCRIPTION
Closes #67

## What Changed

Simplified the session model: removed \AgentPID\, collapsed agent-specific statuses (\gent_running\, \gent_done\, \gent_failed\) down to just \ctive\/\dead\, and added migration \