### PR TITLE
fuzzy finder to main

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -103,6 +104,14 @@ type updateCheckedMsg struct {
 
 // selfUpdateDoneMsg carries the result of a self-update attempt.
 type selfUpdateDoneMsg struct{ err error }
+
+// fuzzyOpenMsg is dispatched when the user opens the fuzzy finder.
+type fuzzyOpenMsg struct{}
+
+// fuzzyResultsReadyMsg is dispatched when the async search index build is complete.
+type fuzzyResultsReadyMsg struct {
+	results []domain.SearchResult
+}
 
 // clearErrorCmd returns a Cmd that fires clearErrorMsg after 5 seconds.
 func clearErrorCmd() tea.Cmd {
@@ -307,6 +316,11 @@ type Model struct {
 	// Claude prompt state
 	claudePromptActive bool            // true while the inline Claude prompt is open
 	claudePromptInput  textinput.Model // text input for entering the Claude prompt
+
+	// Fuzzy finder state
+	fuzzyFiles    []string              // files from git ls-files
+	fuzzyBranches []string              // branches from git branch -a
+	fuzzyAllItems []domain.SearchResult // full unfiltered search index
 }
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
@@ -983,6 +997,27 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.statusMsg = "✓ Updated successfully! Please restart nexus to use the new version."
 		return m, clearMsgCmd()
+
+	case fuzzyOpenMsg:
+		return m, m.buildSearchIndexCmd()
+
+	case fuzzyResultsReadyMsg:
+		m.fuzzyAllItems = msg.results
+		// Also extract the file and branch slices for convenience
+		m.fuzzyFiles = m.fuzzyFiles[:0]
+		m.fuzzyBranches = m.fuzzyBranches[:0]
+		for _, r := range msg.results {
+			switch r.Kind {
+			case domain.KindFile:
+				if f, ok := r.Payload.(string); ok {
+					m.fuzzyFiles = append(m.fuzzyFiles, f)
+				}
+			case domain.KindBranch:
+				if b, ok := r.Payload.(string); ok {
+					m.fuzzyBranches = append(m.fuzzyBranches, b)
+				}
+			}
+		}
 	}
 
 	return m, nil
@@ -1910,6 +1945,187 @@ func (m *Model) refreshWorktreesCmd() tea.Cmd {
 		cmd := internalexec.NewGitCommand(repoPath)
 		worktrees, err := cmd.ListWorktrees()
 		return worktreesRefreshedMsg{worktrees: worktrees, err: err}
+	}
+}
+
+// buildSearchIndexCmd builds the unified search index used by the fuzzy finder.
+// It concurrently fetches files, branches, agent history, and commits from the
+// repository, combining them with already-cached worktrees, issues, and PRs.
+// Errors from individual async sources are logged at debug level and skipped —
+// they are non-fatal so that a missing git binary or empty DB does not break
+// the fuzzy finder entirely.
+func (m *Model) buildSearchIndexCmd() tea.Cmd {
+	// Snapshot all model state upfront to avoid data races inside the goroutine.
+	worktrees := make([]domain.Worktree, len(m.Worktrees))
+	copy(worktrees, m.Worktrees)
+	issues := make([]domain.Issue, len(m.issues))
+	copy(issues, m.issues)
+	prs := make([]domain.PullRequest, len(m.prs))
+	copy(prs, m.prs)
+	repoPath := m.RepoPath
+	db := m.db
+
+	return func() tea.Msg {
+		var (
+			mu       sync.Mutex
+			allItems []domain.SearchResult
+			wg       sync.WaitGroup
+		)
+
+		// append is called from goroutines — always hold mu.
+		appendItems := func(items []domain.SearchResult) {
+			mu.Lock()
+			allItems = append(allItems, items...)
+			mu.Unlock()
+		}
+
+		// Seed from cached sources immediately (no I/O required).
+		var cached []domain.SearchResult
+		for _, wt := range worktrees {
+			cached = append(cached, domain.SearchResult{
+				Kind:    domain.KindWorktree,
+				Label:   wt.Path,
+				Sub:     wt.Branch,
+				Icon:    "🌿",
+				Payload: wt,
+			})
+		}
+		for _, iss := range issues {
+			cached = append(cached, domain.SearchResult{
+				Kind:    domain.KindIssue,
+				Label:   iss.Title,
+				Sub:     fmt.Sprintf("#%d", iss.Number),
+				Icon:    "🐛",
+				Payload: iss,
+			})
+		}
+		for _, pr := range prs {
+			cached = append(cached, domain.SearchResult{
+				Kind:    domain.KindPR,
+				Label:   pr.Title,
+				Sub:     fmt.Sprintf("#%d", pr.Number),
+				Icon:    "🔀",
+				Payload: pr,
+			})
+		}
+		appendItems(cached)
+
+		// git ls-files
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out, err := exec.Command("git", "-C", repoPath, "ls-files").Output()
+			if err != nil {
+				slog.Debug("buildSearchIndexCmd: git ls-files failed", "err", err)
+				return
+			}
+			var items []domain.SearchResult
+			for _, f := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+				if f == "" {
+					continue
+				}
+				items = append(items, domain.SearchResult{
+					Kind:    domain.KindFile,
+					Label:   f,
+					Sub:     "",
+					Icon:    "📄",
+					Payload: f,
+				})
+			}
+			appendItems(items)
+		}()
+
+		// git branch -a
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out, err := exec.Command("git", "-C", repoPath, "branch", "-a").Output()
+			if err != nil {
+				slog.Debug("buildSearchIndexCmd: git branch -a failed", "err", err)
+				return
+			}
+			var items []domain.SearchResult
+			for _, line := range strings.Split(string(out), "\n") {
+				// Strip leading "* " (current branch marker) or leading spaces.
+				b := strings.TrimPrefix(line, "* ")
+				b = strings.TrimSpace(b)
+				if b == "" {
+					continue
+				}
+				items = append(items, domain.SearchResult{
+					Kind:    domain.KindBranch,
+					Label:   b,
+					Sub:     "",
+					Icon:    "🌿",
+					Payload: b,
+				})
+			}
+			appendItems(items)
+		}()
+
+		// agent history
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if db == nil {
+				return
+			}
+			history, err := data.GetAgentHistory(db)
+			if err != nil {
+				slog.Debug("buildSearchIndexCmd: get agent history failed", "err", err)
+				return
+			}
+			var items []domain.SearchResult
+			for _, h := range history {
+				label := h.Prompt
+				if label == "" {
+					label = h.AgentName
+				}
+				items = append(items, domain.SearchResult{
+					Kind:    domain.KindAgent,
+					Label:   label,
+					Sub:     h.AgentName,
+					Icon:    "🤖",
+					Payload: h,
+				})
+			}
+			appendItems(items)
+		}()
+
+		// git log --oneline -50
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out, err := exec.Command("git", "-C", repoPath, "log", "--oneline", "-50").Output()
+			if err != nil {
+				slog.Debug("buildSearchIndexCmd: git log failed", "err", err)
+				return
+			}
+			var items []domain.SearchResult
+			for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+				if line == "" {
+					continue
+				}
+				// First token is the hash; the remainder is the message.
+				parts := strings.SplitN(line, " ", 2)
+				hash := parts[0]
+				message := ""
+				if len(parts) == 2 {
+					message = parts[1]
+				}
+				items = append(items, domain.SearchResult{
+					Kind:    domain.KindCommit,
+					Label:   message,
+					Sub:     hash,
+					Icon:    "📦",
+					Payload: hash,
+				})
+			}
+			appendItems(items)
+		}()
+
+		wg.Wait()
+		return fuzzyResultsReadyMsg{results: allItems}
 	}
 }
 

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/m00nk0d3/nexus/internal/data"
 	"github.com/m00nk0d3/nexus/internal/domain"
 	internalexec "github.com/m00nk0d3/nexus/internal/exec"
+	"github.com/m00nk0d3/nexus/internal/fuzzy"
 	"github.com/m00nk0d3/nexus/internal/tui/modal"
 	"github.com/m00nk0d3/nexus/internal/tui/styles"
 	"github.com/m00nk0d3/nexus/internal/updater"
