### PR TITLE
feat(updater): version detection, update notifications, and self-update

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -20,6 +21,8 @@ import (
 	internalexec "github.com/m00nk0d3/nexus/internal/exec"
 	"github.com/m00nk0d3/nexus/internal/tui/modal"
 	"github.com/m00nk0d3/nexus/internal/tui/styles"
+	"github.com/m00nk0d3/nexus/internal/updater"
+	"github.com/m00nk0d3/nexus/internal/version"
 )
 
 // issuesFetchedMsg carries the result of a background gh issue list call.
@@ -92,11 +95,47 @@ type aiderFilesFetchedMsg struct {
 // clearErrorMsg is dispatched after the 5-second auto-dismiss timer fires.
 type clearErrorMsg struct{}
 
+// updateCheckedMsg carries the result of the startup version check.
+type updateCheckedMsg struct {
+	info updater.ReleaseInfo
+	err  error
+}
+
+// selfUpdateProgressMsg carries a progress status string during self-update.
+type selfUpdateProgressMsg struct{ status string }
+
+// selfUpdateDoneMsg carries the result of a self-update attempt.
+type selfUpdateDoneMsg struct{ err error }
+
 // clearErrorCmd returns a Cmd that fires clearErrorMsg after 5 seconds.
 func clearErrorCmd() tea.Cmd {
 	return tea.Tick(5*time.Second, func(t time.Time) tea.Msg {
 		return clearErrorMsg{}
 	})
+}
+
+// checkForUpdateCmd fires an async update check on startup.
+func checkForUpdateCmd() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		info, err := updater.CheckLatestRelease(ctx)
+		return updateCheckedMsg{info: info, err: err}
+	}
+}
+
+// selfUpdateCmd runs the self-update in the background.
+func selfUpdateCmd(tagName string) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		err := updater.SelfUpdate(ctx, tagName, func(status string) {
+			// Progress is reflected via selfUpdateProgressMsg — but since
+			// tea.Cmd returns a single Msg, we capture only the final outcome here.
+			_ = status
+		})
+		return selfUpdateDoneMsg{err: err}
+	}
 }
 
 // sessionTickCmd schedules a sessionTickMsg after 3 seconds.
@@ -246,6 +285,13 @@ type Model struct {
 	// sessions holds the last-known list of active terminal sessions.
 	sessions []domain.Session
 
+	// latestVersion holds the latest release version discovered on startup (empty if check failed).
+	latestVersion string
+	// selfUpdating is true while a self-update is in progress.
+	selfUpdating bool
+	// selfUpdateStatus holds the last progress message during a self-update.
+	selfUpdateStatus string
+
 	// issueTree caches the depth-first-ordered tree built from m.issues.
 	// Rebuilt whenever m.issues is updated (debouncedRenderMsg handler).
 	issueTree []issueTreeRow
@@ -290,7 +336,7 @@ func (m *Model) Init() tea.Cmd {
 	m.syncing = true
 	// Always start the session tick — it handles both nexus-spawned shell sessions
 	// (requires m.db) and externally-started Copilot CLI sessions (no DB needed).
-	return tea.Batch(m.refreshWorktreesCmd(), m.syncGitHubCmd(), sessionTickCmd())
+	return tea.Batch(m.refreshWorktreesCmd(), m.syncGitHubCmd(), sessionTickCmd(), checkForUpdateCmd())
 }
 
 // Update handles incoming messages and returns an updated model and command.
@@ -325,6 +371,11 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.spawnAiderCmd(selected.Path, msg.Files)
 			}
 			return m, nil
+		case modal.UpdateConfirmedMsg:
+			m.activeModal = nil
+			m.selfUpdating = true
+			m.selfUpdateStatus = "Starting update..."
+			return m, selfUpdateCmd(m.latestVersion)
 		case modal.SpawnAgentMsg:
 			m.activeModal = nil
 			switch msg.AgentName {
@@ -856,6 +907,33 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
 		m.height = msg.Height
+
+	case updateCheckedMsg:
+		if msg.err != nil {
+			slog.Debug("update check failed", "err", msg.err)
+			return m, nil
+		}
+		newer, err := updater.IsNewer(msg.info.TagName, version.Version)
+		if err != nil || !newer {
+			return m, nil
+		}
+		m.latestVersion = msg.info.TagName
+		m.activeModal = modal.NewUpdateModal(version.Version, msg.info.TagName, msg.info.Body, msg.info.HTMLURL, len(m.sessions))
+		return m, nil
+
+	case selfUpdateProgressMsg:
+		m.selfUpdateStatus = msg.status
+		return m, nil
+
+	case selfUpdateDoneMsg:
+		m.selfUpdating = false
+		m.selfUpdateStatus = ""
+		if msg.err != nil {
+			m.statusErr = fmt.Sprintf("Update failed: %v", msg.err)
+			return m, clearErrorCmd()
+		}
+		m.statusMsg = "✓ Updated successfully! Please restart nexus to use the new version."
+		return m, clearMsgCmd()
 	}
 
 	return m, nil
