### PR TITLE
fix(updater): prevent ETXTBSY on Linux self-update

### DIFF
--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -384,27 +384,18 @@ func moveFile(src, dst string) error {
 
 // replaceBinary replaces currentExe with the file at newPath.
 //
-// On non-Windows platforms this is a straightforward atomic rename.
-// On Windows you cannot rename a file on top of a running executable, but you
-// CAN rename the running executable away (the OS holds its open handle by
-// inode, not by name). The strategy is therefore:
-//  1. Rename currentExe → currentExe+".old"  (always succeeds on Windows)
-//  2. Move   newPath    → currentExe          (target no longer exists)
+// The strategy used on all platforms is:
+//  1. Rename currentExe → currentExe+".old"  (the kernel holds the open inode
+//     by reference, so the running process is unaffected by the rename)
+//  2. Move   newPath    → currentExe          (target slot is now free)
 //
-// Step 2 uses moveFile which falls back to copy+delete when the source and
-// destination are on different drives (common when the exe lives on D: but the
-// temp dir is on C:).
+// This avoids ETXTBSY on Linux/macOS (writing to a running executable is
+// forbidden) and the equivalent restriction on Windows. Step 2 uses moveFile
+// which falls back to copy+delete when newPath and currentExe are on different
+// filesystems (e.g. /tmp vs /usr/local/bin, or C: vs D: on Windows).
 //
-// The ".old" file cannot be deleted while the process is running; call
-// CleanupOldBinary on the next startup to remove it.
+// The ".old" file is cleaned up on the next startup by CleanupOldBinary.
 func replaceBinary(newPath, currentExe string) error {
-	if runtime.GOOS != "windows" {
-		if err := moveFile(newPath, currentExe); err != nil {
-			return fmt.Errorf("replace binary: %w", err)
-		}
-		return nil
-	}
-
 	oldExe := currentExe + ".old"
 	// Remove any leftover .old from a previous update so the rename below
 	// doesn't fail if the file already exists.
@@ -423,12 +414,9 @@ func replaceBinary(newPath, currentExe string) error {
 }
 
 // CleanupOldBinary removes the "<executable>.old" file left behind by a
-// Windows self-update. It is a no-op on other platforms and silently ignores
-// any errors (the file may not exist or may still be locked).
+// self-update. It silently ignores any errors (the file may not exist or may
+// still be locked by the OS).
 func CleanupOldBinary() {
-	if runtime.GOOS != "windows" {
-		return
-	}
 	exe, err := os.Executable()
 	if err != nil {
 		return

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -220,12 +220,12 @@ func TestReplaceBinary(t *testing.T) {
 }
 
 func TestReplaceBinary_OldFileCleanedUp(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows-specific behaviour")
-	}
 	dir := t.TempDir()
 
-	currentExe := filepath.Join(dir, "nexus.exe")
+	currentExe := filepath.Join(dir, "nexus")
+	if runtime.GOOS == "windows" {
+		currentExe += ".exe"
+	}
 	newBinary := filepath.Join(dir, "nexus-new")
 	oldExe := currentExe + ".old"
 
@@ -246,11 +246,11 @@ func TestReplaceBinary_OldFileCleanedUp(t *testing.T) {
 }
 
 func TestCleanupOldBinary_RemovesFile(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Windows-specific behaviour")
-	}
 	dir := t.TempDir()
-	exePath := filepath.Join(dir, "nexus.exe")
+	exePath := filepath.Join(dir, "nexus")
+	if runtime.GOOS == "windows" {
+		exePath += ".exe"
+	}
 	oldPath := exePath + ".old"
 
 	require.NoError(t, os.WriteFile(exePath, []byte("running"), 0755))


### PR DESCRIPTION
Closes #95

## What Changed
Unified the binary replacement strategy across all platforms. The non-Windows path in `replaceBinary` was directly overwriting the running executable, triggering `ETXTBSY` on Linux when `/tmp` and the install dir are on different filesystems.

## Why
On Linux, `os.Rename` fails with `cross-device link` when source and destination are on different filesystems (e.g. `/tmp` → `/usr/local/bin`). The copy fallback then tries `O_TRUNC` on the running binary, which the kernel rejects with **ETXTBSY** (text file busy).

The Windows path already solved this by renaming the current exe away first. That same strategy works on all platforms since renaming stays within the same filesystem.

## Changes
- `replaceBinary`: removed the non-Windows early-return shortcut; all platforms now use rename-away + move-in
- `CleanupOldBinary`: now runs on Linux/macOS too, cleaning up the `.old` file on next startup
- Tests: `TestReplaceBinary_OldFileCleanedUp` and `TestCleanupOldBinary_RemovesFile` now run on all platforms (removed Windows-only skip)

## Testing
- All 13 updater tests pass
- Full build passes
- Manually verified on WSL/Ubuntu by building from source and installing