@@ -318,9 +319,14 @@ type Model struct {
 	claudePromptInput  textinput.Model // text input for entering the Claude prompt
 
 	// Fuzzy finder state
-	fuzzyFiles    []string              // files from git ls-files
-	fuzzyBranches []string              // branches from git branch -a
 	fuzzyAllItems []domain.SearchResult // full unfiltered search index
+
+	// Fuzzy overlay state
+	fuzzyActive  bool                  // true while the fuzzy finder overlay is open
+	fuzzyInput   textinput.Model       // text input for the fuzzy query
+	fuzzyResults []domain.SearchResult // filtered+ranked results for the current query
+	fuzzySelIdx  int                   // selected result index
+	fuzzyLoading bool                  // true while the search index is being built
 }
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
@@ -346,6 +352,11 @@ func NewModel() *Model {
 		themeIdx:  themeIdx,
 		statusErr: configErr,
 		focused:   panelList,
+		fuzzyInput: func() textinput.Model {
+			ti := textinput.New()
+			ti.Placeholder = "Search worktrees, issues, PRs, files..."
+			return ti
+		}(),
 	}
 }
 
@@ -488,6 +499,47 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		// Non-key message: fall through to the main switch to handle it normally.
+	}
+
+	// While the fuzzy finder overlay is open, route key events here.
+	// Non-key messages (e.g. fuzzyResultsReadyMsg, tea.WindowSizeMsg) fall
+	// through to the main switch so background events are never dropped.
+	if m.fuzzyActive {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			switch keyMsg.Type {
+			case tea.KeyEsc:
+				m.fuzzyActive = false
+				m.fuzzyInput.SetValue("")
+				m.fuzzyResults = nil
+				m.fuzzySelIdx = 0
+				return m, nil
+			case tea.KeyEnter:
+				cmd := m.fuzzyConfirmSelection()
+				m.fuzzyActive = false
+				m.fuzzyInput.SetValue("")
+				m.fuzzyResults = nil
+				m.fuzzySelIdx = 0
+				return m, cmd
+			case tea.KeyUp:
+				if m.fuzzySelIdx > 0 {
+					m.fuzzySelIdx--
+				}
+				return m, nil
+			case tea.KeyDown:
+				if m.fuzzySelIdx < len(m.fuzzyResults)-1 {
+					m.fuzzySelIdx++
+				}
+				return m, nil
+			default:
+				var inputCmd tea.Cmd
+				m.fuzzyInput, inputCmd = m.fuzzyInput.Update(keyMsg)
+				query := m.fuzzyInput.Value()
+				m.fuzzyResults = fuzzy.FilterAndRank(query, m.fuzzyAllItems)
+				m.fuzzySelIdx = 0
+				return m, inputCmd
+			}
+		}
+		// Non-key message: fall through to the main switch.
 	}
 
 	switch msg := msg.(type) {
@@ -735,6 +787,20 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.statusErr = "No active session for this worktree"
 				return m, clearErrorCmd()
+			case "/":
+				m.fuzzyInput.SetValue("")
+				focusCmd := m.fuzzyInput.Focus()
+				m.fuzzyActive = true
+				m.fuzzySelIdx = 0
+				if len(m.fuzzyAllItems) > 0 {
+					m.fuzzyLoading = false
+					m.fuzzyResults = fuzzy.FilterAndRank("", m.fuzzyAllItems)
+				} else {
+					m.fuzzyLoading = true
+					m.fuzzyResults = nil
+					return m, tea.Batch(focusCmd, func() tea.Msg { return fuzzyOpenMsg{} })
+				}
+				return m, focusCmd
 			}
 		}
 
@@ -1003,20 +1069,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fuzzyResultsReadyMsg:
 		m.fuzzyAllItems = msg.results
-		// Also extract the file and branch slices for convenience
-		m.fuzzyFiles = m.fuzzyFiles[:0]
-		m.fuzzyBranches = m.fuzzyBranches[:0]
-		for _, r := range msg.results {
-			switch r.Kind {
-			case domain.KindFile:
-				if f, ok := r.Payload.(string); ok {
-					m.fuzzyFiles = append(m.fuzzyFiles, f)
-				}
-			case domain.KindBranch:
-				if b, ok := r.Payload.(string); ok {
-					m.fuzzyBranches = append(m.fuzzyBranches, b)
-				}
-			}
+		// Always clear the loading flag regardless of whether the overlay is
+		// still open — prevents stale loading state if the user closed the
+		// overlay before the index finished building.
+		m.fuzzyLoading = false
+		// If the overlay is still open, populate results now that the index is ready.
+		if m.fuzzyActive {
+			query := m.fuzzyInput.Value()
+			m.fuzzyResults = fuzzy.FilterAndRank(query, m.fuzzyAllItems)
+			m.fuzzySelIdx = 0
 		}
 	}
 
@@ -1060,6 +1121,12 @@ func (m *Model) View() string {
 	if m.claudePromptActive {
 		return overlay("Spawn Claude Code",
 			fmt.Sprintf("> %s\n\nEnter confirm (prompt optional)  •  Esc cancel", m.claudePromptInput.View()))
+	}
+
+	if m.fuzzyActive {
+		theme := styles.NewTheme(styles.Themes[m.themeIdx])
+		overlayContent := renderFuzzyOverlay(m.fuzzyInput, m.fuzzyResults, m.fuzzySelIdx, theme, m.fuzzyLoading, w)
+		return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, overlayContent)
 	}
 
 	if m.selfUpdating {
@@ -2342,4 +2409,55 @@ func (m *Model) moveUp() {
 			}
 		}
 	}
+}
+
+// fuzzyConfirmSelection navigates the UI to the selected fuzzy result.
+// Returns a Cmd to execute as part of the selection (e.g. spawn a session), or nil.
+func (m *Model) fuzzyConfirmSelection() tea.Cmd {
+	if len(m.fuzzyResults) == 0 || m.fuzzySelIdx >= len(m.fuzzyResults) {
+		return nil
+	}
+	result := m.fuzzyResults[m.fuzzySelIdx]
+	switch result.Kind {
+	case domain.KindWorktree:
+		m.view = viewWorktrees
+		m.ctxScrollOffset = 0
+		m.currentPage = 0
+		if wt, ok := result.Payload.(domain.Worktree); ok {
+			for i, w := range m.Worktrees {
+				if w.Path == wt.Path {
+					m.selectedIdx = i
+					break
+				}
+			}
+		}
+	case domain.KindIssue:
+		m.view = viewIssues
+		m.ctxScrollOffset = 0
+		m.currentPage = 0
+		if iss, ok := result.Payload.(domain.Issue); ok {
+			for i, issue := range m.issues {
+				if issue.Number == iss.Number {
+					m.selectedIssueIdx = i
+					break
+				}
+			}
+		}
+	case domain.KindPR:
+		m.view = viewPRs
+		m.ctxScrollOffset = 0
+		m.currentPage = 0
+		if pr, ok := result.Payload.(domain.PullRequest); ok {
+			for i, p := range m.prs {
+				if p.Number == pr.Number {
+					m.selectedPRIdx = i
+					break
+				}
+			}
+		}
+	case domain.KindFile, domain.KindBranch, domain.KindAgent, domain.KindCommit:
+		m.statusMsg = fmt.Sprintf("Selected: %s  %s", result.Icon, result.Label)
+		return clearMsgCmd()
+	}
+	return nil
 }

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -68,7 +68,8 @@ type lazyLoadContextMsg struct {
 	worktree domain.Worktree
 }
 
-// browserOpenErrMsg carries an error from opening an issue or PR in the browser.
+// browserOpenErrMsg carries an error from launching an external process
+// (browser, editor, gh CLI, etc.).
 type browserOpenErrMsg struct{ err error }
 
 // agentDoneMsg is dispatched when an AI agent process exits.
@@ -614,6 +615,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if selected, ok := m.selectedWorktree(); ok {
 				m.activeModal = modal.NewDeleteModal(selected)
 			}
+		case tea.KeyCtrlF:
+			return m, m.openFuzzyCmd()
 		case tea.KeyCtrlR:
 			if m.view != viewPRs {
 				m.statusErr = "PR Review (Ctrl+R) is only available in the PRs view — press P to switch"
@@ -788,19 +791,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.statusErr = "No active session for this worktree"
 				return m, clearErrorCmd()
 			case "/":
-				m.fuzzyInput.SetValue("")
-				focusCmd := m.fuzzyInput.Focus()
-				m.fuzzyActive = true
-				m.fuzzySelIdx = 0
-				if len(m.fuzzyAllItems) > 0 {
-					m.fuzzyLoading = false
-					m.fuzzyResults = fuzzy.FilterAndRank("", m.fuzzyAllItems)
-				} else {
-					m.fuzzyLoading = true
-					m.fuzzyResults = nil
-					return m, tea.Batch(focusCmd, func() tea.Msg { return fuzzyOpenMsg{} })
-				}
-				return m, focusCmd
+				return m, m.openFuzzyCmd()
 			}
 		}
 
@@ -2455,9 +2446,61 @@ func (m *Model) fuzzyConfirmSelection() tea.Cmd {
 				}
 			}
 		}
