### PR TITLE
fix(app): wire r key to global refresh

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -623,6 +623,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.ctxScrollOffset = 0
 				m.currentPage = 0
 			case "r", "R":
+				if m.syncing {
+					return m, nil
+				}
 				m.syncing = true
 				return m, tea.Batch(m.refreshWorktreesCmd(), m.syncGitHubCmd())
 			case "n":

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -622,6 +622,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.view = viewPRs
 				m.ctxScrollOffset = 0
 				m.currentPage = 0
+			case "r", "R":
+				m.syncing = true
+				return m, tea.Batch(m.refreshWorktreesCmd(), m.syncGitHubCmd())
 			case "n":
 				m.nextPage()
 				return m, nil

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3805,3 +3805,37 @@ func TestModel_Enter_PR_JumpsToExistingSession(t *testing.T) {
 		})
 	}
 }
+
+// TestModel_RKey_TriggersFullRefresh verifies that pressing 'r' fires both
+// refreshWorktreesCmd and syncGitHubCmd from any view.
+func TestModel_RKey_TriggersFullRefresh(t *testing.T) {
+	views := []activeView{viewWorktrees, viewIssues, viewPRs}
+	for _, v := range views {
+		t.Run(fmt.Sprintf("view_%d", v), func(t *testing.T) {
+			m := NewModel()
+			require.NotNil(t, m)
+			m.view = v
+
+			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+
+			result, ok := updated.(*Model)
+			require.True(t, ok)
+			assert.True(t, result.syncing, "'r' must set syncing=true")
+			assert.NotNil(t, cmd, "'r' must return a non-nil Cmd (batch of refresh+sync)")
+		})
+	}
+}
+
+// TestModel_RKey_NotFiredWithModalOpen verifies that pressing 'r' while a modal
+// is open is consumed by the modal and does NOT trigger a global refresh.
+func TestModel_RKey_NotFiredWithModalOpen(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+	m.activeModal = modal.NewHelpModal()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+
+	result, ok := updated.(*Model)
+	require.True(t, ok)
+	assert.False(t, result.syncing, "'r' with modal open must NOT set syncing=true")
+}

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3806,24 +3806,47 @@ func TestModel_Enter_PR_JumpsToExistingSession(t *testing.T) {
 	}
 }
 
-// TestModel_RKey_TriggersFullRefresh verifies that pressing 'r' fires both
+// TestModel_RKey_TriggersFullRefresh verifies that pressing 'r' or 'R' fires both
 // refreshWorktreesCmd and syncGitHubCmd from any view.
 func TestModel_RKey_TriggersFullRefresh(t *testing.T) {
-	views := []activeView{viewWorktrees, viewIssues, viewPRs}
-	for _, v := range views {
-		t.Run(fmt.Sprintf("view_%d", v), func(t *testing.T) {
+	cases := []struct {
+		view activeView
+		name string
+		key  rune
+	}{
+		{viewWorktrees, "worktrees_r", 'r'},
+		{viewWorktrees, "worktrees_R", 'R'},
+		{viewIssues, "issues_r", 'r'},
+		{viewIssues, "issues_R", 'R'},
+		{viewPRs, "prs_r", 'r'},
+		{viewPRs, "prs_R", 'R'},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
 			m := NewModel()
 			require.NotNil(t, m)
-			m.view = v
+			m.view = tc.view
 
-			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+			updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tc.key}})
 
 			result, ok := updated.(*Model)
 			require.True(t, ok)
-			assert.True(t, result.syncing, "'r' must set syncing=true")
-			assert.NotNil(t, cmd, "'r' must return a non-nil Cmd (batch of refresh+sync)")
+			assert.True(t, result.syncing, "'%c' must set syncing=true", tc.key)
+			assert.NotNil(t, cmd, "'%c' must return a non-nil Cmd (batch of refresh+sync)", tc.key)
 		})
 	}
+}
+
+// TestModel_RKey_NoOpWhenAlreadySyncing verifies that pressing 'r' while a sync
+// is already in progress is a no-op (no duplicate batch fired).
+func TestModel_RKey_NoOpWhenAlreadySyncing(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+	m.syncing = true
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+
+	assert.Nil(t, cmd, "'r' while syncing must return nil Cmd")
 }
 
 // TestModel_RKey_NotFiredWithModalOpen verifies that pressing 'r' while a modal


### PR DESCRIPTION
Closes #91

## What Changed
Added a handler for the `r`/`R` key in `cmd/nexus/app.go` that fires `refreshWorktreesCmd` + `syncGitHubCmd` as a batch — exactly what the help modal documented but never wired up.

## Why Changed
`internal/tui/modal/help.go:384` instructs users to "press r to refresh" but `app.go` had no handler for it. Pressing `r` silently did nothing.

## How It Works
- `r`/`R` added to the `tea.KeyRunes` switch — sets `m.syncing = true` then returns `tea.Batch(refreshWorktreesCmd, syncGitHubCmd)`
- No view guard — works from Worktrees, Issues, and PRs views
- Modal interception already handled by the existing guard at the top of `Update()`: when `activeModal != nil`, key events are routed to the modal and never reach this handler

## Testing
- `TestModel_RKey_TriggersFullRefresh` — verifies `r` fires a non-nil Cmd and sets `syncing=true` across all 3 views
- `TestModel_RKey_NotFiredWithModalOpen` — verifies `r` with an open modal does NOT set `syncing=true`
- All new tests passing; pre-existing `TestBuildNewTabWithCmdCmd` failures are environment-specific (zellij installed locally) and pre-date this PR