### PR TITLE
feat(tui): AI-assisted PR review via auto-provisioned worktree

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -89,6 +89,13 @@ type aiderFilesFetchedMsg struct {
 // clearErrorMsg is dispatched after the 5-second auto-dismiss timer fires.
 type clearErrorMsg struct{}
 
+// prReviewWorktreeDoneMsg is dispatched after the PR review worktree is provisioned.
+type prReviewWorktreeDoneMsg struct {
+	pr           domain.PullRequest
+	worktreePath string
+	err          error
+}
+
 // updateCheckedMsg carries the result of the startup version check.
 type updateCheckedMsg struct {
 	info updater.ReleaseInfo
@@ -177,6 +184,19 @@ type sessionFocusedMsg struct {
 // msgAutoDismissDuration is how long the success/info toast stays visible before
 // being cleared by clearMsgCmd.
 const msgAutoDismissDuration = 3 * time.Second
+
+// prReviewAgentPrompt is the pre-seeded prompt for the AI-assisted PR review flow.
+// It instructs the agent on what to review and how to report findings.
+const prReviewAgentPrompt = `You are performing a pull request code review. If you have a skill specifically for reviewing pull requests, using it is MANDATORY — invoke it before doing anything else.
+
+Your review must cover:
+- Correctness: logic errors, off-by-ones, unhandled edge cases
+- Security: injection, auth issues, exposed secrets, unsafe operations
+- Performance: unnecessary allocations, N+1 queries, blocking calls
+- Maintainability: unclear naming, missing/wrong tests, dead code
+- Breaking changes: API contracts, backward compatibility
+
+Be direct and actionable. Skip formatting/style nitpicks unless they materially harm readability. For each finding, state the file + line, the problem, and a concrete suggestion to fix it.`
 
 // clearMsgMsg is dispatched after the success-notification timer fires.
 type clearMsgMsg struct{}
@@ -521,6 +541,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if selected, ok := m.selectedWorktree(); ok {
 				m.activeModal = modal.NewDeleteModal(selected)
 			}
+		case tea.KeyCtrlR:
+			if m.view != viewPRs {
+				m.statusErr = "PR Review (Ctrl+R) is only available in the PRs view — press P to switch"
+				return m, clearErrorCmd()
+			}
+			if len(m.prs) == 0 || m.selectedPRIdx >= len(m.prs) {
+				m.statusErr = "No PR selected — select one first"
+				return m, clearErrorCmd()
+			}
+			return m, m.provisionPRReviewWorktreeCmd(m.prs[m.selectedPRIdx])
 		case tea.KeyUp:
 			m.moveUp()
 			return m, m.maybeLazyLoadCmd()
@@ -695,6 +725,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.statusErr = fmt.Sprintf("Git operation failed: %v", msg.err)
 			return m, tea.Batch(m.refreshWorktreesCmd(), clearErrorCmd())
 		}
+		return m, m.refreshWorktreesCmd()
+
+	case prReviewWorktreeDoneMsg:
+		if msg.err != nil {
+			m.statusErr = fmt.Sprintf("PR review setup failed: %v", msg.err)
+			return m, tea.Batch(clearErrorCmd(), m.refreshWorktreesCmd())
+		}
+		m.activeModal = modal.NewAgentLauncherModalWithPrompt(m.Config, msg.worktreePath, prReviewAgentPrompt)
 		return m, m.refreshWorktreesCmd()
 
 	case worktreeSwitchedMsg:
@@ -1114,6 +1152,36 @@ func (m *Model) checkoutPRWorktreeCmd(branch, path string) tea.Cmd {
 func prWorktreePath(repoPath, branch string) string {
 	slug := strings.ReplaceAll(branch, "/", "-")
 	return filepath.Join(filepath.Dir(repoPath), "worktrees", slug)
+}
+
+// prReviewWorktreePath derives the filesystem path for a PR review worktree.
+// Uses naming convention pr-<number>-<branch-slug> as specified in issue #78.
+func prReviewWorktreePath(repoPath string, prNumber int, branch string) string {
+	slug := strings.ReplaceAll(branch, "/", "-")
+	name := fmt.Sprintf("pr-%d-%s", prNumber, slug)
+	return filepath.Join(filepath.Dir(repoPath), "worktrees", name)
+}
+
+// provisionPRReviewWorktreeCmd returns a Cmd that provisions a worktree for the given PR.
+// It fetches the remote branch and creates a worktree at the pr-<number>-<branch-slug> path.
+// If a worktree for the branch already exists locally, it reuses that path instead.
+func (m *Model) provisionPRReviewWorktreeCmd(pr domain.PullRequest) tea.Cmd {
+	repoPath := m.RepoPath
+	worktreePath := prReviewWorktreePath(repoPath, pr.Number, pr.Branch)
+	// Check if a worktree for this branch already exists — reuse it if so.
+	for _, wt := range m.Worktrees {
+		if wt.Branch == pr.Branch {
+			worktreePath = wt.Path
+			return func() tea.Msg {
+				return prReviewWorktreeDoneMsg{pr: pr, worktreePath: worktreePath}
+			}
+		}
+	}
+	return func() tea.Msg {
+		cmd := internalexec.NewGitCommand(repoPath)
+		err := cmd.CheckoutPRWorktree(worktreePath, pr.Branch)
+		return prReviewWorktreeDoneMsg{pr: pr, worktreePath: worktreePath, err: err}
+	}
 }
 
 // computeParentBranches returns the branches of any worktrees associated with

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -91,7 +91,6 @@ type clearErrorMsg struct{}
 
 // prReviewWorktreeDoneMsg is dispatched after the PR review worktree is provisioned.
 type prReviewWorktreeDoneMsg struct {
-	pr           domain.PullRequest
 	worktreePath string
 	err          error
 }
@@ -550,6 +549,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.statusErr = "No PR selected — select one first"
 				return m, clearErrorCmd()
 			}
+			m.statusMsg = "Provisioning review worktree…"
 			return m, m.provisionPRReviewWorktreeCmd(m.prs[m.selectedPRIdx])
 		case tea.KeyUp:
 			m.moveUp()
@@ -728,6 +728,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.refreshWorktreesCmd()
 
 	case prReviewWorktreeDoneMsg:
+		m.statusMsg = ""
 		if msg.err != nil {
 			m.statusErr = fmt.Sprintf("PR review setup failed: %v", msg.err)
 			return m, tea.Batch(clearErrorCmd(), m.refreshWorktreesCmd())
@@ -1147,18 +1148,22 @@ func (m *Model) checkoutPRWorktreeCmd(branch, path string) tea.Cmd {
 	}
 }
 
+// branchSlug converts a branch name to a filesystem-safe slug by replacing
+// forward slashes with dashes.
+func branchSlug(branch string) string {
+	return strings.ReplaceAll(branch, "/", "-")
+}
+
 // prWorktreePath derives the filesystem path for a PR worktree using the same
 // convention as issue worktrees: ../worktrees/<branch-with-slashes-as-dashes>.
 func prWorktreePath(repoPath, branch string) string {
-	slug := strings.ReplaceAll(branch, "/", "-")
-	return filepath.Join(filepath.Dir(repoPath), "worktrees", slug)
+	return filepath.Join(filepath.Dir(repoPath), "worktrees", branchSlug(branch))
 }
 
 // prReviewWorktreePath derives the filesystem path for a PR review worktree.
 // Uses naming convention pr-<number>-<branch-slug> as specified in issue #78.
 func prReviewWorktreePath(repoPath string, prNumber int, branch string) string {
-	slug := strings.ReplaceAll(branch, "/", "-")
-	name := fmt.Sprintf("pr-%d-%s", prNumber, slug)
+	name := fmt.Sprintf("pr-%d-%s", prNumber, branchSlug(branch))
 	return filepath.Join(filepath.Dir(repoPath), "worktrees", name)
 }
 
@@ -1173,14 +1178,14 @@ func (m *Model) provisionPRReviewWorktreeCmd(pr domain.PullRequest) tea.Cmd {
 		if wt.Branch == pr.Branch {
 			worktreePath = wt.Path
 			return func() tea.Msg {
-				return prReviewWorktreeDoneMsg{pr: pr, worktreePath: worktreePath}
+				return prReviewWorktreeDoneMsg{worktreePath: worktreePath}
 			}
 		}
 	}
 	return func() tea.Msg {
 		cmd := internalexec.NewGitCommand(repoPath)
 		err := cmd.CheckoutPRWorktree(worktreePath, pr.Branch)
-		return prReviewWorktreeDoneMsg{pr: pr, worktreePath: worktreePath, err: err}
+		return prReviewWorktreeDoneMsg{worktreePath: worktreePath, err: err}
 	}
 }
 

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3465,3 +3465,124 @@ func TestUpdateModal_DoesNotSwallowGithubSyncedMsg(t *testing.T) {
 	require.Len(t, m3.prs, 1, "prs must be populated even when modal is open")
 	assert.Equal(t, 42, m3.prs[0].Number)
 }
+
+// TestPRReviewWorktreePath verifies the pr-<number>-<branch-slug> naming convention.
+func TestPRReviewWorktreePath(t *testing.T) {
+tests := []struct {
+name       string
+repoPath   string
+prNumber   int
+branch     string
+wantSuffix string
+}{
+{
+name:       "simple branch name",
+repoPath:   "/home/user/nexus",
+prNumber:   42,
+branch:     "feat-my-feature",
+wantSuffix: "pr-42-feat-my-feature",
+},
+{
+name:       "branch with slashes",
+repoPath:   "/home/user/nexus",
+prNumber:   7,
+branch:     "feat/issue-7-login",
+wantSuffix: "pr-7-feat-issue-7-login",
+},
+{
+name:       "main branch",
+repoPath:   "/home/user/nexus",
+prNumber:   1,
+branch:     "main",
+wantSuffix: "pr-1-main",
+},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+got := prReviewWorktreePath(tt.repoPath, tt.prNumber, tt.branch)
+assert.True(t, strings.HasSuffix(got, tt.wantSuffix),
+"expected path to end with %q, got %q", tt.wantSuffix, got)
+})
+}
+}
+
+// TestModel_CtrlR_InPRView_WithNoSelectedPR_ShowsError verifies that Ctrl+R with
+// no PRs available surfaces a friendly error rather than panicking.
+func TestModel_CtrlR_InPRView_WithNoSelectedPR_ShowsError(t *testing.T) {
+m := NewModel()
+m.view = viewPRs
+m.prs = []domain.PullRequest{} // empty PR list
+
+updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+result := updated.(*Model)
+
+assert.NotEmpty(t, result.statusErr, "should show an error when no PR is selected")
+assert.NotNil(t, cmd, "should return clearErrorCmd")
+}
+
+// TestModel_CtrlR_InWorktreesView_ShowsError verifies that Ctrl+R outside the PR view
+// shows a helpful error message directing the user to switch views.
+func TestModel_CtrlR_InWorktreesView_ShowsError(t *testing.T) {
+m := NewModel()
+m.view = viewWorktrees
+
+updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+result := updated.(*Model)
+
+assert.NotEmpty(t, result.statusErr, "should show an error when not in PR view")
+assert.NotNil(t, cmd)
+}
+
+// TestModel_PRReviewWorktreeDoneMsg_OpensAgentModal verifies that a successful
+// prReviewWorktreeDoneMsg opens the AgentLauncherModal with the review prompt.
+func TestModel_PRReviewWorktreeDoneMsg_OpensAgentModal(t *testing.T) {
+m := NewModel()
+pr := domain.PullRequest{Number: 42, Title: "Test PR", Branch: "feat-test"}
+
+updated, _ := m.Update(prReviewWorktreeDoneMsg{
+pr:           pr,
+worktreePath: "/home/user/worktrees/pr-42-feat-test",
+})
+result := updated.(*Model)
+
+require.NotNil(t, result.activeModal, "AgentLauncherModal should be open")
+assert.Equal(t, "SPAWN AGENT", result.activeModal.Title())
+}
+
+// TestModel_PRReviewWorktreeDoneMsg_WithError_ShowsStatusError verifies that a failed
+// prReviewWorktreeDoneMsg shows an error and does not open the agent modal.
+func TestModel_PRReviewWorktreeDoneMsg_WithError_ShowsStatusError(t *testing.T) {
+m := NewModel()
+pr := domain.PullRequest{Number: 5, Title: "Bad PR", Branch: "bad-branch"}
+
+updated, cmd := m.Update(prReviewWorktreeDoneMsg{
+pr:  pr,
+err: errors.New("git: branch not found"),
+})
+result := updated.(*Model)
+
+assert.Nil(t, result.activeModal, "modal should not open on error")
+assert.Contains(t, result.statusErr, "PR review setup failed")
+assert.NotNil(t, cmd)
+}
+
+// TestModel_ProvisionPRReviewWorktreeCmd_ReusesExistingWorktree verifies that when
+// a worktree for the PR branch already exists, the provisioning command reuses that
+// path without attempting a new git checkout.
+func TestModel_ProvisionPRReviewWorktreeCmd_ReusesExistingWorktree(t *testing.T) {
+m := NewModel()
+m.RepoPath = "/home/user/nexus"
+m.Worktrees = []domain.Worktree{
+{Path: "/home/user/worktrees/feat-existing", Branch: "feat/existing"},
+}
+pr := domain.PullRequest{Number: 99, Branch: "feat/existing"}
+
+cmd := m.provisionPRReviewWorktreeCmd(pr)
+require.NotNil(t, cmd)
+
+msg := cmd()
+doneMsg, ok := msg.(prReviewWorktreeDoneMsg)
+require.True(t, ok)
+assert.Nil(t, doneMsg.err, "should not error when reusing existing worktree")
+assert.Equal(t, "/home/user/worktrees/feat-existing", doneMsg.worktreePath)
+}

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3468,121 +3468,148 @@ func TestUpdateModal_DoesNotSwallowGithubSyncedMsg(t *testing.T) {
 
 // TestPRReviewWorktreePath verifies the pr-<number>-<branch-slug> naming convention.
 func TestPRReviewWorktreePath(t *testing.T) {
-tests := []struct {
-name       string
-repoPath   string
-prNumber   int
-branch     string
-wantSuffix string
-}{
-{
-name:       "simple branch name",
-repoPath:   "/home/user/nexus",
-prNumber:   42,
-branch:     "feat-my-feature",
-wantSuffix: "pr-42-feat-my-feature",
-},
-{
-name:       "branch with slashes",
-repoPath:   "/home/user/nexus",
-prNumber:   7,
-branch:     "feat/issue-7-login",
-wantSuffix: "pr-7-feat-issue-7-login",
-},
-{
-name:       "main branch",
-repoPath:   "/home/user/nexus",
-prNumber:   1,
-branch:     "main",
-wantSuffix: "pr-1-main",
-},
-}
-for _, tt := range tests {
-t.Run(tt.name, func(t *testing.T) {
-got := prReviewWorktreePath(tt.repoPath, tt.prNumber, tt.branch)
-assert.True(t, strings.HasSuffix(got, tt.wantSuffix),
-"expected path to end with %q, got %q", tt.wantSuffix, got)
-})
-}
+	tests := []struct {
+		name       string
+		repoPath   string
+		prNumber   int
+		branch     string
+		wantSuffix string
+	}{
+		{
+			name:       "simple branch name",
+			repoPath:   "/home/user/nexus",
+			prNumber:   42,
+			branch:     "feat-my-feature",
+			wantSuffix: "pr-42-feat-my-feature",
+		},
+		{
+			name:       "branch with slashes",
+			repoPath:   "/home/user/nexus",
+			prNumber:   7,
+			branch:     "feat/issue-7-login",
+			wantSuffix: "pr-7-feat-issue-7-login",
+		},
+		{
+			name:       "main branch",
+			repoPath:   "/home/user/nexus",
+			prNumber:   1,
+			branch:     "main",
+			wantSuffix: "pr-1-main",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prReviewWorktreePath(tt.repoPath, tt.prNumber, tt.branch)
+			assert.True(t, strings.HasSuffix(got, tt.wantSuffix),
+				"expected path to end with %q, got %q", tt.wantSuffix, got)
+		})
+	}
 }
 
 // TestModel_CtrlR_InPRView_WithNoSelectedPR_ShowsError verifies that Ctrl+R with
 // no PRs available surfaces a friendly error rather than panicking.
 func TestModel_CtrlR_InPRView_WithNoSelectedPR_ShowsError(t *testing.T) {
-m := NewModel()
-m.view = viewPRs
-m.prs = []domain.PullRequest{} // empty PR list
+	m := NewModel()
+	m.view = viewPRs
+	m.prs = []domain.PullRequest{} // empty PR list
 
-updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
-result := updated.(*Model)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	result := updated.(*Model)
 
-assert.NotEmpty(t, result.statusErr, "should show an error when no PR is selected")
-assert.NotNil(t, cmd, "should return clearErrorCmd")
+	assert.NotEmpty(t, result.statusErr, "should show an error when no PR is selected")
+	assert.NotNil(t, cmd, "should return clearErrorCmd")
 }
 
 // TestModel_CtrlR_InWorktreesView_ShowsError verifies that Ctrl+R outside the PR view
 // shows a helpful error message directing the user to switch views.
 func TestModel_CtrlR_InWorktreesView_ShowsError(t *testing.T) {
-m := NewModel()
-m.view = viewWorktrees
+	m := NewModel()
+	m.view = viewWorktrees
 
-updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
-result := updated.(*Model)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	result := updated.(*Model)
 
-assert.NotEmpty(t, result.statusErr, "should show an error when not in PR view")
-assert.NotNil(t, cmd)
+	assert.NotEmpty(t, result.statusErr, "should show an error when not in PR view")
+	assert.NotNil(t, cmd)
+}
+
+// TestModel_CtrlR_InPRView_WithValidPR_DispatchesProvisionCmd verifies that Ctrl+R
+// with a selected PR dispatches the provisioning command and sets a loading status.
+func TestModel_CtrlR_InPRView_WithValidPR_DispatchesProvisionCmd(t *testing.T) {
+	m := NewModel()
+	m.view = viewPRs
+	m.prs = []domain.PullRequest{{Number: 42, Branch: "feat/my-feature", Title: "My Feature"}}
+	m.selectedPRIdx = 0
+	// Pre-populate Worktrees so the reuse path fires synchronously (no git I/O).
+	m.Worktrees = []domain.Worktree{
+		{Path: "/home/user/worktrees/feat-my-feature", Branch: "feat/my-feature"},
+	}
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlR})
+	result := updated.(*Model)
+
+	require.NotNil(t, cmd, "should return provisionPRReviewWorktreeCmd")
+	assert.Empty(t, result.statusErr, "should not set an error on valid dispatch")
+	assert.NotEmpty(t, result.statusMsg, "should set a loading status message")
+
+	// Verify the cmd resolves to a prReviewWorktreeDoneMsg for the correct worktree.
+	msg := cmd()
+	doneMsg, ok := msg.(prReviewWorktreeDoneMsg)
+	require.True(t, ok, "cmd should resolve to prReviewWorktreeDoneMsg")
+	assert.Nil(t, doneMsg.err)
+	assert.Equal(t, "/home/user/worktrees/feat-my-feature", doneMsg.worktreePath)
 }
 
 // TestModel_PRReviewWorktreeDoneMsg_OpensAgentModal verifies that a successful
 // prReviewWorktreeDoneMsg opens the AgentLauncherModal with the review prompt.
 func TestModel_PRReviewWorktreeDoneMsg_OpensAgentModal(t *testing.T) {
-m := NewModel()
-pr := domain.PullRequest{Number: 42, Title: "Test PR", Branch: "feat-test"}
+	m := NewModel()
+	m.statusMsg = "Provisioning review worktree…"
 
-updated, _ := m.Update(prReviewWorktreeDoneMsg{
-pr:           pr,
-worktreePath: "/home/user/worktrees/pr-42-feat-test",
-})
-result := updated.(*Model)
+	updated, _ := m.Update(prReviewWorktreeDoneMsg{
+		worktreePath: "/home/user/worktrees/pr-42-feat-test",
+	})
+	result := updated.(*Model)
 
-require.NotNil(t, result.activeModal, "AgentLauncherModal should be open")
-assert.Equal(t, "SPAWN AGENT", result.activeModal.Title())
+	require.NotNil(t, result.activeModal, "AgentLauncherModal should be open")
+	assert.Equal(t, "SPAWN AGENT", result.activeModal.Title())
+	assert.Empty(t, result.statusMsg, "loading status should be cleared on success")
 }
 
 // TestModel_PRReviewWorktreeDoneMsg_WithError_ShowsStatusError verifies that a failed
 // prReviewWorktreeDoneMsg shows an error and does not open the agent modal.
 func TestModel_PRReviewWorktreeDoneMsg_WithError_ShowsStatusError(t *testing.T) {
-m := NewModel()
-pr := domain.PullRequest{Number: 5, Title: "Bad PR", Branch: "bad-branch"}
+	m := NewModel()
+	m.statusMsg = "Provisioning review worktree…"
 
-updated, cmd := m.Update(prReviewWorktreeDoneMsg{
-pr:  pr,
-err: errors.New("git: branch not found"),
-})
-result := updated.(*Model)
+	updated, cmd := m.Update(prReviewWorktreeDoneMsg{
+		err: errors.New("git: branch not found"),
+	})
+	result := updated.(*Model)
 
-assert.Nil(t, result.activeModal, "modal should not open on error")
-assert.Contains(t, result.statusErr, "PR review setup failed")
-assert.NotNil(t, cmd)
+	assert.Nil(t, result.activeModal, "modal should not open on error")
+	assert.Contains(t, result.statusErr, "PR review setup failed")
+	assert.Empty(t, result.statusMsg, "loading status should be cleared on error")
+	assert.NotNil(t, cmd)
 }
 
 // TestModel_ProvisionPRReviewWorktreeCmd_ReusesExistingWorktree verifies that when
 // a worktree for the PR branch already exists, the provisioning command reuses that
 // path without attempting a new git checkout.
 func TestModel_ProvisionPRReviewWorktreeCmd_ReusesExistingWorktree(t *testing.T) {
-m := NewModel()
-m.RepoPath = "/home/user/nexus"
-m.Worktrees = []domain.Worktree{
-{Path: "/home/user/worktrees/feat-existing", Branch: "feat/existing"},
-}
-pr := domain.PullRequest{Number: 99, Branch: "feat/existing"}
+	m := NewModel()
+	m.RepoPath = "/home/user/nexus"
+	m.Worktrees = []domain.Worktree{
+		{Path: "/home/user/worktrees/feat-existing", Branch: "feat/existing"},
+	}
+	pr := domain.PullRequest{Number: 99, Branch: "feat/existing"}
 
-cmd := m.provisionPRReviewWorktreeCmd(pr)
-require.NotNil(t, cmd)
+	cmd := m.provisionPRReviewWorktreeCmd(pr)
+	require.NotNil(t, cmd)
 
-msg := cmd()
-doneMsg, ok := msg.(prReviewWorktreeDoneMsg)
-require.True(t, ok)
-assert.Nil(t, doneMsg.err, "should not error when reusing existing worktree")
-assert.Equal(t, "/home/user/worktrees/feat-existing", doneMsg.worktreePath)
+	msg := cmd()
+	doneMsg, ok := msg.(prReviewWorktreeDoneMsg)
+	require.True(t, ok)
+	assert.Nil(t, doneMsg.err, "should not error when reusing existing worktree")
+	assert.Equal(t, "/home/user/worktrees/feat-existing", doneMsg.worktreePath)
 }

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -20,7 +20,7 @@ import (
 const (
 	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [q/esc] Quit"
 	footerHintsIssues    = "[Tab] Panel | [j/k] Navigate | [Enter] New WT | [t] Settings | [g] GH | [q/esc] Quit"
-	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [t] Settings | [g] GH | [q/esc] Quit"
+	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [Ctrl+R] Review | [t] Settings | [g] GH | [q/esc] Quit"
 	footerHintsDefault   = footerHintsWorktrees
 	actionBarHints       = "[enter] Open  [c-d] Delete  [c-l] Lock | [f1] Help"
 	defaultTermWidth     = 120

--- a/internal/tui/modal/agent_launcher.go
+++ b/internal/tui/modal/agent_launcher.go
@@ -35,7 +35,8 @@ type AgentLauncherModal struct {
 	worktreePath  string
 	promptInput   textinput.Model
 	selectedAgent agentOption
-	width         int // terminal width, set by the parent view
+	initialPrompt string // pre-seeded prompt text; pre-fills input when advancing to prompt step
+	width         int    // terminal width, set by the parent view
 }
 
 // newAgentLauncherModal is the internal constructor used in production and in tests.
@@ -96,6 +97,15 @@ func buildAgentOptions(cfg *domain.Config) []agentOption {
 // NewAgentLauncherModal creates an AgentLauncherModal with availability computed from config.
 func NewAgentLauncherModal(cfg *domain.Config, worktreePath string) *AgentLauncherModal {
 	return newAgentLauncherModal(buildAgentOptions(cfg), worktreePath)
+}
+
+// NewAgentLauncherModalWithPrompt creates an AgentLauncherModal with a pre-seeded prompt.
+// When the user selects an agent that uses the prompt step (Claude or Copilot),
+// the prompt input will be pre-filled with initialPrompt so the user can review/edit before confirming.
+func NewAgentLauncherModalWithPrompt(cfg *domain.Config, worktreePath, initialPrompt string) *AgentLauncherModal {
+	m := newAgentLauncherModal(buildAgentOptions(cfg), worktreePath)
+	m.initialPrompt = initialPrompt
+	return m
 }
 
 // Init satisfies tea.Model.
@@ -188,6 +198,10 @@ func (m *AgentLauncherModal) selectAgent(opt agentOption) (tea.Model, tea.Cmd) {
 	// Claude and Copilot: advance to the inline prompt step.
 	m.promptInput.Placeholder = fmt.Sprintf("Enter %s prompt…", opt.name)
 	m.promptInput.SetValue("")
+	if m.initialPrompt != "" {
+		m.promptInput.SetValue(m.initialPrompt)
+		m.promptInput.CursorEnd()
+	}
 	focusCmd := m.promptInput.Focus()
 	m.step = stepAgentPrompt
 	return m, focusCmd

--- a/internal/tui/modal/agent_launcher_test.go
+++ b/internal/tui/modal/agent_launcher_test.go
@@ -389,3 +389,51 @@ func TestAgentLauncherModal_ShortcutD_WhenAvailable_EmitsSpawnMsg(t *testing.T) 
 	assert.Equal(t, "aider", spawnMsg.AgentName)
 }
 
+
+// --- NewAgentLauncherModalWithPrompt ---
+
+func TestNewAgentLauncherModalWithPrompt_PreFillsOnAgentSelect(t *testing.T) {
+cfg := &domain.Config{}
+m := NewAgentLauncherModalWithPrompt(cfg, testWorktreePath, "review this PR")
+
+require.NotNil(t, m)
+assert.Equal(t, "review this PR", m.initialPrompt)
+assert.Equal(t, stepAgentSelect, m.step, "should start on selection step")
+}
+
+func TestNewAgentLauncherModalWithPrompt_PreFillsPromptInput_OnClaudeSelect(t *testing.T) {
+opts := []agentOption{
+{name: "Claude Code", key: "a", internal: AgentNameClaude, available: true},
+}
+m := newAgentLauncherModal(opts, testWorktreePath)
+m.initialPrompt = "review the PR"
+
+updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m = updated.(*AgentLauncherModal)
+
+require.NotNil(t, cmd, "Focus cmd should be returned")
+assert.Equal(t, stepAgentPrompt, m.step)
+assert.Equal(t, "review the PR", m.promptInput.Value(), "prompt input should be pre-filled with initialPrompt")
+}
+
+func TestNewAgentLauncherModalWithPrompt_PreFilledPrompt_SubmitsCorrectly(t *testing.T) {
+opts := []agentOption{
+{name: "Claude Code", key: "a", internal: AgentNameClaude, available: true},
+}
+m := newAgentLauncherModal(opts, testWorktreePath)
+m.initialPrompt = "review the PR"
+
+// Select Claude — advances to prompt step with pre-filled value.
+updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+m = updated.(*AgentLauncherModal)
+require.Equal(t, stepAgentPrompt, m.step)
+
+// Submit without modifying the prompt — should use pre-filled value.
+_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+require.NotNil(t, cmd)
+
+msg := cmd()
+spawnMsg, ok := msg.(SpawnAgentMsg)
+require.True(t, ok)
+assert.Equal(t, "review the PR", spawnMsg.Prompt)
+}

--- a/internal/tui/modal/agent_launcher_test.go
+++ b/internal/tui/modal/agent_launcher_test.go
@@ -389,51 +389,50 @@ func TestAgentLauncherModal_ShortcutD_WhenAvailable_EmitsSpawnMsg(t *testing.T) 
 	assert.Equal(t, "aider", spawnMsg.AgentName)
 }
 
-
 // --- NewAgentLauncherModalWithPrompt ---
 
 func TestNewAgentLauncherModalWithPrompt_PreFillsOnAgentSelect(t *testing.T) {
-cfg := &domain.Config{}
-m := NewAgentLauncherModalWithPrompt(cfg, testWorktreePath, "review this PR")
+	cfg := &domain.Config{}
+	m := NewAgentLauncherModalWithPrompt(cfg, testWorktreePath, "review this PR")
 
-require.NotNil(t, m)
-assert.Equal(t, "review this PR", m.initialPrompt)
-assert.Equal(t, stepAgentSelect, m.step, "should start on selection step")
+	require.NotNil(t, m)
+	assert.Equal(t, "review this PR", m.initialPrompt)
+	assert.Equal(t, stepAgentSelect, m.step, "should start on selection step")
 }
 
 func TestNewAgentLauncherModalWithPrompt_PreFillsPromptInput_OnClaudeSelect(t *testing.T) {
-opts := []agentOption{
-{name: "Claude Code", key: "a", internal: AgentNameClaude, available: true},
-}
-m := newAgentLauncherModal(opts, testWorktreePath)
-m.initialPrompt = "review the PR"
+	opts := []agentOption{
+		{name: "Claude Code", key: "a", internal: AgentNameClaude, available: true},
+	}
+	m := newAgentLauncherModal(opts, testWorktreePath)
+	m.initialPrompt = "review the PR"
 
-updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-m = updated.(*AgentLauncherModal)
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*AgentLauncherModal)
 
-require.NotNil(t, cmd, "Focus cmd should be returned")
-assert.Equal(t, stepAgentPrompt, m.step)
-assert.Equal(t, "review the PR", m.promptInput.Value(), "prompt input should be pre-filled with initialPrompt")
+	require.NotNil(t, cmd, "Focus cmd should be returned")
+	assert.Equal(t, stepAgentPrompt, m.step)
+	assert.Equal(t, "review the PR", m.promptInput.Value(), "prompt input should be pre-filled with initialPrompt")
 }
 
 func TestNewAgentLauncherModalWithPrompt_PreFilledPrompt_SubmitsCorrectly(t *testing.T) {
-opts := []agentOption{
-{name: "Claude Code", key: "a", internal: AgentNameClaude, available: true},
-}
-m := newAgentLauncherModal(opts, testWorktreePath)
-m.initialPrompt = "review the PR"
+	opts := []agentOption{
+		{name: "Claude Code", key: "a", internal: AgentNameClaude, available: true},
+	}
+	m := newAgentLauncherModal(opts, testWorktreePath)
+	m.initialPrompt = "review the PR"
 
-// Select Claude — advances to prompt step with pre-filled value.
-updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-m = updated.(*AgentLauncherModal)
-require.Equal(t, stepAgentPrompt, m.step)
+	// Select Claude — advances to prompt step with pre-filled value.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(*AgentLauncherModal)
+	require.Equal(t, stepAgentPrompt, m.step)
 
-// Submit without modifying the prompt — should use pre-filled value.
-_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
-require.NotNil(t, cmd)
+	// Submit without modifying the prompt — should use pre-filled value.
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
 
-msg := cmd()
-spawnMsg, ok := msg.(SpawnAgentMsg)
-require.True(t, ok)
-assert.Equal(t, "review the PR", spawnMsg.Prompt)
+	msg := cmd()
+	spawnMsg, ok := msg.(SpawnAgentMsg)
+	require.True(t, ok)
+	assert.Equal(t, "review the PR", spawnMsg.Prompt)
 }


### PR DESCRIPTION
Closes #78

## What changed

Adds **Ctrl+R** in the PRs view to launch an AI-assisted code review against the selected PR.

- New `prReviewWorktreePath` derives a `pr-<number>-<branch-slug>` path (distinct from the existing PR checkout path)
- `provisionPRReviewWorktreeCmd` reuses an existing local worktree when the PR branch is already checked out; otherwise fetches and creates one via `CheckoutPRWorktree`
- `AgentLauncherModal` gains an `initialPrompt` field and a `NewAgentLauncherModalWithPrompt` constructor so the review prompt is pre-seeded before the user confirms their agent
- Footer hints in the PRs view now show `[Ctrl+R] Review`

## Why

Integrates the AI agent launcher with the PR list so reviewers can spin up a structured code review in one keypress without leaving Nexus. The worktree auto-provisioning means the agent always runs against the correct branch, and the pre-seeded prompt ensures consistent, actionable review coverage (correctness, security, performance, maintainability, breaking changes).

## Testing

- 9 new tests: `TestPRReviewWorktreePath` (3 subtests), `TestModel_CtrlR_InPRView_WithNoSelectedPR_ShowsError`, `TestModel_CtrlR_InWorktreesView_ShowsError`, `TestModel_PRReviewWorktreeDoneMsg_OpensAgentModal`, `TestModel_PRReviewWorktreeDoneMsg_WithError_ShowsStatusError`, `TestModel_ProvisionPRReviewWorktreeCmd_ReusesExistingWorktree`, plus 3 modal tests for `initialPrompt` pre-fill behaviour
- All 9 pass; pre-existing `TestBuildNewTabWithCmdCmd` failures are unrelated (Zellij installed in this environment)
- Manual flow: Ctrl+R → worktree provisioned → AgentLauncherModal opens with review prompt pre-filled → select agent → agent spawns in new terminal