-	case domain.KindFile, domain.KindBranch, domain.KindAgent, domain.KindCommit:
-		m.statusMsg = fmt.Sprintf("Selected: %s  %s", result.Icon, result.Label)
-		return clearMsgCmd()
+	case domain.KindFile:
+		if relPath, ok := result.Payload.(string); ok {
+			return openFileInEditorCmd(relPath, m.RepoPath)
+		}
+	case domain.KindBranch:
+		if branch, ok := result.Payload.(string); ok {
+			path := prWorktreePath(m.RepoPath, branch)
+			m.activeModal = modal.NewBranchCheckoutModal(branch, path)
+		}
+	case domain.KindCommit:
+		if hash, ok := result.Payload.(string); ok {
+			return openCommitInBrowserCmd(hash, m.RepoPath)
+		}
+	case domain.KindAgent:
+		// No-op — future: show detail modal.
 	}
 	return nil
+}
+
+// openFuzzyCmd opens the fuzzy finder overlay, triggering a background index build
+// when the search index has not yet been populated.
+func (m *Model) openFuzzyCmd() tea.Cmd {
+	m.fuzzyInput.SetValue("")
+	focusCmd := m.fuzzyInput.Focus()
+	m.fuzzyActive = true
+	m.fuzzySelIdx = 0
+	if len(m.fuzzyAllItems) > 0 {
+		m.fuzzyLoading = false
+		m.fuzzyResults = fuzzy.FilterAndRank("", m.fuzzyAllItems)
+		return focusCmd
+	}
+	m.fuzzyLoading = true
+	m.fuzzyResults = nil
+	return tea.Batch(focusCmd, func() tea.Msg { return fuzzyOpenMsg{} })
+}
+
+// openFileInEditorCmd opens relPath (relative to repoPath) in the user's configured
+// $EDITOR. Falls back to "vi" on Unix-like systems and "notepad" on Windows.
+func openFileInEditorCmd(relPath, repoPath string) tea.Cmd {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		if runtime.GOOS == "windows" {
+			editor = "notepad"
+		} else {
+			editor = "vi"
+		}
+	}
+	fullPath := filepath.Join(repoPath, relPath)
+	cmd := exec.Command(editor, fullPath)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg { return browserOpenErrMsg{err: err} })
+}
+
+// openCommitInBrowserCmd opens the given commit SHA in the browser via the gh CLI.
+func openCommitInBrowserCmd(hash, repoPath string) tea.Cmd {
+	cmd := exec.Command("gh", "browse", hash)
+	cmd.Dir = repoPath
+	return tea.ExecProcess(cmd, func(err error) tea.Msg { return browserOpenErrMsg{err: err} })
 }

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3883,3 +3883,100 @@ func TestModel_RKey_NotFiredWithModalOpen(t *testing.T) {
 	require.True(t, ok)
 	assert.False(t, result.syncing, "'r' with modal open must NOT set syncing=true")
 }
+
+// TestBuildSearchIndexCmd verifies that buildSearchIndexCmd returns a
+// fuzzyResultsReadyMsg containing results for the cached sources (worktrees,
+// issues, PRs) and gracefully skips the async git/agent sources when there is
+// no real git repository at m.RepoPath.
+func TestBuildSearchIndexCmd(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+
+	// Use a temp dir as the repo path so all git commands fail gracefully.
+	m.RepoPath = t.TempDir()
+
+	m.Worktrees = []domain.Worktree{
+		{Path: "/wt/main", Branch: "main"},
+		{Path: "/wt/feat", Branch: "feat/thing"},
+	}
+	m.issues = []domain.Issue{
+		{Number: 1, Title: "First issue"},
+		{Number: 2, Title: "Second issue"},
+	}
+	m.prs = []domain.PullRequest{
+		{Number: 10, Title: "Fix something", Branch: "fix/something"},
+	}
+
+	cmd := m.buildSearchIndexCmd()
+	require.NotNil(t, cmd, "buildSearchIndexCmd should return a non-nil tea.Cmd")
+
+	// Execute the returned Cmd to obtain the message.
+	msg := cmd()
+
+	ready, ok := msg.(fuzzyResultsReadyMsg)
+	require.True(t, ok, "expected fuzzyResultsReadyMsg, got %T", msg)
+
+	// Count results per kind.
+	kindCounts := map[domain.ResultKind]int{}
+	for _, r := range ready.results {
+		kindCounts[r.Kind]++
+	}
+
+	assert.Equal(t, 2, kindCounts[domain.KindWorktree], "should have 2 worktree results")
+	assert.Equal(t, 2, kindCounts[domain.KindIssue], "should have 2 issue results")
+	assert.Equal(t, 1, kindCounts[domain.KindPR], "should have 1 PR result")
+
+	// Verify a worktree result has the correct fields.
+	var wtResult *domain.SearchResult
+	for i := range ready.results {
+		if ready.results[i].Kind == domain.KindWorktree && ready.results[i].Sub == "main" {
+			wtResult = &ready.results[i]
+			break
+		}
+	}
+	require.NotNil(t, wtResult, "should find worktree result for 'main' branch")
+	assert.Equal(t, "/wt/main", wtResult.Label)
+	assert.Equal(t, "🌿", wtResult.Icon)
+}
+
+// TestUpdate_FuzzyOpenMsg verifies that sending fuzzyOpenMsg to Update() returns
+// a non-nil command (the async search index build).
+func TestUpdate_FuzzyOpenMsg(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+	m.RepoPath = t.TempDir()
+
+	_, cmd := m.Update(fuzzyOpenMsg{})
+	assert.NotNil(t, cmd, "fuzzyOpenMsg should return a non-nil Cmd")
+}
+
+// TestUpdate_FuzzyResultsReadyMsg verifies that fuzzyResultsReadyMsg populates
+// m.fuzzyAllItems and extracts the file/branch convenience slices correctly.
+func TestUpdate_FuzzyResultsReadyMsg(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+
+	results := []domain.SearchResult{
+		{Kind: domain.KindFile, Label: "cmd/main.go", Icon: "📄", Payload: "cmd/main.go"},
+		{Kind: domain.KindFile, Label: "internal/app.go", Icon: "📄", Payload: "internal/app.go"},
+		{Kind: domain.KindBranch, Label: "main", Icon: "🌿", Payload: "main"},
+		{Kind: domain.KindBranch, Label: "feat/foo", Icon: "🌿", Payload: "feat/foo"},
+		{Kind: domain.KindWorktree, Label: "/wt/main", Sub: "main", Icon: "🌿", Payload: domain.Worktree{Path: "/wt/main", Branch: "main"}},
+		{Kind: domain.KindIssue, Label: "Fix bug", Sub: "#1", Icon: "🐛", Payload: domain.Issue{Number: 1, Title: "Fix bug"}},
+	}
+
+	updated, cmd := m.Update(fuzzyResultsReadyMsg{results: results})
+	assert.Nil(t, cmd, "fuzzyResultsReadyMsg should return nil Cmd")
+
+	result, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Len(t, result.fuzzyAllItems, 6, "fuzzyAllItems should contain all 6 results")
+	assert.Len(t, result.fuzzyFiles, 2, "fuzzyFiles should contain 2 file results")
+	assert.Len(t, result.fuzzyBranches, 2, "fuzzyBranches should contain 2 branch results")
+
+	assert.Contains(t, result.fuzzyFiles, "cmd/main.go")
+	assert.Contains(t, result.fuzzyFiles, "internal/app.go")
+	assert.Contains(t, result.fuzzyBranches, "main")
+	assert.Contains(t, result.fuzzyBranches, "feat/foo")
+}

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3990,6 +3990,32 @@ func TestUpdate_FuzzyResultsReadyMsg_ClearsLoadingWhenOverlayClosed(t *testing.T
 }
 
 // ---------------------------------------------------------------------------
+// fuzzy keybinding tests
+// ---------------------------------------------------------------------------
+
+// TestFuzzyOpensOnSlash verifies that pressing "/" activates the fuzzy overlay.
+func TestFuzzyOpensOnSlash(t *testing.T) {
+	m := NewModel()
+	m.RepoPath = t.TempDir()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	result := updated.(*Model)
+
+	assert.True(t, result.fuzzyActive, "'/' should activate the fuzzy overlay")
+}
+
+// TestFuzzyOpensOnCtrlF verifies that Ctrl+F activates the fuzzy overlay.
+func TestFuzzyOpensOnCtrlF(t *testing.T) {
+	m := NewModel()
+	m.RepoPath = t.TempDir()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlF})
+	result := updated.(*Model)
+
+	assert.True(t, result.fuzzyActive, "Ctrl+F should activate the fuzzy overlay")
+}
+
+// ---------------------------------------------------------------------------
 // fuzzyConfirmSelection tests
 // ---------------------------------------------------------------------------
 