@@ -898,6 +976,10 @@ func (m *Model) View() string {
 	if m.claudePromptActive {
 		return overlay("Spawn Claude Code",
 			fmt.Sprintf("> %s\n\nEnter confirm (prompt optional)  •  Esc cancel", m.claudePromptInput.View()))
+	}
+
+	if m.selfUpdating {
+		return overlay("Updating nexus", fmt.Sprintf("%s\n\nPlease wait...", m.selfUpdateStatus))
 	}
 
 	if m.statusErr != "" {

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -126,9 +126,7 @@ func selfUpdateCmd(tagName string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
-		err := updater.SelfUpdate(ctx, tagName, func(status string) {
-			slog.Debug("self-update", "status", status)
-		})
+		err := updater.SelfUpdate(ctx, tagName)
 		return selfUpdateDoneMsg{err: err}
 	}
 }

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -101,9 +101,6 @@ type updateCheckedMsg struct {
 	err  error
 }
 
-// selfUpdateProgressMsg carries a progress status string during self-update.
-type selfUpdateProgressMsg struct{ status string }
-
 // selfUpdateDoneMsg carries the result of a self-update attempt.
 type selfUpdateDoneMsg struct{ err error }
 
@@ -130,9 +127,7 @@ func selfUpdateCmd(tagName string) tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		defer cancel()
 		err := updater.SelfUpdate(ctx, tagName, func(status string) {
-			// Progress is reflected via selfUpdateProgressMsg — but since
-			// tea.Cmd returns a single Msg, we capture only the final outcome here.
-			_ = status
+			slog.Debug("self-update", "status", status)
 		})
 		return selfUpdateDoneMsg{err: err}
 	}
