### PR TITLE
fix(worktree): scope worktree paths to repo name to prevent collisions

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -1169,16 +1169,18 @@ func branchSlug(branch string) string {
 }
 
 // prWorktreePath derives the filesystem path for a PR worktree using the same
-// convention as issue worktrees: ../worktrees/<branch-with-slashes-as-dashes>.
+// convention as issue worktrees: ../worktrees/<repo>/<branch-with-slashes-as-dashes>.
+// The repo name is included to avoid path collisions when multiple projects share the same parent directory.
 func prWorktreePath(repoPath, branch string) string {
-	return filepath.Join(filepath.Dir(repoPath), "worktrees", branchSlug(branch))
+	return filepath.Join(filepath.Dir(repoPath), "worktrees", filepath.Base(repoPath), branchSlug(branch))
 }
 
 // prReviewWorktreePath derives the filesystem path for a PR review worktree.
 // Uses naming convention pr-<number>-<branch-slug> as specified in issue #78.
+// The repo name is included to avoid path collisions when multiple projects share the same parent directory.
 func prReviewWorktreePath(repoPath string, prNumber int, branch string) string {
 	name := fmt.Sprintf("pr-%d-%s", prNumber, branchSlug(branch))
-	return filepath.Join(filepath.Dir(repoPath), "worktrees", name)
+	return filepath.Join(filepath.Dir(repoPath), "worktrees", filepath.Base(repoPath), name)
 }
 
 // provisionPRReviewWorktreeCmd returns a Cmd that provisions a worktree for the given PR.

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"testing"
 	"time"
 
@@ -1763,34 +1762,37 @@ func TestModel_A_Key_BinaryNotFound_SetsError(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestPRWorktreePath verifies that prWorktreePath produces the correct path
-// by replacing slashes in the branch name with dashes and joining under worktrees/.
+// by replacing slashes in the branch name with dashes and scoping under worktrees/<repo>/.
 func TestPRWorktreePath(t *testing.T) {
 	tests := []struct {
 		name     string
 		repoPath string
 		branch   string
-		wantSlug string // just the slug portion; full path is computed via filepath.Join
+		wantPath string
 	}{
 		{
 			name:     "simple branch no slashes",
 			repoPath: "/repos/nexus",
 			branch:   "main",
-			wantSlug: "main",
+			wantPath: "/repos/worktrees/nexus/main",
 		},
 		{
 			name:     "branch with slashes converted to dashes",
 			repoPath: "/repos/nexus",
 			branch:   "feat/issue-42-my-feature",
-			wantSlug: "feat-issue-42-my-feature",
+			wantPath: "/repos/worktrees/nexus/feat-issue-42-my-feature",
+		},
+		{
+			name:     "different repo does not collide with nexus",
+			repoPath: "/repos/nova",
+			branch:   "feat/issue-42-my-feature",
+			wantPath: "/repos/worktrees/nova/feat-issue-42-my-feature",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := prWorktreePath(tt.repoPath, tt.branch)
-			assert.True(t, strings.HasSuffix(got, tt.wantSlug),
-				"expected path to end with %q, got %q", tt.wantSlug, got)
-			assert.True(t, strings.Contains(got, "worktrees"),
-				"expected path to contain 'worktrees' directory, got %q", got)
+			assert.Equal(t, tt.wantPath, got)
 		})
 	}
 }
@@ -3466,42 +3468,49 @@ func TestUpdateModal_DoesNotSwallowGithubSyncedMsg(t *testing.T) {
 	assert.Equal(t, 42, m3.prs[0].Number)
 }
 
-// TestPRReviewWorktreePath verifies the pr-<number>-<branch-slug> naming convention.
+// TestPRReviewWorktreePath verifies the pr-<number>-<branch-slug> naming convention
+// and that paths are scoped to the repo name to avoid cross-project collisions.
 func TestPRReviewWorktreePath(t *testing.T) {
 	tests := []struct {
-		name       string
-		repoPath   string
-		prNumber   int
-		branch     string
-		wantSuffix string
+		name     string
+		repoPath string
+		prNumber int
+		branch   string
+		wantPath string
 	}{
 		{
-			name:       "simple branch name",
-			repoPath:   "/home/user/nexus",
-			prNumber:   42,
-			branch:     "feat-my-feature",
-			wantSuffix: "pr-42-feat-my-feature",
+			name:     "simple branch name",
+			repoPath: "/home/user/nexus",
+			prNumber: 42,
+			branch:   "feat-my-feature",
+			wantPath: "/home/user/worktrees/nexus/pr-42-feat-my-feature",
 		},
 		{
-			name:       "branch with slashes",
-			repoPath:   "/home/user/nexus",
-			prNumber:   7,
-			branch:     "feat/issue-7-login",
-			wantSuffix: "pr-7-feat-issue-7-login",
+			name:     "branch with slashes",
+			repoPath: "/home/user/nexus",
+			prNumber: 7,
+			branch:   "feat/issue-7-login",
+			wantPath: "/home/user/worktrees/nexus/pr-7-feat-issue-7-login",
 		},
 		{
-			name:       "main branch",
-			repoPath:   "/home/user/nexus",
-			prNumber:   1,
-			branch:     "main",
-			wantSuffix: "pr-1-main",
+			name:     "main branch",
+			repoPath: "/home/user/nexus",
+			prNumber: 1,
+			branch:   "main",
+			wantPath: "/home/user/worktrees/nexus/pr-1-main",
+		},
+		{
+			name:     "different repo does not collide with nexus",
+			repoPath: "/home/user/nova",
+			prNumber: 42,
+			branch:   "feat-my-feature",
+			wantPath: "/home/user/worktrees/nova/pr-42-feat-my-feature",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := prReviewWorktreePath(tt.repoPath, tt.prNumber, tt.branch)
-			assert.True(t, strings.HasSuffix(got, tt.wantSuffix),
-				"expected path to end with %q, got %q", tt.wantSuffix, got)
+			assert.Equal(t, tt.wantPath, got)
 		})
 	}
 }