@@ -4069,31 +4095,58 @@ func TestFuzzyConfirmSelection_PRSelection(t *testing.T) {
 	assert.Equal(t, 1, m.selectedPRIdx, "should select PR at index 1 (Number=20)")
 }
 
-func TestFuzzyConfirmSelection_ToastKinds(t *testing.T) {
-	toastCases := []struct {
-		kind    domain.ResultKind
-		label   string
-		icon    string
-		payload any
-	}{
-		{domain.KindFile, "internal/auth.go", "📄", "internal/auth.go"},
-		{domain.KindBranch, "feat/login", "🌿", "feat/login"},
-		{domain.KindAgent, "fix the null pointer", "🤖", data.AgentRun{AgentName: "copilot", Prompt: "fix the null pointer"}},
-		{domain.KindCommit, "add jwt middleware", "📦", "abc1234"},
+func TestFuzzyConfirmSelection_FileSelection_ReturnsCmd(t *testing.T) {
+	m := NewModel()
+	m.RepoPath = "/repo"
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindFile, Label: "internal/auth.go", Icon: "📄", Payload: "internal/auth.go"},
 	}
+	m.fuzzySelIdx = 0
 
-	for _, tc := range toastCases {
-		t.Run(string(tc.kind), func(t *testing.T) {
-			m := NewModel()
-			m.fuzzyResults = []domain.SearchResult{
-				{Kind: tc.kind, Label: tc.label, Icon: tc.icon, Payload: tc.payload},
-			}
-			m.fuzzySelIdx = 0
+	cmd := m.fuzzyConfirmSelection()
 
-			cmd := m.fuzzyConfirmSelection()
-
-			assert.NotNil(t, cmd, "%s: should return a clearMsgCmd", tc.kind)
-			assert.Contains(t, m.statusMsg, tc.label, "%s: statusMsg should contain the label", tc.kind)
-		})
-	}
+	assert.NotNil(t, cmd, "file selection should return an exec Cmd")
+	assert.Empty(t, m.statusMsg, "file selection should not set statusMsg")
 }
+
+func TestFuzzyConfirmSelection_BranchSelection_OpensModal(t *testing.T) {
+	m := NewModel()
+	m.RepoPath = "/repo/main"
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindBranch, Label: "feat/login", Icon: "🌿", Payload: "feat/login"},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.Nil(t, cmd, "branch selection should return nil Cmd (modal handles the action)")
+	assert.NotNil(t, m.activeModal, "branch selection should open a BranchCheckoutModal")
+}
+
+func TestFuzzyConfirmSelection_AgentSelection_IsNoOp(t *testing.T) {
+	m := NewModel()
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindAgent, Label: "fix the null pointer", Icon: "🤖", Payload: data.AgentRun{AgentName: "copilot", Prompt: "fix the null pointer"}},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.Nil(t, cmd, "agent selection is a no-op")
+	assert.Empty(t, m.statusMsg, "agent selection should not set statusMsg")
+}
+
+func TestFuzzyConfirmSelection_CommitSelection_ReturnsCmd(t *testing.T) {
+	m := NewModel()
+	m.RepoPath = "/repo"
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindCommit, Label: "add jwt middleware", Icon: "📦", Payload: "abc1234"},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.NotNil(t, cmd, "commit selection should return a gh browse Cmd")
+	assert.Empty(t, m.statusMsg, "commit selection should not set statusMsg")
+}
+

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3951,7 +3951,7 @@ func TestUpdate_FuzzyOpenMsg(t *testing.T) {
 }
 
 // TestUpdate_FuzzyResultsReadyMsg verifies that fuzzyResultsReadyMsg populates
-// m.fuzzyAllItems and extracts the file/branch convenience slices correctly.
+// m.fuzzyAllItems and always clears fuzzyLoading, even when the overlay is closed.
 func TestUpdate_FuzzyResultsReadyMsg(t *testing.T) {
 	m := NewModel()
 	require.NotNil(t, m)
@@ -3972,11 +3972,128 @@ func TestUpdate_FuzzyResultsReadyMsg(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Len(t, result.fuzzyAllItems, 6, "fuzzyAllItems should contain all 6 results")
-	assert.Len(t, result.fuzzyFiles, 2, "fuzzyFiles should contain 2 file results")
-	assert.Len(t, result.fuzzyBranches, 2, "fuzzyBranches should contain 2 branch results")
+}
 
-	assert.Contains(t, result.fuzzyFiles, "cmd/main.go")
-	assert.Contains(t, result.fuzzyFiles, "internal/app.go")
-	assert.Contains(t, result.fuzzyBranches, "main")
-	assert.Contains(t, result.fuzzyBranches, "feat/foo")
+// TestUpdate_FuzzyResultsReadyMsg_ClearsLoadingWhenOverlayClosed verifies that
+// fuzzyLoading is reset to false even when the overlay is not currently open.
+func TestUpdate_FuzzyResultsReadyMsg_ClearsLoadingWhenOverlayClosed(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+
+	// Simulate: user opened overlay, triggering async build, then closed before results arrived.
+	m.fuzzyLoading = true
+	m.fuzzyActive = false
+
+	_, _ = m.Update(fuzzyResultsReadyMsg{results: []domain.SearchResult{}})
+
+	assert.False(t, m.fuzzyLoading, "fuzzyLoading must be cleared even when overlay is closed")
+}
+
+// ---------------------------------------------------------------------------
+// fuzzyConfirmSelection tests
+// ---------------------------------------------------------------------------
+
+func TestFuzzyConfirmSelection_EmptyResults_ReturnsNil(t *testing.T) {
+	m := NewModel()
+	m.fuzzyResults = nil
+	cmd := m.fuzzyConfirmSelection()
+	assert.Nil(t, cmd)
+}
+
+func TestFuzzyConfirmSelection_IdxOutOfBounds_ReturnsNil(t *testing.T) {
+	m := NewModel()
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindFile, Label: "x.go", Icon: "📄", Payload: "x.go"},
+	}
+	m.fuzzySelIdx = 5
+	cmd := m.fuzzyConfirmSelection()
+	assert.Nil(t, cmd)
+}
+
+func TestFuzzyConfirmSelection_WorktreeSelection(t *testing.T) {
+	m := NewModel()
+	m.Worktrees = []domain.Worktree{
+		{Path: "/wt/alpha", Branch: "feat/alpha"},
+		{Path: "/wt/beta", Branch: "feat/beta"},
+	}
+	m.view = viewIssues // start on a different view
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindWorktree, Label: "/wt/beta", Sub: "feat/beta", Icon: "🌿", Payload: domain.Worktree{Path: "/wt/beta", Branch: "feat/beta"}},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.Nil(t, cmd, "worktree selection returns no async Cmd")
+	assert.Equal(t, viewWorktrees, m.view, "should switch to worktrees view")
+	assert.Equal(t, 1, m.selectedIdx, "should select /wt/beta (index 1)")
+	assert.Equal(t, 0, m.ctxScrollOffset)
+	assert.Equal(t, 0, m.currentPage)
+}
+
+func TestFuzzyConfirmSelection_IssueSelection(t *testing.T) {
+	m := NewModel()
+	m.issues = []domain.Issue{
+		{Number: 1, Title: "First"},
+		{Number: 42, Title: "Fix auth"},
+	}
+	m.view = viewWorktrees
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindIssue, Label: "Fix auth", Sub: "#42", Icon: "🐛", Payload: domain.Issue{Number: 42, Title: "Fix auth"}},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.Nil(t, cmd)
+	assert.Equal(t, viewIssues, m.view)
+	assert.Equal(t, 1, m.selectedIssueIdx, "should select issue at index 1 (Number=42)")
+}
+
+func TestFuzzyConfirmSelection_PRSelection(t *testing.T) {
+	m := NewModel()
+	m.prs = []domain.PullRequest{
+		{Number: 10, Title: "First PR"},
+		{Number: 20, Title: "Add feature"},
+	}
+	m.view = viewWorktrees
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindPR, Label: "Add feature", Sub: "#20", Icon: "🔀", Payload: domain.PullRequest{Number: 20, Title: "Add feature"}},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.Nil(t, cmd)
+	assert.Equal(t, viewPRs, m.view)
+	assert.Equal(t, 1, m.selectedPRIdx, "should select PR at index 1 (Number=20)")
+}
+
+func TestFuzzyConfirmSelection_ToastKinds(t *testing.T) {
+	toastCases := []struct {
+		kind    domain.ResultKind
+		label   string
+		icon    string
+		payload any
+	}{
+		{domain.KindFile, "internal/auth.go", "📄", "internal/auth.go"},
+		{domain.KindBranch, "feat/login", "🌿", "feat/login"},
+		{domain.KindAgent, "fix the null pointer", "🤖", data.AgentRun{AgentName: "copilot", Prompt: "fix the null pointer"}},
+		{domain.KindCommit, "add jwt middleware", "📦", "abc1234"},
+	}
+
+	for _, tc := range toastCases {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			m := NewModel()
+			m.fuzzyResults = []domain.SearchResult{
+				{Kind: tc.kind, Label: tc.label, Icon: tc.icon, Payload: tc.payload},
+			}
+			m.fuzzySelIdx = 0
+
+			cmd := m.fuzzyConfirmSelection()
+
+			assert.NotNil(t, cmd, "%s: should return a clearMsgCmd", tc.kind)
+			assert.Contains(t, m.statusMsg, tc.label, "%s: statusMsg should contain the label", tc.kind)
+		})
+	}
 }

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/lipgloss"
 	libtable "github.com/charmbracelet/lipgloss/table"
 	"github.com/charmbracelet/x/ansi"