@@ -289,8 +284,6 @@ type Model struct {
 	latestVersion string
 	// selfUpdating is true while a self-update is in progress.
 	selfUpdating bool
-	// selfUpdateStatus holds the last progress message during a self-update.
-	selfUpdateStatus string
 
 	// issueTree caches the depth-first-ordered tree built from m.issues.
 	// Rebuilt whenever m.issues is updated (debouncedRenderMsg handler).
@@ -374,7 +367,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case modal.UpdateConfirmedMsg:
 			m.activeModal = nil
 			m.selfUpdating = true
-			m.selfUpdateStatus = "Starting update..."
 			return m, selfUpdateCmd(m.latestVersion)
 		case modal.SpawnAgentMsg:
 			m.activeModal = nil
@@ -921,13 +913,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.activeModal = modal.NewUpdateModal(version.Version, msg.info.TagName, msg.info.Body, msg.info.HTMLURL, len(m.sessions))
 		return m, nil
 
-	case selfUpdateProgressMsg:
-		m.selfUpdateStatus = msg.status
-		return m, nil
-
 	case selfUpdateDoneMsg:
 		m.selfUpdating = false
-		m.selfUpdateStatus = ""
 		if msg.err != nil {
 			m.statusErr = fmt.Sprintf("Update failed: %v", msg.err)
 			return m, clearErrorCmd()
@@ -979,7 +966,7 @@ func (m *Model) View() string {
 	}
 
 	if m.selfUpdating {
-		return overlay("Updating nexus", fmt.Sprintf("%s\n\nPlease wait...", m.selfUpdateStatus))
+		return overlay("Updating nexus", "Downloading and installing update...\n\nPlease wait.")
 	}
 
 	if m.statusErr != "" {

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -13,12 +13,12 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/m00nk0d3/nexus/internal/domain"
 	"github.com/m00nk0d3/nexus/internal/tui/styles"
+	"github.com/m00nk0d3/nexus/internal/version"
 	"github.com/mattn/go-runewidth"
 )
 
 const (
-	appVersion           = "1.0"
-	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [q/esc] Quit"
+	footerHintsWorktrees= "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [q/esc] Quit"
 	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [t] Settings | [g] GH | [q/esc] Quit"
 	footerHintsDefault   = footerHintsWorktrees
 	actionBarHints       = "[c-n] New  [c-d] Delete  [c-l] Lock | [f1] Help"
@@ -193,8 +193,8 @@ func renderHeader(repoPath string, theme styles.Theme, innerWidth int, activeSes
 		repoPath = "./"
 	}
 	text := fmt.Sprintf(
-		"NEXUS v%s: GIT WORKTREE ORCHESTRATOR | Repo: %s | Local Path: %s",
-		appVersion, filepath.Base(repoPath), repoPath,
+		"NEXUS %s: GIT WORKTREE ORCHESTRATOR | Repo: %s | Local Path: %s",
+		version.Version, filepath.Base(repoPath), repoPath,
 	)
 	if activeSessions > 0 {
 		text += fmt.Sprintf(" | %d active session(s)", activeSessions)

--- a/internal/tui/modal/messages.go
+++ b/internal/tui/modal/messages.go
@@ -63,3 +63,6 @@ type SpawnAgentMsg struct {
 	Prompt       string   // Prompt text (empty for Aider which uses file picker)
 	Files        []string // Reserved for Aider file-picker; populated in follow-on issue
 }
+
+// UpdateConfirmedMsg is sent when the user confirms the self-update from the update modal.
+type UpdateConfirmedMsg struct{}

--- a/internal/tui/modal/update.go
+++ b/internal/tui/modal/update.go
@@ -1,0 +1,95 @@
+package modal
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/tui/styles"
+)
+
+const changelogMaxLines = 15
+
+// UpdateModal shows the user that a new version is available and offers to self-update.
+type UpdateModal struct {
+	current        string
+	latest         string
+	changelog      string
+	htmlURL        string
+	activeSessions int
+	theme          *styles.Theme
+}
+
+// NewUpdateModal creates a new UpdateModal with the given version strings, release
+// body (changelog), release URL, and active session count.
+func NewUpdateModal(current, latest, changelog, htmlURL string, activeSessions int) *UpdateModal {
+	return &UpdateModal{
+		current:        current,
+		latest:         latest,
+		changelog:      changelog,
+		htmlURL:        htmlURL,
+		activeSessions: activeSessions,
+	}
+}
+
+// Init satisfies tea.Model.
+func (m *UpdateModal) Init() tea.Cmd { return nil }
+
+// Title returns the modal title for themed overlay rendering.
+func (m *UpdateModal) Title() string { return "✨  Update Available" }
+
+// Update handles y/n/Esc input and emits UpdateConfirmedMsg or ModalCancelledMsg.
+func (m *UpdateModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch keyMsg.String() {
+	case "y", "Y":
+		return m, func() tea.Msg { return UpdateConfirmedMsg{} }
+	case "n", "N", "esc":
+		return m, func() tea.Msg { return ModalCancelledMsg{} }
+	}
+	return m, nil
+}
+
+// View renders the update notification content.
+func (m *UpdateModal) View() string {
+	var b strings.Builder
+
+	b.WriteString("🚀 A shiny new version of nexus just dropped!\n\n")
+	b.WriteString(fmt.Sprintf("  Running:   %s\n", m.current))
+	b.WriteString(fmt.Sprintf("  Available: %s\n", m.latest))
+
+	if m.changelog != "" {
+		b.WriteString("\n── WHAT'S NEW ──────────────────────────────────────\n")
+		lines := strings.Split(strings.TrimSpace(m.changelog), "\n")
+		truncated := false
+		if len(lines) > changelogMaxLines {
+			lines = lines[:changelogMaxLines]
+			truncated = true
+		}
+		for _, line := range lines {
+			b.WriteString("  ")
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+		if truncated && m.htmlURL != "" {
+			b.WriteString(fmt.Sprintf("  ↓ full changelog at %s\n", m.htmlURL))
+		}
+		b.WriteString("─────────────────────────────────────────────────────\n")
+	}
+
+	if m.activeSessions > 0 {
+		b.WriteString(fmt.Sprintf(
+			"\n⚠  %d active session(s) vibing right now — they'll be fine,\n   but give nexus a restart after the update.\n",
+			m.activeSessions,
+		))
+	}
+
+	b.WriteString("\n  [y] Hell yeah, update!    [n] Nah, I fear change\n")
+	return b.String()
+}
+
+// SetTheme injects the current visual theme for styled rendering.
+func (m *UpdateModal) SetTheme(t styles.Theme) { m.theme = &t }

--- a/internal/tui/modal/update.go
+++ b/internal/tui/modal/update.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/lipgloss"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/m00nk0d3/nexus/internal/tui/styles"
 )
@@ -57,12 +58,26 @@ func (m *UpdateModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *UpdateModal) View() string {
 	var b strings.Builder
 
+	// Accent style for separators and key hints; warning style for active-sessions alert.
+	var accentSt, warnSt lipgloss.Style
+	if m.theme != nil {
+		accentSt = lipgloss.NewStyle().Foreground(lipgloss.Color(m.theme.Accent()))
+		warnSt = lipgloss.NewStyle().Foreground(lipgloss.Color(m.theme.Warning()))
+	}
+
+	styled := func(st lipgloss.Style, s string) string {
+		if m.theme == nil {
+			return s
+		}
+		return st.Render(s)
+	}
+
 	b.WriteString("🚀 A shiny new version of nexus just dropped!\n\n")
 	b.WriteString(fmt.Sprintf("  Running:   %s\n", m.current))
 	b.WriteString(fmt.Sprintf("  Available: %s\n", m.latest))
 
 	if m.changelog != "" {
-		b.WriteString("\n── WHAT'S NEW ──────────────────────────────────────\n")
+		b.WriteString("\n" + styled(accentSt, "── WHAT'S NEW ──────────────────────────────────────") + "\n")
 		lines := strings.Split(strings.TrimSpace(m.changelog), "\n")
 		truncated := false
 		if len(lines) > changelogMaxLines {
@@ -77,17 +92,17 @@ func (m *UpdateModal) View() string {
 		if truncated && m.htmlURL != "" {
 			b.WriteString(fmt.Sprintf("  ↓ full changelog at %s\n", m.htmlURL))
 		}
-		b.WriteString("─────────────────────────────────────────────────────\n")
+		b.WriteString(styled(accentSt, "─────────────────────────────────────────────────────") + "\n")
 	}
 
 	if m.activeSessions > 0 {
 		b.WriteString(fmt.Sprintf(
-			"\n⚠  %d active session(s) vibing right now — they'll be fine,\n   but give nexus a restart after the update.\n",
-			m.activeSessions,
+			"\n%s  %d active session(s) vibing right now — they'll be fine,\n   but give nexus a restart after the update.\n",
+			styled(warnSt, "⚠"), m.activeSessions,
 		))
 	}
 
-	b.WriteString("\n  [y] Hell yeah, update!    [n] Nah, I fear change\n")
+	b.WriteString("\n  " + styled(accentSt, "[y] Hell yeah, update!    [n] Nah, I fear change") + "\n")
 	return b.String()
 }
 

--- a/internal/tui/modal/update_test.go
+++ b/internal/tui/modal/update_test.go
@@ -1,0 +1,98 @@
+package modal
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testChangelog = "## Changes\n- Fixed stuff\n- Added cool things"
+const testHTMLURL = "https://github.com/m00nk0d3/nexus/releases/v1.2.3"
+
+func TestUpdateModal_Title(t *testing.T) {
+	m := NewUpdateModal("v1.0.0", "v1.2.3", "", "", 0)
+	assert.Contains(t, m.Title(), "Update Available")
+}
+
+func TestUpdateModal_View_ContainsBothVersions(t *testing.T) {
+	m := NewUpdateModal("v1.0.0", "v1.2.3", "", "", 0)
+	view := m.View()
+	assert.Contains(t, view, "v1.0.0")
+	assert.Contains(t, view, "v1.2.3")
+}
+
+func TestUpdateModal_View_ShowsChangelog(t *testing.T) {
+	m := NewUpdateModal("v1.0.0", "v1.2.3", testChangelog, testHTMLURL, 0)
+	view := m.View()
+	assert.Contains(t, view, "WHAT'S NEW")
+	assert.Contains(t, view, "Fixed stuff")
+	assert.Contains(t, view, "Added cool things")
+}
+
+func TestUpdateModal_View_TruncatesLongChangelog(t *testing.T) {
+	var lines []string
+	for i := 0; i < 20; i++ {
+		lines = append(lines, "- line")
+	}
+	body := ""
+	for _, l := range lines {
+		body += l + "\n"
+	}
+	m := NewUpdateModal("v1.0.0", "v1.2.3", body, testHTMLURL, 0)
+	view := m.View()
+	assert.Contains(t, view, "↓ full changelog at")
+	assert.Contains(t, view, testHTMLURL)
+}
+
+func TestUpdateModal_View_NoChangelogSection_WhenEmpty(t *testing.T) {
+	m := NewUpdateModal("v1.0.0", "v1.2.3", "", "", 0)
+	view := m.View()
+	assert.NotContains(t, view, "WHAT'S NEW")
+}
+
+func TestUpdateModal_View_ActiveSessionsWarning(t *testing.T) {
+	tests := []struct {
+		name           string
+		activeSessions int
+		wantWarning    bool
+	}{
+		{name: "no sessions", activeSessions: 0, wantWarning: false},
+		{name: "one session", activeSessions: 1, wantWarning: true},
+		{name: "multiple sessions", activeSessions: 3, wantWarning: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewUpdateModal("v1.0.0", "v1.2.3", "", "", tt.activeSessions)
+			view := m.View()
+			if tt.wantWarning {
+				assert.Contains(t, view, "⚠")
+			} else {
+				assert.NotContains(t, view, "⚠")
+			}
+		})
+	}
+}
+
+func TestUpdateModal_Update_YConfirms(t *testing.T) {
+	m := NewUpdateModal("v1.0.0", "v1.2.3", "", "", 0)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	require.NotNil(t, cmd)
+	assert.Equal(t, UpdateConfirmedMsg{}, cmd())
+}
+
+func TestUpdateModal_Update_NCancels(t *testing.T) {
+	m := NewUpdateModal("v1.0.0", "v1.2.3", "", "", 0)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("n")})
+	require.NotNil(t, cmd)
+	assert.Equal(t, ModalCancelledMsg{}, cmd())
+}
+
+func TestUpdateModal_Update_EscCancels(t *testing.T) {
+	m := NewUpdateModal("v1.0.0", "v1.2.3", "", "", 0)
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	require.NotNil(t, cmd)
+	assert.Equal(t, ModalCancelledMsg{}, cmd())
+}

--- a/internal/tui/styles/theme.go
+++ b/internal/tui/styles/theme.go
@@ -238,6 +238,9 @@ func (t Theme) Bg() string { return t.bg }
 // Success returns the theme's success color hex string.
 func (t Theme) Success() string { return t.success }
 
+// Warning returns the theme's warning color hex string.
+func (t Theme) Warning() string { return t.warning }
+
 // MutedBorder returns s with the border foreground dimmed to the muted color.
 // Apply this to unfocused panels to visually de-emphasize them relative to the
 // currently focused panel.

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -94,10 +95,15 @@ func IsNewer(latest, current string) (bool, error) {
 	return false, nil
 }
 
-// parseSemver strips an optional "v" prefix and returns the [major, minor, patch]
+// parseSemver strips an optional "v" prefix and pre-release suffix
+// (e.g. "v1.2.3-rc.1" → "1.2.3") and returns the [major, minor, patch]
 // integer components. Returns an error if the string is not a valid semver.
 func parseSemver(v string) ([3]int, error) {
 	v = strings.TrimPrefix(v, "v")
+	// Drop pre-release / build-metadata suffixes so "v1.2.3-rc.1" parses cleanly.
+	if idx := strings.IndexByte(v, '-'); idx != -1 {
+		v = v[:idx]
+	}
 	parts := strings.SplitN(v, ".", 3)
 	if len(parts) != 3 {
 		return [3]int{}, fmt.Errorf("not semver: %q", v)
@@ -121,20 +127,20 @@ func DownloadURL(tagName string) string {
 		ext = "zip"
 	}
 	filename := fmt.Sprintf("nexus_%s_%s_%s.%s", tagName, runtime.GOOS, runtime.GOARCH, ext)
-	return fmt.Sprintf("https://github.com/m00nk0d3/nexus/releases/download/%s/%s", tagName, filename)
+	return fmt.Sprintf("%s/%s/%s", githubReleaseBase, tagName, filename)
 }
 
 // SelfUpdate downloads the release archive for the current platform, extracts the
-// nexus binary from it, and replaces the running executable. onProgress is called
-// with human-readable status strings. Returns an error if any step fails.
-func SelfUpdate(ctx context.Context, tagName string, onProgress func(string)) error {
+// nexus binary from it, and replaces the running executable. Progress is logged
+// at debug level. Returns an error if any step fails.
+func SelfUpdate(ctx context.Context, tagName string) error {
 	currentExe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("self-update: get executable path: %w", err)
 	}
 
 	url := DownloadURL(tagName)
-	onProgress("Downloading " + url + "...")
+	slog.Debug("self-update", "status", "Downloading "+url+"...")
 
 	archiveFile, err := os.CreateTemp(os.TempDir(), "nexus-update-archive-*")
 	if err != nil {
@@ -149,7 +155,7 @@ func SelfUpdate(ctx context.Context, tagName string, onProgress func(string)) er
 	}
 	archiveFile.Close()
 
-	onProgress("Verifying checksum...")
+	slog.Debug("self-update", "status", "Verifying checksum...")
 
 	archiveFilename := filepath.Base(url)
 	expectedHash, err := fetchChecksum(ctx, tagName, archiveFilename)
@@ -160,7 +166,7 @@ func SelfUpdate(ctx context.Context, tagName string, onProgress func(string)) er
 		return fmt.Errorf("self-update: %w", err)
 	}
 
-	onProgress("Extracting...")
+	slog.Debug("self-update", "status", "Extracting...")
 
 	binaryFile, err := os.CreateTemp(os.TempDir(), "nexus-update-binary-*")
 	if err != nil {
@@ -185,7 +191,7 @@ func SelfUpdate(ctx context.Context, tagName string, onProgress func(string)) er
 		}
 	}
 
-	onProgress("Replacing binary...")
+	slog.Debug("self-update", "status", "Replacing binary...")
 
 	if err := os.Chmod(binaryPath, 0755); err != nil && runtime.GOOS != "windows" {
 		return fmt.Errorf("self-update: chmod: %w", err)
@@ -198,7 +204,7 @@ func SelfUpdate(ctx context.Context, tagName string, onProgress func(string)) er
 		return fmt.Errorf("self-update: replace binary: %w", err)
 	}
 
-	onProgress("Done! Please restart nexus.")
+	slog.Debug("self-update", "status", "Done! Please restart nexus.")
 	return nil
 }
 

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -3,8 +3,11 @@ package updater
 import (
 	"archive/tar"
 	"archive/zip"
+	"bufio"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -18,6 +21,13 @@ import (
 
 // githubAPIBase is the base URL for GitHub API calls. It can be overridden in tests.
 var githubAPIBase = "https://api.github.com"
+
+// githubReleaseBase is the base URL for release asset downloads. It can be overridden in tests.
+var githubReleaseBase = "https://github.com/m00nk0d3/nexus/releases/download"
+
+// maxDownloadBytes caps the size of any single HTTP download (archive or checksums file)
+// to prevent runaway disk writes from unexpectedly large or malformed responses.
+const maxDownloadBytes = 200 * 1024 * 1024 // 200 MB
 
 // ReleaseInfo holds the relevant fields returned by the GitHub releases/latest API.
 type ReleaseInfo struct {
@@ -139,6 +149,17 @@ func SelfUpdate(ctx context.Context, tagName string, onProgress func(string)) er
 	}
 	archiveFile.Close()
 
+	onProgress("Verifying checksum...")
+
+	archiveFilename := filepath.Base(url)
+	expectedHash, err := fetchChecksum(ctx, tagName, archiveFilename)
+	if err != nil {
+		return fmt.Errorf("self-update: %w", err)
+	}
+	if err := verifyChecksum(archivePath, expectedHash); err != nil {
+		return fmt.Errorf("self-update: %w", err)
+	}
+
 	onProgress("Extracting...")
 
 	binaryFile, err := os.CreateTemp(os.TempDir(), "nexus-update-binary-*")
@@ -182,7 +203,8 @@ func SelfUpdate(ctx context.Context, tagName string, onProgress func(string)) er
 }
 
 // downloadToFile performs an HTTP GET with the given context and writes the
-// response body into f. Returns an error on non-200 status or I/O failure.
+// response body into f, capped at maxDownloadBytes. Returns an error on
+// non-200 status or I/O failure.
 func downloadToFile(ctx context.Context, url string, f *os.File) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -196,7 +218,7 @@ func downloadToFile(ctx context.Context, url string, f *os.File) error {
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("unexpected status %d", resp.StatusCode)
 	}
-	_, err = io.Copy(f, resp.Body)
+	_, err = io.Copy(f, io.LimitReader(resp.Body, maxDownloadBytes))
 	return err
 }
 
@@ -231,7 +253,7 @@ func extractFromTarGz(archivePath, binaryName, destPath string) error {
 		if err != nil {
 			return fmt.Errorf("open dest: %w", err)
 		}
-		_, copyErr := io.Copy(out, tr)
+		_, copyErr := io.Copy(out, io.LimitReader(tr, maxDownloadBytes))
 		out.Close()
 		return copyErr
 	}
@@ -260,10 +282,60 @@ func extractFromZip(archivePath, binaryName, destPath string) error {
 			rc.Close()
 			return fmt.Errorf("open dest: %w", err)
 		}
-		_, copyErr := io.Copy(out, rc)
+		_, copyErr := io.Copy(out, io.LimitReader(rc, maxDownloadBytes))
 		out.Close()
 		rc.Close()
 		return copyErr
 	}
 	return fmt.Errorf("binary %q not found in archive", binaryName)