--- a/internal/tui/modal/create.go
+++ b/internal/tui/modal/create.go
@@ -260,10 +260,12 @@ func (m *CreateModal) BranchName() string {
 	return fmt.Sprintf("%s/issue-%d-%s", m.SelectedType(), issue.Number, m.slugInput.Value())
 }
 
-// WorktreePath returns the filesystem path for the new worktree: ../worktrees/<type>-issue-<N>-<slug>.
+// WorktreePath returns the filesystem path for the new worktree: ../worktrees/<repo>/<type>-issue-<N>-<slug>.
+// The repo name is included to avoid path collisions when multiple projects share the same parent directory.
 func (m *CreateModal) WorktreePath() string {
 	slug := strings.ReplaceAll(m.BranchName(), "/", "-")
-	return filepath.Join(filepath.Dir(m.repoPath), "worktrees", slug)
+	repoName := filepath.Base(m.repoPath)
+	return filepath.Join(filepath.Dir(m.repoPath), "worktrees", repoName, slug)
 }
 
 // Title returns the modal title for themed overlay rendering.

--- a/internal/tui/modal/create_test.go
+++ b/internal/tui/modal/create_test.go
@@ -150,6 +150,35 @@ func TestCreateModal_WorktreePath_IsParentWorktreesDir(t *testing.T) {
 	assert.Contains(t, path, "worktrees")
 }
 
+func TestCreateModal_WorktreePath_IsScopedToRepoName(t *testing.T) {
+	tests := []struct {
+		name     string
+		repoPath string
+		wantPath string
+	}{
+		{
+			name:     "nexus repo scoped correctly",
+			repoPath: "/home/user/nexus",
+			wantPath: "/home/user/worktrees/nexus/feat-issue-5-create-delete-modals",
+		},
+		{
+			name:     "nova repo scoped correctly — no collision with nexus",
+			repoPath: "/home/user/nova",
+			wantPath: "/home/user/worktrees/nova/feat-issue-5-create-delete-modals",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewCreateModal(testIssues, tt.repoPath)
+			m.issueIdx = 0
+			m.typeIdx = 0 // feat
+			m.slugInput.SetValue("create-delete-modals")
+
+			assert.Equal(t, tt.wantPath, m.WorktreePath())
+		})
+	}
+}
+
 func TestCreateModal_Enter_AtConfirmStep_EmitsCreateMsg(t *testing.T) {
 	m := NewCreateModal(testIssues, "/home/user/repo")
 	m.step = stepConfirm


### PR DESCRIPTION
Closes #98

## What Changed

All three worktree path builder functions now include the repo name as an intermediate directory segment, scoping worktrees under `../worktrees/<repo>/` instead of the flat `../worktrees/`.

**Functions fixed:**
- `CreateModal.WorktreePath()` → `../worktrees/<repo>/<type>-issue-<N>-<slug>`
- `prWorktreePath()` → `../worktrees/<repo>/<branch-slug>`
- `prReviewWorktreePath()` → `../worktrees/<repo>/pr-<number>-<branch-slug>`

## Why

When two projects like `nexus` and `nova` share the same parent directory, the old flat layout produced identical paths (e.g. both resolving to `/home/moonkode/development/worktrees/feat-issue-42-foo`), causing git to fail with a path collision error.

## Testing

- Updated existing tests to assert exact scoped paths rather than just suffix/contains checks
- Added `TestCreateModal_WorktreePath_IsScopedToRepoName` covering the multi-repo collision scenario
- Added cross-project collision test case to `TestPRWorktreePath` and `TestPRReviewWorktreePath`
- All new and existing tests pass (one pre-existing unrelated failure in `TestBuildNewTabWithCmdCmd` is unchanged)