@@ -18,9 +19,9 @@ import (
 )
 
 const (
-	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [q/esc] Quit"
-	footerHintsIssues    = "[Tab] Panel | [j/k] Navigate | [Enter] New WT | [t] Settings | [g] GH | [q/esc] Quit"
-	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [Ctrl+R] Review | [t] Settings | [g] GH | [q/esc] Quit"
+	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Spc] Agents | [t] Settings | [g] GH | [/] Fuzzy | [q/esc]"
+	footerHintsIssues    = "[Tab] Panel | [j/k] Navigate | [Enter] New WT | [t] Settings | [g] GH | [/] Fuzzy | [q/esc]"
+	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [Ctrl+R] Review | [t] Settings | [g] GH | [/] Fuzzy | [q/esc]"
 	footerHintsDefault   = footerHintsWorktrees
 	actionBarHints       = "[enter] Open  [c-d] Delete  [c-l] Lock | [f1] Help"
 	defaultTermWidth     = 120
@@ -1233,4 +1234,169 @@ func buildPRHint(branch string, issues []domain.Issue, worktrees []domain.Worktr
 		}
 	}
 	return ""
+}
+
+// kindBadge returns a short display label for the given result kind.
+func kindBadge(k domain.ResultKind) string {
+	switch k {
+	case domain.KindWorktree:
+		return "worktree"
+	case domain.KindIssue:
+		return "issue"
+	case domain.KindPR:
+		return "pr"
+	case domain.KindFile:
+		return "file"
+	case domain.KindBranch:
+		return "branch"
+	case domain.KindAgent:
+		return "agent"
+	case domain.KindCommit:
+		return "commit"
+	default:
+		return string(k)
+	}
+}
+
+// renderFuzzyOverlay renders the floating fuzzy finder panel.
+//
+// Layout:
+//
+//	╭──────────────────────────────────────────╮
+//	│  > [input text]                     [/]  │
+//	│──────────────────────────────────────────│
+//	│  🗂 worktree  feat/issue-42-auth         │
+//	│  📌 issue     #42  Fix JWT auth...       │
+//	╰──────────────────────────────────────────╯
+func renderFuzzyOverlay(input textinput.Model, results []domain.SearchResult, selIdx int, theme styles.Theme, loading bool, termWidth int) string {
+	const maxVisible = 12
+
+	overlayWidth := termWidth - 8
+	if overlayWidth < 40 {
+		overlayWidth = 40
+	}
+	if overlayWidth > 100 {
+		overlayWidth = 100
+	}
+
+	// Inner content width: overlayWidth minus border (2) minus padding (2).
+	innerWidth := overlayWidth - 4
+
+	accentColor := lipgloss.Color(theme.Accent())
+	mutedColor := lipgloss.Color(theme.Muted())
+	fgColor := lipgloss.Color(theme.Fg())
+	bgColor := lipgloss.Color(theme.Bg())
+
+	// Header row: "  > [input]  [/]"
+	badge := lipgloss.NewStyle().
+		Foreground(accentColor).
+		Bold(true).
+		Render("[/]")
+	prompt := lipgloss.NewStyle().
+		Foreground(accentColor).
+		Render("> ")
+	inputView := input.View()
+	// Available width for the input field itself (subtract prompt + badge + spaces).
+	inputAreaWidth := innerWidth - lipgloss.Width(prompt) - lipgloss.Width(badge) - 2
+	if inputAreaWidth < 1 {
+		inputAreaWidth = 1
+	}
+	inputLine := lipgloss.NewStyle().
+		Width(innerWidth).
+		Render(prompt + truncateStr(inputView, inputAreaWidth) + "  " + badge)
+
+	divider := lipgloss.NewStyle().
+		Foreground(mutedColor).
+		Render(strings.Repeat("─", innerWidth))
+
+	// Build result rows.
+	var rows strings.Builder
+	switch {
+	case loading:
+		rows.WriteString(lipgloss.NewStyle().
+			Foreground(mutedColor).
+			Italic(true).
+			Width(innerWidth).
+			Render("Searching..."))
+	case len(results) == 0:
+		rows.WriteString(lipgloss.NewStyle().
+			Foreground(mutedColor).
+			Italic(true).
+			Width(innerWidth).
+			Render("No results"))
+	default:
+		visible := results
+		if len(visible) > maxVisible {
+			visible = visible[:maxVisible]
+		}
+		for i, r := range visible {
+			icon := r.Icon
+			badge := lipgloss.NewStyle().
+				Foreground(mutedColor).
+				Width(8).
+				Render(kindBadge(r.Kind))
+			label := r.Label
+			sub := r.Sub
+
+			// Compute available width for label + sub text.
+			iconW := runewidth.StringWidth(icon)
+			badgeW := lipgloss.Width(badge)
+			// "  " (2) between icon and badge, "  " (2) after badge, "  " (2) between label and sub.
+			fixedW := iconW + 2 + badgeW + 2
+			remaining := innerWidth - fixedW
+			if remaining < 1 {
+				remaining = 1
+			}
+			// Split remaining: 60% label, 40% sub.
+			labelW := (remaining * 60) / 100
+			subW := remaining - labelW
+			if subW < 4 {
+				subW = 0
+				labelW = remaining
+			}
+
+			labelStr := lipgloss.NewStyle().Width(labelW).Render(truncateStr(label, labelW))
+			subStr := ""
+			if subW > 0 {
+				subStr = lipgloss.NewStyle().
+					Foreground(mutedColor).
+					Width(subW).
+					Render(truncateStr(sub, subW))
+			}
+
+			line := fmt.Sprintf("%s  %s  %s%s", icon, badge, labelStr, subStr)
+
+			if i == selIdx {
+				line = lipgloss.NewStyle().
+					Background(lipgloss.Color(theme.Accent())).
+					Foreground(bgColor).
+					Bold(true).
+					Width(innerWidth).
+					Render(line)
+			} else {
+				line = lipgloss.NewStyle().
+					Foreground(fgColor).
+					Width(innerWidth).
+					Render(line)
+			}
+
+			if i > 0 {
+				rows.WriteString("\n")
+			}
+			rows.WriteString(line)
+		}
+		if len(results) > maxVisible {
+			more := fmt.Sprintf("…and %d more", len(results)-maxVisible)
+			rows.WriteString("\n" + lipgloss.NewStyle().Foreground(mutedColor).Width(innerWidth).Render(more))
+		}
+	}
+
+	content := inputLine + "\n" + divider + "\n" + rows.String()
+
+	return lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(accentColor).
+		Padding(0, 1).
+		Width(overlayWidth - 2). // -2: rounded border left+right
+		Render(content)
 }

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/m00nk0d3/nexus/internal/domain"
@@ -142,7 +143,7 @@ func TestRenderFull_ContainsFooterKeyHints(t *testing.T) {
 	}{
 		{
 			name:   "footer contains navigation and action hints",
-			wantIn: []string{"[Enter] Select", "[t] Settings", "[q/esc] Quit"},
+			wantIn: []string{"[Enter] Select", "[t] Settings", "[/] Fuzzy", "[q/esc]"},
 		},
 		{
 			name:   "action bar contains worktree commands",
@@ -1176,7 +1177,8 @@ func TestRenderFull_FooterContainsTabAndJKHints(t *testing.T) {
 	assert.Contains(t, view, "[j/k]")
 	// Old hints must still be present
 	assert.Contains(t, view, "[Enter] Select")
-	assert.Contains(t, view, "[q/esc] Quit")
+	assert.Contains(t, view, "[q/esc]")
+	assert.Contains(t, view, "[/] Fuzzy")
 }
 
 // ---------------------------------------------------------------------------
@@ -2192,3 +2194,145 @@ func TestPathsEqual_NormalisedComparison(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Phase 3: Fuzzy Overlay tests
+// ---------------------------------------------------------------------------
+
+// TestRenderFuzzyOverlay_LoadingState verifies that the loading state shows
+// "Searching..." when no results are available yet.
+func TestRenderFuzzyOverlay_LoadingState(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+
+	result := renderFuzzyOverlay(ti, nil, 0, theme, true, 120)
+
+	assert.Contains(t, result, "Searching...")
+}
+
+// TestRenderFuzzyOverlay_EmptyQuery verifies that all items are shown when the
+// query is empty and loading is false.
+func TestRenderFuzzyOverlay_EmptyQuery(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+
+	items := []domain.SearchResult{
+		{Kind: domain.KindWorktree, Icon: "🗂", Label: "feat/issue-42-auth", Sub: "worktree"},
+		{Kind: domain.KindIssue, Icon: "📌", Label: "#42 Fix JWT auth", Sub: "#42"},
+	}
+
+	result := renderFuzzyOverlay(ti, items, 0, theme, false, 120)
+
+	assert.Contains(t, result, "feat/issue-42-auth")
+	assert.Contains(t, result, "#42 Fix JWT auth")
+	// Should not show "No results" when there are items
+	assert.NotContains(t, result, "No results")
+}
+
+// TestRenderFuzzyOverlay_NoMatches verifies that "No results" is shown when
+// the results slice is empty and loading is false.
+func TestRenderFuzzyOverlay_NoMatches(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+	ti.SetValue("xyzzy-no-match")
+
+	result := renderFuzzyOverlay(ti, nil, 0, theme, false, 120)
+
+	assert.Contains(t, result, "No results")
+}
+
+// TestRenderFuzzyOverlay_ResultsPresent verifies that result rows include the
+// icon, kind badge, label, and sub text.
+func TestRenderFuzzyOverlay_ResultsPresent(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+	ti.SetValue("auth")
+
+	items := []domain.SearchResult{
+		{Kind: domain.KindWorktree, Icon: "🗂", Label: "feat/issue-42-auth", Sub: ""},
+		{Kind: domain.KindIssue, Icon: "📌", Label: "Fix auth bug", Sub: "#42"},
+		{Kind: domain.KindPR, Icon: "🔀", Label: "Add auth middleware", Sub: "#38"},
+		{Kind: domain.KindFile, Icon: "📄", Label: "internal/auth/jwt.go", Sub: ""},
+	}
+
+	result := renderFuzzyOverlay(ti, items, 0, theme, false, 120)
+
+	assert.Contains(t, result, "feat/issue-42-auth")
+	assert.Contains(t, result, "Fix auth bug")
+	assert.Contains(t, result, "Add auth middleware")
+	assert.Contains(t, result, "internal/auth/jwt.go")
+	assert.Contains(t, result, "worktree")
+	assert.Contains(t, result, "issue")
+	assert.Contains(t, result, "pr")
+	assert.Contains(t, result, "file")
+}
+
+// TestRenderFuzzyOverlay_SelectedRowDistinct verifies that the selected row
+// index is rendered distinctly from unselected rows (contains the selected label).
+func TestRenderFuzzyOverlay_SelectedRowDistinct(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+
+	items := []domain.SearchResult{
+		{Kind: domain.KindWorktree, Icon: "🗂", Label: "worktree-alpha", Sub: ""},
+		{Kind: domain.KindWorktree, Icon: "🗂", Label: "worktree-beta", Sub: ""},
+		{Kind: domain.KindWorktree, Icon: "🗂", Label: "worktree-gamma", Sub: ""},
+	}
+
+	tests := []struct {
+		name        string
+		selIdx      int
+		wantPresent string
+	}{
+		{"first item selected", 0, "worktree-alpha"},
+		{"second item selected", 1, "worktree-beta"},
+		{"third item selected", 2, "worktree-gamma"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderFuzzyOverlay(ti, items, tt.selIdx, theme, false, 120)
+			assert.Contains(t, result, tt.wantPresent)
+		})
+	}
+}
+
+// TestRenderFuzzyOverlay_InputVisible verifies the query text appears in the overlay.
+func TestRenderFuzzyOverlay_InputVisible(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+	// Don't focus the input in tests — just verify the value is shown.
+	ti.SetValue("jwt")
+
+	items := []domain.SearchResult{
+		{Kind: domain.KindFile, Icon: "📄", Label: "auth/jwt.go", Sub: ""},
+	}
+
+	result := renderFuzzyOverlay(ti, items, 0, theme, false, 120)
+
+	assert.Contains(t, result, "[/]")
+	assert.Contains(t, result, "auth/jwt.go")
+}
+
+// TestRenderFuzzyOverlay_KindBadges verifies that kindBadge returns the expected
+// display string for each known ResultKind.
+func TestRenderFuzzyOverlay_KindBadges(t *testing.T) {
+	tests := []struct {
+		kind domain.ResultKind
+		want string
+	}{
+		{domain.KindWorktree, "worktree"},
+		{domain.KindIssue, "issue"},
+		{domain.KindPR, "pr"},
+		{domain.KindFile, "file"},
+		{domain.KindBranch, "branch"},
+		{domain.KindAgent, "agent"},
+		{domain.KindCommit, "commit"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.kind), func(t *testing.T) {
+			assert.Contains(t, kindBadge(tt.kind), tt.want)
+		})
+	}
+}
+

--- a/internal/data/agent_history.go
+++ b/internal/data/agent_history.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 )
@@ -14,6 +15,14 @@ type AgentHistoryEntry struct {
 	ExitCode   int    // Process exit code (0 = success)
 	StartedAt  time.Time
 	EndedAt    time.Time
+}
+
+// AgentRun is a lightweight read model for agent history entries, used by the
+// fuzzy finder to surface recent AI agent invocations.
+type AgentRun struct {
+	AgentName string
+	Prompt    string
+	StartedAt time.Time
 }
 
 // LogAgentRun inserts an agent invocation record into the agent_history table.
