### PR TITLE
feat: create worktree from selected issue

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -25,12 +25,6 @@ import (
 	"github.com/m00nk0d3/nexus/internal/version"
 )
 
-// issuesFetchedMsg carries the result of a background gh issue list call.
-type issuesFetchedMsg struct {
-	issues []domain.Issue // List of fetched issues, or nil on error
-	err    error          // Error during fetch, if any
-}
-
 // worktreeOpDoneMsg carries the result of an add/remove worktree operation.
 type worktreeOpDoneMsg struct {
 	err error // Error during operation, if any
@@ -467,6 +461,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case tea.KeyEnter:
 			switch m.view {
+			case viewIssues:
+				issue, ok := m.selectedIssue()
+				if !ok {
+					return m, nil
+				}
+				m.activeModal = modal.NewCreateModalForIssue(issue, m.RepoPath, computeParentBranches(m.issues, m.Worktrees)...)
+				return m, nil
 			case viewPRs:
 				if len(m.prs) == 0 || m.selectedPRIdx >= len(m.prs) {
 					return m, nil
@@ -510,8 +511,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyF1:
 			m.activeModal = modal.NewHelpModal()
 			return m, nil
-		case tea.KeyCtrlN:
-			return m, m.fetchIssuesCmd()
 		case tea.KeyCtrlD:
 			if selected, ok := m.selectedWorktree(); ok {
 				m.activeModal = modal.NewDeleteModal(selected)
@@ -673,11 +672,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.statusErr = "No active session for this worktree"
 				return m, clearErrorCmd()
 			}
-		}
-
-	case issuesFetchedMsg:
-		if msg.err == nil {
-			m.activeModal = modal.NewCreateModal(msg.issues, m.RepoPath, computeParentBranches(m.issues, m.Worktrees)...)
 		}
 
 	case aiderFilesFetchedMsg:
@@ -998,17 +992,6 @@ func (m *Model) openInBrowserCmd() tea.Cmd {
 		return tea.ExecProcess(cmd, func(err error) tea.Msg { return browserOpenErrMsg{err: err} })
 	default:
 		return nil
-	}
-}
-
-// fetchIssuesCmd returns a Cmd that fetches open GitHub issues in the background,
-// allowing the user to create worktrees from issues.
-func (m *Model) fetchIssuesCmd() tea.Cmd {
-	repoPath := m.RepoPath
-	return func() tea.Msg {
-		cmd := internalexec.NewIssueCommand(repoPath)
-		issues, err := cmd.ListOpenIssues()
-		return issuesFetchedMsg{issues: issues, err: err}
 	}
 }
 
@@ -1830,6 +1813,14 @@ func (m *Model) selectedWorktree() (domain.Worktree, bool) {
 	}
 
 	return m.Worktrees[m.selectedIdx], true
+}
+
+func (m *Model) selectedIssue() (domain.Issue, bool) {
+	if len(m.issues) == 0 || m.selectedIssueIdx < 0 || m.selectedIssueIdx >= len(m.issues) {
+		return domain.Issue{}, false
+	}
+
+	return m.issues[m.selectedIssueIdx], true
 }
 
 func (m *Model) clampSelectedIdx() {

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -1856,6 +1856,40 @@ func TestModel_Enter_InViewPRs_EmptyList_NoOp(t *testing.T) {
 	assert.Nil(t, updatedModel.activeModal)
 }
 
+func TestModel_Enter_InViewIssues_OpensCreateModalForSelectedIssue(t *testing.T) {
+	m := NewModel()
+	m.view = viewIssues
+	m.RepoPath = "/repos/nexus"
+	m.issues = []domain.Issue{
+		{Number: 1, Title: "First issue"},
+		{Number: 2, Title: "Second issue"},
+	}
+	m.selectedIssueIdx = 1
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Nil(t, cmd, "no cmd until the create modal is confirmed")
+	createModal, ok := updatedModel.activeModal.(*modal.CreateModal)
+	require.True(t, ok, "create modal should be open")
+	assert.Equal(t, 2, createModal.SelectedIssue().Number)
+	assert.Contains(t, createModal.View(), "Select branch type")
+	assert.NotContains(t, createModal.View(), "Select issue")
+}
+
+func TestModel_Enter_InViewIssues_EmptyList_NoOp(t *testing.T) {
+	m := NewModel()
+	m.view = viewIssues
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updatedModel, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Nil(t, cmd)
+	assert.Nil(t, updatedModel.activeModal)
+}
+
 // TestModel_Enter_InViewWorktrees_SpawnsSession verifies that Enter spawns a
 // session (same as the s key) when a worktree is selected.
 func TestModel_Enter_InViewWorktrees_SpawnsSession(t *testing.T) {

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -18,10 +18,11 @@ import (
 )
 
 const (
-	footerHintsWorktrees= "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [q/esc] Quit"
+	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [q/esc] Quit"
+	footerHintsIssues    = "[Tab] Panel | [j/k] Navigate | [Enter] New WT | [t] Settings | [g] GH | [q/esc] Quit"
 	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [t] Settings | [g] GH | [q/esc] Quit"
 	footerHintsDefault   = footerHintsWorktrees
-	actionBarHints       = "[c-n] New  [c-d] Delete  [c-l] Lock | [f1] Help"
+	actionBarHints       = "[enter] Open  [c-d] Delete  [c-l] Lock | [f1] Help"
 	defaultTermWidth     = 120
 	navPanelInner        = 18
 	// ctxPanelInner is no longer a constant — use computeCtxInner(termWidth) instead.
@@ -778,7 +779,10 @@ func clipContent(content string, offset, maxLines int) string {
 
 func renderFooterBar(theme styles.Theme, date string, termWidth int, syncing bool, lastSynced time.Time, syncErr error, view activeView, issues []domain.Issue, prs []domain.PullRequest, currentPage int) string {
 	hints := footerHintsDefault
-	if view == viewPRs {
+	switch view {
+	case viewIssues:
+		hints = footerHintsIssues
+	case viewPRs:
 		hints = footerHintsPRs
 	}
 

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -146,7 +146,7 @@ func TestRenderFull_ContainsFooterKeyHints(t *testing.T) {
 		},
 		{
 			name:   "action bar contains worktree commands",
-			wantIn: []string{"[c-n] New", "[c-d] Delete", "[f1] Help"},
+			wantIn: []string{"[enter] Open", "[c-d] Delete", "[f1] Help"},
 		},
 	}
 

--- a/internal/tui/modal/create.go
+++ b/internal/tui/modal/create.go
@@ -62,6 +62,14 @@ func NewCreateModal(issues []domain.Issue, repoPath string, parentBranches ...st
 	}
 }
 
+// NewCreateModalForIssue creates a new CreateModal for an already-selected issue.
+// It skips the issue picker and starts directly at the branch type step.
+func NewCreateModalForIssue(issue domain.Issue, repoPath string, parentBranches ...string) *CreateModal {
+	m := NewCreateModal([]domain.Issue{issue}, repoPath, parentBranches...)
+	m.step = stepType
+	return m
+}
+
 // Init satisfies tea.Model.
 func (m *CreateModal) Init() tea.Cmd { return nil }
 

--- a/internal/tui/modal/create_test.go
+++ b/internal/tui/modal/create_test.go
@@ -24,6 +24,15 @@ func TestNewCreateModal_StartsAtIssueListStep(t *testing.T) {
 	assert.Equal(t, 0, m.typeIdx)
 }
 
+func TestNewCreateModalForIssue_StartsAtTypeStep(t *testing.T) {
+	m := NewCreateModalForIssue(testIssues[1], "/home/user/repo")
+
+	require.NotNil(t, m)
+	assert.Equal(t, stepType, m.step)
+	assert.Equal(t, 0, m.issueIdx)
+	assert.Equal(t, testIssues[1].Number, m.SelectedIssue().Number)
+}
+
 func TestCreateModal_View_IssueStep_ShowsIssues(t *testing.T) {
 	m := NewCreateModal(testIssues, "/home/user/repo")
 	view := m.View()

--- a/internal/tui/modal/help.go
+++ b/internal/tui/modal/help.go
@@ -40,13 +40,13 @@ var keybindingGroups = []bindingGroup{
 			{"↑/↓  j/k", "Navigate within panel"},
 			{"←/→  h/l", "Switch between panels / tabs"},
 			{"Tab", "Cycle panel focus / tab"},
-			{"Enter", "Open shell in worktree / Select"},
+			{"Enter", "Open selected item"},
 		},
 	},
 	{
 		title: "WORKTREE OPERATIONS",
 		bindings: [][2]string{
-			{"Ctrl+N", "Create new worktree"},
+			{"Enter (Issues view)", "Create worktree from selected issue"},
 			{"Ctrl+D", "Delete selected worktree"},
 			{"s", "Open shell in worktree"},
 			{"x", "Close session and terminal tab"},
@@ -336,7 +336,8 @@ func isAllCaps(s string) bool {
 const tipsContent = `COMMON WORKFLOWS
 
 1. Create a worktree from a GitHub issue
-   Press Ctrl+N → pick issue → choose branch type → confirm.
+   Open the Issues view, select an issue, then press Enter.
+   Choose the branch type and confirm.
    Nexus creates the branch and worktree automatically.
 
 2. Switch to a worktree and start coding
@@ -350,7 +351,7 @@ const tipsContent = `COMMON WORKFLOWS
 
 4. Keep GitHub data fresh
    Nexus auto-syncs on startup and at the configured interval
-   (~5 min default). Use Ctrl+N to fetch fresh issue data.
+   (~5 min default).
 
 5. Open an issue or PR in the browser
    While in the Issues or PRs view, press g to open the
@@ -404,4 +405,3 @@ Nexus helps you manage multiple git worktrees and
 launch AI coding agents with the correct filesystem
 context — all from a single terminal interface.`, version.Version)
 }
-


### PR DESCRIPTION
- open the new worktree modal directly from the selected issue in the Issues view
- remove the old Ctrl+N issue picker flow
- update help, footer hints, and tests for the new interaction