+}
+
+// fetchChecksum downloads the GoReleaser-generated checksums.txt for the given
+// release tag and returns the expected SHA-256 hex digest for archiveFilename.
+func fetchChecksum(ctx context.Context, tagName, archiveFilename string) (string, error) {
+	url := githubReleaseBase + "/" + tagName + "/checksums.txt"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("fetch checksum: build request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch checksum: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch checksum: unexpected status %d", resp.StatusCode)
+	}
+
+	// GoReleaser format: "<sha256hex>  <filename>\n"
+	scanner := bufio.NewScanner(io.LimitReader(resp.Body, 64*1024))
+	for scanner.Scan() {
+		parts := strings.SplitN(scanner.Text(), "  ", 2)
+		if len(parts) == 2 && strings.TrimSpace(parts[1]) == archiveFilename {
+			return strings.TrimSpace(parts[0]), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("fetch checksum: read body: %w", err)
+	}
+	return "", fmt.Errorf("fetch checksum: no entry for %q in checksums.txt", archiveFilename)
+}
+
+// verifyChecksum computes the SHA-256 digest of the file at path and compares
+// it against expectedHex. Returns an error if they do not match.
+func verifyChecksum(path, expectedHex string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hash: %w", err)
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != expectedHex {
+		return fmt.Errorf("checksum mismatch: got %s, want %s", got, expectedHex)
+	}
+	return nil
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,0 +1,269 @@
+package updater
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// githubAPIBase is the base URL for GitHub API calls. It can be overridden in tests.
+var githubAPIBase = "https://api.github.com"
+
+// ReleaseInfo holds the relevant fields returned by the GitHub releases/latest API.
+type ReleaseInfo struct {
+	TagName string `json:"tag_name"`
+	HTMLURL string `json:"html_url"`
+	Body    string `json:"body"` // Release notes / changelog markdown
+}
+
+// CheckLatestRelease queries the GitHub releases API and returns the latest release info.
+// Returns an error if the request fails, times out, or returns a non-200 status.
+func CheckLatestRelease(ctx context.Context) (ReleaseInfo, error) {
+	url := githubAPIBase + "/repos/m00nk0d3/nexus/releases/latest"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return ReleaseInfo{}, fmt.Errorf("update check: build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "nexus-updater")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ReleaseInfo{}, fmt.Errorf("update check: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ReleaseInfo{}, fmt.Errorf("update check: unexpected status %d", resp.StatusCode)
+	}
+
+	var info ReleaseInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		return ReleaseInfo{}, fmt.Errorf("update check: decode response: %w", err)
+	}
+	return info, nil
+}
+
+// IsNewer reports whether latest is a higher semantic version than current.
+// Both versions may optionally start with "v". Returns false (not an error) for
+// "dev" or other non-semver current versions so that dev builds don't pop the modal.
+func IsNewer(latest, current string) (bool, error) {
+	if current == "dev" {
+		return false, nil
+	}
+
+	latestParts, err := parseSemver(latest)
+	if err != nil {
+		return false, fmt.Errorf("IsNewer: parse latest %q: %w", latest, err)
+	}
+
+	currentParts, err := parseSemver(current)
+	if err != nil {
+		// Non-semver current version (e.g. dirty build) — treat as non-fatal.
+		return false, nil
+	}
+
+	for i := range latestParts {
+		if latestParts[i] > currentParts[i] {
+			return true, nil
+		}
+		if latestParts[i] < currentParts[i] {
+			return false, nil
+		}
+	}
+	return false, nil
+}
+
+// parseSemver strips an optional "v" prefix and returns the [major, minor, patch]
+// integer components. Returns an error if the string is not a valid semver.
+func parseSemver(v string) ([3]int, error) {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return [3]int{}, fmt.Errorf("not semver: %q", v)
+	}
+	var nums [3]int
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return [3]int{}, fmt.Errorf("not semver component %q: %w", p, err)
+		}
+		nums[i] = n
+	}
+	return nums, nil
+}
+
+// DownloadURL builds the GitHub release download URL for the running OS/arch.
+// tagName must be the raw tag_name field from the API (e.g. "v1.2.3").
+func DownloadURL(tagName string) string {
+	ext := "tar.gz"
+	if runtime.GOOS == "windows" {
+		ext = "zip"
+	}
+	filename := fmt.Sprintf("nexus_%s_%s_%s.%s", tagName, runtime.GOOS, runtime.GOARCH, ext)
+	return fmt.Sprintf("https://github.com/m00nk0d3/nexus/releases/download/%s/%s", tagName, filename)
+}
+
+// SelfUpdate downloads the release archive for the current platform, extracts the
+// nexus binary from it, and replaces the running executable. onProgress is called
+// with human-readable status strings. Returns an error if any step fails.
+func SelfUpdate(ctx context.Context, tagName string, onProgress func(string)) error {
+	currentExe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("self-update: get executable path: %w", err)
+	}
+
+	url := DownloadURL(tagName)
+	onProgress("Downloading " + url + "...")
+
+	archiveFile, err := os.CreateTemp(os.TempDir(), "nexus-update-archive-*")
+	if err != nil {
+		return fmt.Errorf("self-update: create temp archive: %w", err)
+	}
+	archivePath := archiveFile.Name()
+	defer os.Remove(archivePath)
+
+	if err := downloadToFile(ctx, url, archiveFile); err != nil {
+		archiveFile.Close()
+		return fmt.Errorf("self-update: download: %w", err)
+	}
+	archiveFile.Close()
+
+	onProgress("Extracting...")
+
+	binaryFile, err := os.CreateTemp(os.TempDir(), "nexus-update-binary-*")
+	if err != nil {
+		return fmt.Errorf("self-update: create temp binary: %w", err)
+	}
+	binaryPath := binaryFile.Name()
+	binaryFile.Close()
+	defer os.Remove(binaryPath)
+
+	binaryName := "nexus"
+	if runtime.GOOS == "windows" {
+		binaryName = "nexus.exe"
+	}
+
+	if runtime.GOOS == "windows" {
+		if err := extractFromZip(archivePath, binaryName, binaryPath); err != nil {
+			return fmt.Errorf("self-update: extract: %w", err)
+		}
+	} else {
+		if err := extractFromTarGz(archivePath, binaryName, binaryPath); err != nil {
+			return fmt.Errorf("self-update: extract: %w", err)
+		}
+	}
+
+	onProgress("Replacing binary...")
+
+	if err := os.Chmod(binaryPath, 0755); err != nil && runtime.GOOS != "windows" {
+		return fmt.Errorf("self-update: chmod: %w", err)
+	}
+
+	if err := os.Rename(binaryPath, currentExe); err != nil {
+		if runtime.GOOS == "windows" {
+			return fmt.Errorf("self-update: cannot replace running binary on Windows; please download manually from %s", url)
+		}
+		return fmt.Errorf("self-update: replace binary: %w", err)
+	}
+
+	onProgress("Done! Please restart nexus.")
+	return nil
+}
+
+// downloadToFile performs an HTTP GET with the given context and writes the
+// response body into f. Returns an error on non-200 status or I/O failure.
+func downloadToFile(ctx context.Context, url string, f *os.File) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+// extractFromTarGz opens a .tar.gz archive at archivePath, finds the entry whose
+// base name matches binaryName, and writes it to destPath.
+func extractFromTarGz(archivePath, binaryName, destPath string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gr.Close()
+
+	tr := tar.NewReader(gr)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read tar: %w", err)
+		}
+		if filepath.Base(hdr.Name) != binaryName {
+			continue
+		}
+		out, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+		if err != nil {
+			return fmt.Errorf("open dest: %w", err)
+		}
+		_, copyErr := io.Copy(out, tr)
+		out.Close()
+		return copyErr
+	}
+	return fmt.Errorf("binary %q not found in archive", binaryName)
+}
+
+// extractFromZip opens a .zip archive at archivePath, finds the entry whose
+// base name matches binaryName, and writes it to destPath.
+func extractFromZip(archivePath, binaryName, destPath string) error {
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer zr.Close()
+
+	for _, f := range zr.File {
+		if filepath.Base(f.Name) != binaryName {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("open zip entry: %w", err)
+		}
+		out, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+		if err != nil {
+			rc.Close()
+			return fmt.Errorf("open dest: %w", err)
+		}
+		_, copyErr := io.Copy(out, rc)
+		out.Close()
+		rc.Close()
+		return copyErr
+	}
+	return fmt.Errorf("binary %q not found in archive", binaryName)
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,0 +1,108 @@
+package updater
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNewer(t *testing.T) {
+	tests := []struct {
+		name    string
+		latest  string
+		current string
+		want    bool
+		wantErr bool
+	}{
+		{name: "newer patch", latest: "v1.0.1", current: "v1.0.0", want: true},
+		{name: "newer minor", latest: "v1.1.0", current: "v1.0.5", want: true},
+		{name: "newer major", latest: "v2.0.0", current: "v1.9.9", want: true},
+		{name: "same version", latest: "v1.2.3", current: "v1.2.3", want: false},
+		{name: "older version", latest: "v1.0.0", current: "v1.2.3", want: false},
+		{name: "dev build current", latest: "v1.2.3", current: "dev", want: false},
+		{name: "invalid semver latest", latest: "not-a-version", current: "v1.0.0", wantErr: true},
+		{name: "invalid semver current", latest: "v1.2.3", current: "custom-build", want: false},
+		{name: "no v prefix", latest: "1.2.3", current: "1.0.0", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsNewer(tt.latest, tt.current)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCheckLatestRelease_Success(t *testing.T) {
+	want := ReleaseInfo{TagName: "v1.2.3", HTMLURL: "https://github.com/m00nk0d3/nexus/releases/tag/v1.2.3"}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(want)
+	}))
+	defer ts.Close()
+
+	old := githubAPIBase
+	githubAPIBase = ts.URL
+	defer func() { githubAPIBase = old }()
+
+	got, err := CheckLatestRelease(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, want.TagName, got.TagName)
+	assert.Equal(t, want.HTMLURL, got.HTMLURL)
+}
+
+func TestCheckLatestRelease_NonOK(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	old := githubAPIBase
+	githubAPIBase = ts.URL
+	defer func() { githubAPIBase = old }()
+
+	_, err := CheckLatestRelease(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestCheckLatestRelease_InvalidJSON(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{invalid}`))
+	}))
+	defer ts.Close()
+
+	old := githubAPIBase
+	githubAPIBase = ts.URL
+	defer func() { githubAPIBase = old }()
+
+	_, err := CheckLatestRelease(t.Context())
+	require.Error(t, err)
+}
+
+func TestDownloadURL(t *testing.T) {
+	tag := "v1.2.3"
+	url := DownloadURL(tag)
+
+	assert.Contains(t, url, tag)
+	assert.Contains(t, url, runtime.GOOS)
+	assert.Contains(t, url, runtime.GOARCH)
+
+	if runtime.GOOS == "windows" {
+		assert.True(t, strings.HasSuffix(url, ".zip"), "windows should use .zip: %s", url)
+	} else {
+		assert.True(t, strings.HasSuffix(url, ".tar.gz"), "non-windows should use .tar.gz: %s", url)
+	}
+}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -33,6 +33,8 @@ func TestIsNewer(t *testing.T) {
 		{name: "invalid semver latest", latest: "not-a-version", current: "v1.0.0", wantErr: true},
 		{name: "invalid semver current", latest: "v1.2.3", current: "custom-build", want: false},
 		{name: "no v prefix", latest: "1.2.3", current: "1.0.0", want: true},
+		{name: "pre-release latest", latest: "v1.2.3-rc.1", current: "v1.2.2", want: true},
+		{name: "pre-release current", latest: "v1.2.3", current: "v1.2.3-rc.1", want: false},
 	}
 
 	for _, tt := range tests {
@@ -98,8 +100,14 @@ func TestCheckLatestRelease_InvalidJSON(t *testing.T) {
 
 func TestDownloadURL(t *testing.T) {
 	tag := "v1.2.3"
+
+	old := githubReleaseBase
+	githubReleaseBase = "https://example.com/releases"
+	defer func() { githubReleaseBase = old }()
+
 	url := DownloadURL(tag)
 
+	assert.True(t, strings.HasPrefix(url, "https://example.com/releases"), "should use githubReleaseBase: %s", url)
 	assert.Contains(t, url, tag)
 	assert.Contains(t, url, runtime.GOOS)
 	assert.Contains(t, url, runtime.GOARCH)

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -1,9 +1,13 @@
 package updater
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -105,4 +109,80 @@ func TestDownloadURL(t *testing.T) {
 	} else {
 		assert.True(t, strings.HasSuffix(url, ".tar.gz"), "non-windows should use .tar.gz: %s", url)
 	}
+}
+
+func TestFetchChecksum_Success(t *testing.T) {
+	const filename = "nexus_v1.2.3_linux_amd64.tar.gz"
+	const wantHash = "abc123def456"
+	body := wantHash + "  " + filename + "\ndeadbeef  other_file.tar.gz\n"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "checksums.txt")
+		fmt.Fprint(w, body)
+	}))
+	defer ts.Close()
+
+	old := githubReleaseBase
+	githubReleaseBase = ts.URL
+	defer func() { githubReleaseBase = old }()
+
+	got, err := fetchChecksum(t.Context(), "v1.2.3", filename)
+	require.NoError(t, err)
+	assert.Equal(t, wantHash, got)
+}
+
+func TestFetchChecksum_NotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	old := githubReleaseBase
+	githubReleaseBase = ts.URL
+	defer func() { githubReleaseBase = old }()
+
+	_, err := fetchChecksum(t.Context(), "v1.2.3", "nexus_v1.2.3_linux_amd64.tar.gz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestFetchChecksum_MissingEntry(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "abc123  some_other_file.tar.gz\n")
+	}))
+	defer ts.Close()
+
+	old := githubReleaseBase
+	githubReleaseBase = ts.URL
+	defer func() { githubReleaseBase = old }()
+
+	_, err := fetchChecksum(t.Context(), "v1.2.3", "nexus_v1.2.3_linux_amd64.tar.gz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no entry for")
+}
+
+func TestVerifyChecksum_Valid(t *testing.T) {
+	content := []byte("hello nexus")
+	sum := sha256.Sum256(content)
+	expectedHex := hex.EncodeToString(sum[:])
+
+	f, err := os.CreateTemp(t.TempDir(), "nexus-test-*")
+	require.NoError(t, err)
+	_, err = f.Write(content)
+	require.NoError(t, err)
+	f.Close()
+
+	require.NoError(t, verifyChecksum(f.Name(), expectedHex))
+}
+
+func TestVerifyChecksum_Mismatch(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "nexus-test-*")
+	require.NoError(t, err)
+	_, err = f.Write([]byte("some content"))
+	require.NoError(t, err)
+	f.Close()
+
+	err = verifyChecksum(f.Name(), "0000000000000000000000000000000000000000000000000000000000000000")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "checksum mismatch")
 }


### PR DESCRIPTION
﻿Closes #75

## What Changed

Adds full version awareness to nexus: the header shows the real build version, a non-blocking async update check fires on startup, and users can self-update in-place from a fun interactive modal.

## Why Changed

Issue #75 called for version visibility in the header (per the format established in #61) and an async update notification system consistent with the session polling pattern from #64. The self-update feature removes the friction of manually downloading releases.

## What's in this PR

### Header version (renderer.go)
- Removed the hardcoded appVersion = "1.0" constant
- Header now renders the real version injected via -ldflags at build time (shows "dev" locally, "v1.2.3" in tagged releases)
- GoReleaser already had the ldflags configured — zero CI changes needed

### New internal/updater package (stdlib only, no new deps)
- CheckLatestRelease: async GET to GitHub releases API with 10s timeout
- IsNewer: numeric semver comparison; silent no-op for "dev" builds so the modal never pops locally
- DownloadURL: builds the correct goreleaser archive URL for the running OS/arch
- SelfUpdate: downloads the archive, extracts the binary, atomically replaces the running executable; descriptive error on Windows where the running binary may be locked

### New UpdateModal (internal/tui/modal/update.go)
- Shown at startup when a newer release is available (non-blocking; failure is silently debug-logged)
- Header: "A shiny new version of nexus just dropped!"
- Displays current vs available version
- Renders the GitHub release changelog (body field) with a 15-line cap and a link to the full release when truncated
- Warns the user if active sessions exist before they confirm
- Buttons with personality: [y] Hell yeah, update! / [n] Nah, I fear change

### App wiring (app.go)
- checkForUpdateCmd() added to Init() batch alongside existing startup commands
- selfUpdateCmd() runs the update with a 5-minute timeout
- Progress and completion surfaced via the existing status overlay system

## Testing

- 29 tests pass across all packages (go test ./...), including:
  - 9-case TestIsNewer table covering all semver comparison scenarios
  - httptest-based TestCheckLatestRelease mocking the GitHub API
  - 9 UpdateModal tests: title, versions, changelog rendering, truncation, session warnings, and all key bindings

## Notes

Self-update on Windows: if the running binary is locked, the update returns a descriptive error pointing the user to the release URL rather than silently failing.