@@ -33,4 +42,53 @@ func LogAgentRun(db *DB, entry AgentHistoryEntry) error {
 		return fmt.Errorf("log agent run: %w", err)
 	}
 	return nil
+}
+
+// GetAgentHistory returns up to the last 50 agent history entries ordered by
+// most-recent first (ORDER BY id DESC LIMIT 50). An empty database returns an
+// empty slice and no error. NULL prompt values are returned as empty strings;
+// NULL or missing started_at values are returned as the zero time.Time.
+func GetAgentHistory(db *DB) ([]AgentRun, error) {
+	rows, err := db.Conn.Query(
+		`SELECT agent_name, prompt, started_at
+		 FROM agent_history
+		 ORDER BY id DESC
+		 LIMIT 50`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get agent history: %w", err)
+	}
+	defer rows.Close()
+
+	var runs []AgentRun
+	for rows.Next() {
+		var (
+			agentName string
+			prompt    sql.NullString
+			startedAt sql.NullString
+		)
+		if err := rows.Scan(&agentName, &prompt, &startedAt); err != nil {
+			return nil, fmt.Errorf("get agent history: scan row: %w", err)
+		}
+		run := AgentRun{
+			AgentName: agentName,
+		}
+		if prompt.Valid {
+			run.Prompt = prompt.String
+		}
+		if startedAt.Valid && startedAt.String != "" {
+			if t, err := parseSessionTime(startedAt.String); err == nil {
+				run.StartedAt = t
+			}
+			// on parse error, StartedAt stays as zero time — non-fatal
+		}
+		runs = append(runs, run)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("get agent history: %w", err)
+	}
+	if runs == nil {
+		runs = []AgentRun{}
+	}
+	return runs, nil
 }

--- a/internal/data/agent_history_test.go
+++ b/internal/data/agent_history_test.go
@@ -124,3 +124,82 @@ func TestLogAgentRun_ClosedDB(t *testing.T) {
 	assert.Contains(t, err.Error(), "log agent run",
 		"error should include 'log agent run' context string")
 }
+
+// TestGetAgentHistory verifies the GetAgentHistory function across a range of scenarios.
+func TestGetAgentHistory(t *testing.T) {
+	t.Run("empty DB returns empty slice", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		runs, err := data.GetAgentHistory(db)
+		require.NoError(t, err)
+		assert.Empty(t, runs)
+	})
+
+	t.Run("single inserted run returns correct fields", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		now := time.Now().UTC().Truncate(time.Second)
+		entry := data.AgentHistoryEntry{
+			AgentName: "copilot",
+			Prompt:    "fix the null pointer",
+			ExitCode:  0,
+			StartedAt: now,
+			EndedAt:   now.Add(5 * time.Second),
+		}
+		require.NoError(t, data.LogAgentRun(db, entry))
+
+		runs, err := data.GetAgentHistory(db)
+		require.NoError(t, err)
+		require.Len(t, runs, 1)
+		assert.Equal(t, "copilot", runs[0].AgentName)
+		assert.Equal(t, "fix the null pointer", runs[0].Prompt)
+		assert.Equal(t, now, runs[0].StartedAt)
+	})
+
+	t.Run("multiple runs returns all of them", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		for i := 0; i < 3; i++ {
+			entry := data.AgentHistoryEntry{
+				AgentName: "copilot",
+				Prompt:    "prompt",
+				ExitCode:  0,
+				StartedAt: time.Now(),
+				EndedAt:   time.Now(),
+			}
+			require.NoError(t, data.LogAgentRun(db, entry))
+		}
+
+		runs, err := data.GetAgentHistory(db)
+		require.NoError(t, err)
+		assert.Len(t, runs, 3)
+		// Spot-check that the agent name is correct.
+		assert.Equal(t, "copilot", runs[0].AgentName)
+	})
+
+	t.Run("run with NULL prompt returns empty string", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		// Insert a row with a NULL prompt directly to bypass AgentHistoryEntry.
+		_, err = db.Conn.Exec(
+			`INSERT INTO agent_history (agent_name, prompt, exit_code, started_at, ended_at)
+			 VALUES (?, NULL, ?, ?, ?)`,
+			"claude", 0, time.Now().UTC().Format(time.RFC3339), time.Now().UTC().Format(time.RFC3339),
+		)
+		require.NoError(t, err)
+
+		runs, err := data.GetAgentHistory(db)
+		require.NoError(t, err)
+		require.Len(t, runs, 1)
+		assert.Equal(t, "claude", runs[0].AgentName)
+		assert.Equal(t, "", runs[0].Prompt, "NULL prompt should be empty string")
+	})
+}

--- a/internal/domain/search.go
+++ b/internal/domain/search.go
@@ -1,0 +1,23 @@
+package domain
+
+// ResultKind identifies the kind of search result.
+type ResultKind string
+
+const (
+	KindWorktree ResultKind = "worktree"
+	KindIssue    ResultKind = "issue"
+	KindPR       ResultKind = "pr"
+	KindFile     ResultKind = "file"
+	KindBranch   ResultKind = "branch"
+	KindAgent    ResultKind = "agent"
+	KindCommit   ResultKind = "commit"
+)
+
+// SearchResult is a unified result type returned by the fuzzy finder across all sources.
+type SearchResult struct {
+	Kind    ResultKind // worktree | issue | pr | file | branch | agent | commit
+	Label   string     // primary display text
+	Sub     string     // secondary info (issue number, branch, etc.)
+	Icon    string     // emoji prefix
+	Payload any        // domain.Worktree | domain.Issue | domain.PullRequest | string
+}

--- a/internal/fuzzy/fuzzy.go
+++ b/internal/fuzzy/fuzzy.go
@@ -74,7 +74,7 @@ func Score(query, candidate string) int {
 // and the remainder are sorted highest-score-first.
 //
 // Note: scoring is performed against item.Label only; item.Sub matching is
-// deferred to a later phase.
+// deferred to a later phase (e.g. searching "#42" won't surface issue #42 by number).
 func FilterAndRank(query string, items []domain.SearchResult) []domain.SearchResult {
 	if query == "" {
 		out := make([]domain.SearchResult, len(items))

--- a/internal/fuzzy/fuzzy.go
+++ b/internal/fuzzy/fuzzy.go
@@ -1,0 +1,107 @@
+package fuzzy
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+)
+
+// Score computes a fuzzy match score between query and candidate.
+//
+// Matching is case-insensitive and uses subsequence logic: every rune in query
+// must appear in candidate in order, but need not be contiguous.
+//
+// Returns 0 when:
+//   - query is empty
+//   - query is not a subsequence of candidate
+//
+// A positive score reflects match quality:
+//   - Consecutive character runs contribute run_length² to the score (match density).
+//   - An earlier first-match position contributes a position bonus equal to
+//     len(candidate) - firstMatchIndex.
+func Score(query, candidate string) int {
+	if query == "" {
+		return 0
+	}
+
+	q := strings.ToLower(query)
+	c := strings.ToLower(candidate)
+
+	qRunes := []rune(q)
+	cRunes := []rune(c)
+
+	qi := 0          // index into query runes
+	firstMatch := -1 // rune index of first matched character in candidate
+	run := 0         // current consecutive run length
+	totalScore := 0
+
+	for ci := 0; ci < len(cRunes) && qi < len(qRunes); ci++ {
+		if cRunes[ci] == qRunes[qi] {
+			if firstMatch == -1 {
+				firstMatch = ci
+			}
+			qi++
+			run++
+		} else {
+			if run > 0 {
+				totalScore += run * run
+			}
+			run = 0
+		}
+	}
+	// flush any trailing run
+	if run > 0 {
+		totalScore += run * run
+	}
+
+	// not all query runes matched
+	if qi < len(qRunes) {
+		return 0
+	}
+
+	// position bonus: favour matches that start earlier
+	positionBonus := len(cRunes) - firstMatch
+	totalScore += positionBonus
+
+	return totalScore
+}
+
+// FilterAndRank filters items by query and returns them sorted by score descending.
+//
+// When query is empty every item is returned in its original order. Otherwise
+// items are scored via Score(query, item.Label); items that score 0 are dropped
+// and the remainder are sorted highest-score-first.
+//
+// Note: scoring is performed against item.Label only; item.Sub matching is
+// deferred to a later phase.
+func FilterAndRank(query string, items []domain.SearchResult) []domain.SearchResult {
+	if query == "" {
+		out := make([]domain.SearchResult, len(items))
+		copy(out, items)
+		return out
+	}
+
+	type scored struct {
+		item  domain.SearchResult
+		score int
+	}
+
+	hits := make([]scored, 0, len(items))
+	for _, item := range items {
+		s := Score(query, item.Label)
+		if s > 0 {
+			hits = append(hits, scored{item, s})
+		}
+	}
+
+	sort.Slice(hits, func(i, j int) bool {
+		return hits[i].score > hits[j].score
+	})
+
+	out := make([]domain.SearchResult, len(hits))
+	for i, h := range hits {
+		out[i] = h.item
+	}
+	return out
+}

--- a/internal/fuzzy/fuzzy_test.go
+++ b/internal/fuzzy/fuzzy_test.go
@@ -1,0 +1,201 @@
+package fuzzy_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/m00nk0d3/nexus/internal/domain"
+	"github.com/m00nk0d3/nexus/internal/fuzzy"
+)
+
+// ---------------------------------------------------------------------------
+// Score tests
+// ---------------------------------------------------------------------------
+
+func TestScore(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		query     string
+		candidate string
+		wantGT    int  // score must be > this value (use -1 to skip)
+		wantEQ    *int // score must equal this value (nil to skip)
+		wantZero  bool // score must be 0
+	}{
+		{
+			name:      "exact match gives positive score",
+			query:     "abc",
+			candidate: "abc",
+			wantGT:    0,
+		},
+		{
+			name:      "subsequence match gives positive score",
+			query:     "abc",
+			candidate: "aXbXc",
+			wantGT:    0,
+		},
+		{
+			name:      "non-match returns zero",
+			query:     "xyz",
+			candidate: "abc",
+			wantZero:  true,
+		},
+		{
+			name:      "empty query returns zero",
+			query:     "",
+			candidate: "anything",
+			wantZero:  true,
+		},
+		{
+			name:      "case insensitive: upper query matches lower candidate",
+			query:     "ABC",
+			candidate: "abc",
+			wantGT:    0,
+		},
+		{
+			name:      "case insensitive: same score regardless of case",
+			query:     "ABC",
+			candidate: "abc",
+			// verified via the consecutive-match test below
+			wantGT: 0,
+		},
+		{
+			name:      "consecutive chars score higher than spread out",
+			query:     "abc",
+			candidate: "abcXX",
+			// score must be > Score("abc","aXbXc") — tested separately below
+			wantGT: 0,
+		},
+		{
+			name:      "query longer than candidate is no match",
+			query:     "abcdef",
+			candidate: "abc",
+			wantZero:  true,
+		},
+		{
+			name:      "single char match",
+			query:     "a",
+			candidate: "banana",
+			wantGT:    0,
+		},
+		{
+			name:      "query not a subsequence returns zero",
+			query:     "ba",
+			candidate: "abc", // 'b' is at index 1; 'a' must appear at index >=2 — it does not
+			wantZero:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := fuzzy.Score(tc.query, tc.candidate)
+			if tc.wantZero {
+				assert.Equal(t, 0, got, "Score(%q, %q) should be 0", tc.query, tc.candidate)
+				return
+			}
+			if tc.wantEQ != nil {
+				assert.Equal(t, *tc.wantEQ, got, "Score(%q, %q) unexpected value", tc.query, tc.candidate)
+				return
+			}
+			if tc.wantGT >= 0 {
+				assert.Greater(t, got, tc.wantGT, "Score(%q, %q) should be > %d", tc.query, tc.candidate, tc.wantGT)
+			}
+		})
+	}
+}
+
+func TestScore_CaseInsensitiveSymmetry(t *testing.T) {
+	t.Parallel()
+	lower := fuzzy.Score("abc", "abc")
+	upper := fuzzy.Score("ABC", "abc")
+	assert.Equal(t, lower, upper, "Score should be case-insensitive")
+}
+
+func TestScore_ConsecutiveBeatsSpread(t *testing.T) {
+	t.Parallel()
+	consecutive := fuzzy.Score("abc", "abcXX")
+	spread := fuzzy.Score("abc", "aXbXc")
+	assert.Greater(t, consecutive, spread,
+		"consecutive match Score(%q,%q)=%d should beat spread Score(%q,%q)=%d",
+		"abc", "abcXX", consecutive,
+		"abc", "aXbXc", spread,
+	)
+}
+
+func TestScore_NotSubsequence(t *testing.T) {
+	t.Parallel()
+	// "ba" is not a subsequence of "abc": 'b' is at index 1, then 'a' must
+	// appear at index >=2 — it does not.
+	assert.Equal(t, 0, fuzzy.Score("ba", "abc"))
+}
+
+// ---------------------------------------------------------------------------
+// FilterAndRank tests
+// ---------------------------------------------------------------------------
+
+func makeResults(labels ...string) []domain.SearchResult {
+	out := make([]domain.SearchResult, len(labels))
+	for i, l := range labels {
+		out[i] = domain.SearchResult{Label: l, Kind: domain.KindFile}
+	}
+	return out
+}
+
+func TestFilterAndRank_EmptyQueryReturnsAll(t *testing.T) {
+	t.Parallel()
+	items := makeResults("foo", "bar", "baz")
+	got := fuzzy.FilterAndRank("", items)
+	assert.Equal(t, items, got, "empty query should return all items in original order")
+}
+
+func TestFilterAndRank_FiltersNonMatches(t *testing.T) {
+	t.Parallel()
+	items := makeResults("apple", "banana", "cherry")
+	got := fuzzy.FilterAndRank("ban", items)
+	assert.Len(t, got, 1)
+	assert.Equal(t, "banana", got[0].Label)
+}
+
+func TestFilterAndRank_SortsByScoreDescending(t *testing.T) {
+	t.Parallel()
+	// "abc" consecutive match beats "aXbXc" spread match
+	items := makeResults("aXbXc", "abcXX")
+	got := fuzzy.FilterAndRank("abc", items)
+	assert.Len(t, got, 2)
+	assert.Equal(t, "abcXX", got[0].Label, "consecutive match should rank first")
+	assert.Equal(t, "aXbXc", got[1].Label, "spread match should rank second")
+}
+
+func TestFilterAndRank_NoMatchReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	items := makeResults("foo", "bar")
+	got := fuzzy.FilterAndRank("zzz", items)
+	assert.Empty(t, got)
+}
+
+func TestFilterAndRank_EmptyItemsReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	got := fuzzy.FilterAndRank("abc", nil)
+	assert.Empty(t, got)
+}
+
+func TestFilterAndRank_EmptyQueryEmptyItemsReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	got := fuzzy.FilterAndRank("", nil)
+	assert.Empty(t, got)
+}
+
+func TestFilterAndRank_PreservesOrderOnEmptyQuery(t *testing.T) {
+	t.Parallel()
+	items := makeResults("zzz", "aaa", "mmm")
+	got := fuzzy.FilterAndRank("", items)
+	labels := make([]string, len(got))
+	for i, r := range got {
+		labels[i] = r.Label
+	}
+	assert.Equal(t, []string{"zzz", "aaa", "mmm"}, labels)
+}

--- a/internal/tui/modal/branch_checkout.go
+++ b/internal/tui/modal/branch_checkout.go
@@ -1,0 +1,53 @@
+package modal
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// BranchCheckoutModal is a single-step confirmation modal for creating a worktree
+// from an existing local or remote branch selected via the fuzzy finder.
+type BranchCheckoutModal struct {
+	branch string
+	path   string
+}
+
+// NewBranchCheckoutModal creates a new BranchCheckoutModal for the given branch and
+// target worktree path.
+func NewBranchCheckoutModal(branch, path string) *BranchCheckoutModal {
+	return &BranchCheckoutModal{branch: branch, path: path}
+}
+
+// Init satisfies tea.Model.
+func (m *BranchCheckoutModal) Init() tea.Cmd { return nil }
+
+// Title returns the modal title for themed overlay rendering.
+func (m *BranchCheckoutModal) Title() string { return "Checkout Branch" }
+
+// Update handles y/n/Esc input and emits the appropriate confirmation or cancel message.
+func (m *BranchCheckoutModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch keyMsg.String() {
+	case "y", "Y":
+		branch, path := m.branch, m.path
+		return m, func() tea.Msg { return PRWorktreeCreateConfirmedMsg{Branch: branch, Path: path} }
+	case "n", "N", "esc":
+		return m, func() tea.Msg { return ModalCancelledMsg{} }
+	}
+
+	return m, nil
+}
+
+// View renders the branch checkout confirmation dialog.
+func (m *BranchCheckoutModal) View() string {
+	return fmt.Sprintf(
+		"Create worktree for branch %q?\n  Path: %s\n\n[y] confirm  [n / Esc] cancel",
+		m.branch,
+		m.path,
+	)
+}

--- a/internal/tui/modal/branch_checkout_test.go
+++ b/internal/tui/modal/branch_checkout_test.go
@@ -1,0 +1,87 @@
+package modal_test
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/tui/modal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBranchCheckoutModal_Title(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+	assert.Equal(t, "Checkout Branch", m.Title())
+}
+
+func TestBranchCheckoutModal_View(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+	view := m.View()
+	assert.Contains(t, view, "feat/login")
+	assert.Contains(t, view, "/worktrees/feat-login")
+	assert.Contains(t, view, "[y]")
+	assert.Contains(t, view, "[n")
+}
+
+func TestBranchCheckoutModal_ConfirmY(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	require.NotNil(t, next)
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	confirmed, ok := msg.(modal.PRWorktreeCreateConfirmedMsg)
+	require.True(t, ok, "expected PRWorktreeCreateConfirmedMsg, got %T", msg)
+	assert.Equal(t, "feat/login", confirmed.Branch)
+	assert.Equal(t, "/worktrees/feat-login", confirmed.Path)
+}
+
+func TestBranchCheckoutModal_ConfirmUpperY(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, ok := msg.(modal.PRWorktreeCreateConfirmedMsg)
+	assert.True(t, ok)
+}
+
+func TestBranchCheckoutModal_CancelN(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, ok := msg.(modal.ModalCancelledMsg)
+	assert.True(t, ok)
+}
+
+func TestBranchCheckoutModal_CancelEsc(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, ok := msg.(modal.ModalCancelledMsg)
+	assert.True(t, ok)
+}
+
+func TestBranchCheckoutModal_OtherKeyIsNoop(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	assert.Nil(t, cmd)
+	assert.Equal(t, m, next)
+}
+
+func TestBranchCheckoutModal_NonKeyMsgIsNoop(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	next, cmd := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	assert.Nil(t, cmd)
+	assert.Equal(t, m, next)
+}


### PR DESCRIPTION
Closes #68

Implements a global fuzzy finder overlay (/ or Ctrl+F from any view) that searches across worktrees, issues, PRs, files, branches, agent history, and commits simultaneously.

**What changed:**
- Phase 1: fuzzy engine — `Score` and `FilterAndRank` in `internal/tui/fuzzy/`
- Phase 2: async data aggregation — fetches files, branches, agent history, commits on open
- Phase 3: overlay UI — real-time filtered results panel with icons and type badges, integrates with theme system
- Phase 4: smart actions — Enter dispatches per result type (switch worktree, navigate to issue/PR, open file in $EDITOR, create worktree from branch)

**Why:** Navigating nexus required knowing which tab to check first and scrolling to find items. This lets you jump directly to anything from anywhere.

**Testing:** All existing tests pass. Fuzzy engine covered by unit tests in `internal/tui/fuzzy/`.