### PR TITLE
feat(fuzzy): phase 2 - async data aggregation search index

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
@@ -103,6 +104,14 @@ type updateCheckedMsg struct {
 
 // selfUpdateDoneMsg carries the result of a self-update attempt.
 type selfUpdateDoneMsg struct{ err error }
+
+// fuzzyOpenMsg is dispatched when the user opens the fuzzy finder.
+type fuzzyOpenMsg struct{}
+
+// fuzzyResultsReadyMsg is dispatched when the async search index build is complete.
+type fuzzyResultsReadyMsg struct {
+	results []domain.SearchResult
+}
 
 // clearErrorCmd returns a Cmd that fires clearErrorMsg after 5 seconds.
 func clearErrorCmd() tea.Cmd {
@@ -307,6 +316,11 @@ type Model struct {
 	// Claude prompt state
 	claudePromptActive bool            // true while the inline Claude prompt is open
 	claudePromptInput  textinput.Model // text input for entering the Claude prompt
+
+	// Fuzzy finder state
+	fuzzyFiles    []string              // files from git ls-files
+	fuzzyBranches []string              // branches from git branch -a
+	fuzzyAllItems []domain.SearchResult // full unfiltered search index
 }
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
@@ -972,6 +986,27 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.statusMsg = "✓ Updated successfully! Please restart nexus to use the new version."
 		return m, clearMsgCmd()
+
+	case fuzzyOpenMsg:
+		return m, m.buildSearchIndexCmd()
+
+	case fuzzyResultsReadyMsg:
+		m.fuzzyAllItems = msg.results
+		// Also extract the file and branch slices for convenience
+		m.fuzzyFiles = m.fuzzyFiles[:0]
+		m.fuzzyBranches = m.fuzzyBranches[:0]
+		for _, r := range msg.results {
+			switch r.Kind {
+			case domain.KindFile:
+				if f, ok := r.Payload.(string); ok {
+					m.fuzzyFiles = append(m.fuzzyFiles, f)
+				}
+			case domain.KindBranch:
+				if b, ok := r.Payload.(string); ok {
+					m.fuzzyBranches = append(m.fuzzyBranches, b)
+				}
+			}
+		}
 	}
 
 	return m, nil
@@ -1897,6 +1932,187 @@ func (m *Model) refreshWorktreesCmd() tea.Cmd {
 		cmd := internalexec.NewGitCommand(repoPath)
 		worktrees, err := cmd.ListWorktrees()
 		return worktreesRefreshedMsg{worktrees: worktrees, err: err}
+	}
+}
+
+// buildSearchIndexCmd builds the unified search index used by the fuzzy finder.
+// It concurrently fetches files, branches, agent history, and commits from the
+// repository, combining them with already-cached worktrees, issues, and PRs.
+// Errors from individual async sources are logged at debug level and skipped —
+// they are non-fatal so that a missing git binary or empty DB does not break
+// the fuzzy finder entirely.
+func (m *Model) buildSearchIndexCmd() tea.Cmd {
+	// Snapshot all model state upfront to avoid data races inside the goroutine.
+	worktrees := make([]domain.Worktree, len(m.Worktrees))
+	copy(worktrees, m.Worktrees)
+	issues := make([]domain.Issue, len(m.issues))
+	copy(issues, m.issues)
+	prs := make([]domain.PullRequest, len(m.prs))
+	copy(prs, m.prs)
+	repoPath := m.RepoPath
+	db := m.db
+
+	return func() tea.Msg {
+		var (
+			mu       sync.Mutex
+			allItems []domain.SearchResult
+			wg       sync.WaitGroup
+		)
+
+		// append is called from goroutines — always hold mu.
+		appendItems := func(items []domain.SearchResult) {
+			mu.Lock()
+			allItems = append(allItems, items...)
+			mu.Unlock()
+		}
+
+		// Seed from cached sources immediately (no I/O required).
+		var cached []domain.SearchResult
+		for _, wt := range worktrees {
+			cached = append(cached, domain.SearchResult{
+				Kind:    domain.KindWorktree,
+				Label:   wt.Path,
+				Sub:     wt.Branch,
+				Icon:    "🌿",
+				Payload: wt,
+			})
+		}
+		for _, iss := range issues {
+			cached = append(cached, domain.SearchResult{
+				Kind:    domain.KindIssue,
+				Label:   iss.Title,
+				Sub:     fmt.Sprintf("#%d", iss.Number),
+				Icon:    "🐛",
+				Payload: iss,
+			})
+		}
+		for _, pr := range prs {
+			cached = append(cached, domain.SearchResult{
+				Kind:    domain.KindPR,
+				Label:   pr.Title,
+				Sub:     fmt.Sprintf("#%d", pr.Number),
+				Icon:    "🔀",
+				Payload: pr,
+			})
+		}
+		appendItems(cached)
+
+		// git ls-files
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out, err := exec.Command("git", "-C", repoPath, "ls-files").Output()
+			if err != nil {
+				slog.Debug("buildSearchIndexCmd: git ls-files failed", "err", err)
+				return
+			}
+			var items []domain.SearchResult
+			for _, f := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+				if f == "" {
+					continue
+				}
+				items = append(items, domain.SearchResult{
+					Kind:    domain.KindFile,
+					Label:   f,
+					Sub:     "",
+					Icon:    "📄",
+					Payload: f,
+				})
+			}
+			appendItems(items)
+		}()
+
+		// git branch -a
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out, err := exec.Command("git", "-C", repoPath, "branch", "-a").Output()
+			if err != nil {
+				slog.Debug("buildSearchIndexCmd: git branch -a failed", "err", err)
+				return
+			}
+			var items []domain.SearchResult
+			for _, line := range strings.Split(string(out), "\n") {
+				// Strip leading "* " (current branch marker) or leading spaces.
+				b := strings.TrimPrefix(line, "* ")
+				b = strings.TrimSpace(b)
+				if b == "" {
+					continue
+				}
+				items = append(items, domain.SearchResult{
+					Kind:    domain.KindBranch,
+					Label:   b,
+					Sub:     "",
+					Icon:    "🌿",
+					Payload: b,
+				})
+			}
+			appendItems(items)
+		}()
+
+		// agent history
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if db == nil {
+				return
+			}
+			history, err := data.GetAgentHistory(db)
+			if err != nil {
+				slog.Debug("buildSearchIndexCmd: get agent history failed", "err", err)
+				return
+			}
+			var items []domain.SearchResult
+			for _, h := range history {
+				label := h.Prompt
+				if label == "" {
+					label = h.AgentName
+				}
+				items = append(items, domain.SearchResult{
+					Kind:    domain.KindAgent,
+					Label:   label,
+					Sub:     h.AgentName,
+					Icon:    "🤖",
+					Payload: h,
+				})
+			}
+			appendItems(items)
+		}()
+
+		// git log --oneline -50
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out, err := exec.Command("git", "-C", repoPath, "log", "--oneline", "-50").Output()
+			if err != nil {
+				slog.Debug("buildSearchIndexCmd: git log failed", "err", err)
+				return
+			}
+			var items []domain.SearchResult
+			for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+				if line == "" {
+					continue
+				}
+				// First token is the hash; the remainder is the message.
+				parts := strings.SplitN(line, " ", 2)
+				hash := parts[0]
+				message := ""
+				if len(parts) == 2 {
+					message = parts[1]
+				}
+				items = append(items, domain.SearchResult{
+					Kind:    domain.KindCommit,
+					Label:   message,
+					Sub:     hash,
+					Icon:    "📦",
+					Payload: hash,
+				})
+			}
+			appendItems(items)
+		}()
+
+		wg.Wait()
+		return fuzzyResultsReadyMsg{results: allItems}
 	}
 }
 

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3862,3 +3862,100 @@ func TestModel_RKey_NotFiredWithModalOpen(t *testing.T) {
 	require.True(t, ok)
 	assert.False(t, result.syncing, "'r' with modal open must NOT set syncing=true")
 }
+
+// TestBuildSearchIndexCmd verifies that buildSearchIndexCmd returns a
+// fuzzyResultsReadyMsg containing results for the cached sources (worktrees,
+// issues, PRs) and gracefully skips the async git/agent sources when there is
+// no real git repository at m.RepoPath.
+func TestBuildSearchIndexCmd(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+
+	// Use a temp dir as the repo path so all git commands fail gracefully.
+	m.RepoPath = t.TempDir()
+
+	m.Worktrees = []domain.Worktree{
+		{Path: "/wt/main", Branch: "main"},
+		{Path: "/wt/feat", Branch: "feat/thing"},
+	}
+	m.issues = []domain.Issue{
+		{Number: 1, Title: "First issue"},
+		{Number: 2, Title: "Second issue"},
+	}
+	m.prs = []domain.PullRequest{
+		{Number: 10, Title: "Fix something", Branch: "fix/something"},
+	}
+
+	cmd := m.buildSearchIndexCmd()
+	require.NotNil(t, cmd, "buildSearchIndexCmd should return a non-nil tea.Cmd")
+
+	// Execute the returned Cmd to obtain the message.
+	msg := cmd()
+
+	ready, ok := msg.(fuzzyResultsReadyMsg)
+	require.True(t, ok, "expected fuzzyResultsReadyMsg, got %T", msg)
+
+	// Count results per kind.
+	kindCounts := map[domain.ResultKind]int{}
+	for _, r := range ready.results {
+		kindCounts[r.Kind]++
+	}
+
+	assert.Equal(t, 2, kindCounts[domain.KindWorktree], "should have 2 worktree results")
+	assert.Equal(t, 2, kindCounts[domain.KindIssue], "should have 2 issue results")
+	assert.Equal(t, 1, kindCounts[domain.KindPR], "should have 1 PR result")
+
+	// Verify a worktree result has the correct fields.
+	var wtResult *domain.SearchResult
+	for i := range ready.results {
+		if ready.results[i].Kind == domain.KindWorktree && ready.results[i].Sub == "main" {
+			wtResult = &ready.results[i]
+			break
+		}
+	}
+	require.NotNil(t, wtResult, "should find worktree result for 'main' branch")
+	assert.Equal(t, "/wt/main", wtResult.Label)
+	assert.Equal(t, "🌿", wtResult.Icon)
+}
+
+// TestUpdate_FuzzyOpenMsg verifies that sending fuzzyOpenMsg to Update() returns
+// a non-nil command (the async search index build).
+func TestUpdate_FuzzyOpenMsg(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+	m.RepoPath = t.TempDir()
+
+	_, cmd := m.Update(fuzzyOpenMsg{})
+	assert.NotNil(t, cmd, "fuzzyOpenMsg should return a non-nil Cmd")
+}
+
+// TestUpdate_FuzzyResultsReadyMsg verifies that fuzzyResultsReadyMsg populates
+// m.fuzzyAllItems and extracts the file/branch convenience slices correctly.
+func TestUpdate_FuzzyResultsReadyMsg(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+
+	results := []domain.SearchResult{
+		{Kind: domain.KindFile, Label: "cmd/main.go", Icon: "📄", Payload: "cmd/main.go"},
+		{Kind: domain.KindFile, Label: "internal/app.go", Icon: "📄", Payload: "internal/app.go"},
+		{Kind: domain.KindBranch, Label: "main", Icon: "🌿", Payload: "main"},
+		{Kind: domain.KindBranch, Label: "feat/foo", Icon: "🌿", Payload: "feat/foo"},
+		{Kind: domain.KindWorktree, Label: "/wt/main", Sub: "main", Icon: "🌿", Payload: domain.Worktree{Path: "/wt/main", Branch: "main"}},
+		{Kind: domain.KindIssue, Label: "Fix bug", Sub: "#1", Icon: "🐛", Payload: domain.Issue{Number: 1, Title: "Fix bug"}},
+	}
+
+	updated, cmd := m.Update(fuzzyResultsReadyMsg{results: results})
+	assert.Nil(t, cmd, "fuzzyResultsReadyMsg should return nil Cmd")
+
+	result, ok := updated.(*Model)
+	require.True(t, ok)
+
+	assert.Len(t, result.fuzzyAllItems, 6, "fuzzyAllItems should contain all 6 results")
+	assert.Len(t, result.fuzzyFiles, 2, "fuzzyFiles should contain 2 file results")
+	assert.Len(t, result.fuzzyBranches, 2, "fuzzyBranches should contain 2 branch results")
+
+	assert.Contains(t, result.fuzzyFiles, "cmd/main.go")
+	assert.Contains(t, result.fuzzyFiles, "internal/app.go")
+	assert.Contains(t, result.fuzzyBranches, "main")
+	assert.Contains(t, result.fuzzyBranches, "feat/foo")
+}

--- a/internal/data/agent_history.go
+++ b/internal/data/agent_history.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 )
@@ -14,6 +15,14 @@ type AgentHistoryEntry struct {
 	ExitCode   int    // Process exit code (0 = success)
 	StartedAt  time.Time
 	EndedAt    time.Time
+}
+
+// AgentRun is a lightweight read model for agent history entries, used by the
+// fuzzy finder to surface recent AI agent invocations.
+type AgentRun struct {
+	AgentName string
+	Prompt    string
+	StartedAt time.Time
 }
 
 // LogAgentRun inserts an agent invocation record into the agent_history table.
@@ -33,4 +42,53 @@ func LogAgentRun(db *DB, entry AgentHistoryEntry) error {
 		return fmt.Errorf("log agent run: %w", err)
 	}
 	return nil
+}
+
+// GetAgentHistory returns up to the last 50 agent history entries ordered by
+// most-recent first (ORDER BY id DESC LIMIT 50). An empty database returns an
+// empty slice and no error. NULL prompt values are returned as empty strings;
+// NULL or missing started_at values are returned as the zero time.Time.
+func GetAgentHistory(db *DB) ([]AgentRun, error) {
+	rows, err := db.Conn.Query(
+		`SELECT agent_name, prompt, started_at
+		 FROM agent_history
+		 ORDER BY id DESC
+		 LIMIT 50`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get agent history: %w", err)
+	}
+	defer rows.Close()
+
+	var runs []AgentRun
+	for rows.Next() {
+		var (
+			agentName string
+			prompt    sql.NullString
+			startedAt sql.NullString
+		)
+		if err := rows.Scan(&agentName, &prompt, &startedAt); err != nil {
+			return nil, fmt.Errorf("get agent history: scan row: %w", err)
+		}
+		run := AgentRun{
+			AgentName: agentName,
+		}
+		if prompt.Valid {
+			run.Prompt = prompt.String
+		}
+		if startedAt.Valid && startedAt.String != "" {
+			if t, err := parseSessionTime(startedAt.String); err == nil {
+				run.StartedAt = t
+			}
+			// on parse error, StartedAt stays as zero time — non-fatal
+		}
+		runs = append(runs, run)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("get agent history: %w", err)
+	}
+	if runs == nil {
+		runs = []AgentRun{}
+	}
+	return runs, nil
 }

--- a/internal/data/agent_history_test.go
+++ b/internal/data/agent_history_test.go
@@ -124,3 +124,82 @@ func TestLogAgentRun_ClosedDB(t *testing.T) {
 	assert.Contains(t, err.Error(), "log agent run",
 		"error should include 'log agent run' context string")
 }
+
+// TestGetAgentHistory verifies the GetAgentHistory function across a range of scenarios.
+func TestGetAgentHistory(t *testing.T) {
+	t.Run("empty DB returns empty slice", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		runs, err := data.GetAgentHistory(db)
+		require.NoError(t, err)
+		assert.Empty(t, runs)
+	})
+
+	t.Run("single inserted run returns correct fields", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		now := time.Now().UTC().Truncate(time.Second)
+		entry := data.AgentHistoryEntry{
+			AgentName: "copilot",
+			Prompt:    "fix the null pointer",
+			ExitCode:  0,
+			StartedAt: now,
+			EndedAt:   now.Add(5 * time.Second),
+		}
+		require.NoError(t, data.LogAgentRun(db, entry))
+
+		runs, err := data.GetAgentHistory(db)
+		require.NoError(t, err)
+		require.Len(t, runs, 1)
+		assert.Equal(t, "copilot", runs[0].AgentName)
+		assert.Equal(t, "fix the null pointer", runs[0].Prompt)
+		assert.Equal(t, now, runs[0].StartedAt)
+	})
+
+	t.Run("multiple runs returns all of them", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		for i := 0; i < 3; i++ {
+			entry := data.AgentHistoryEntry{
+				AgentName: "copilot",
+				Prompt:    "prompt",
+				ExitCode:  0,
+				StartedAt: time.Now(),
+				EndedAt:   time.Now(),
+			}
+			require.NoError(t, data.LogAgentRun(db, entry))
+		}
+
+		runs, err := data.GetAgentHistory(db)
+		require.NoError(t, err)
+		assert.Len(t, runs, 3)
+		// Spot-check that the agent name is correct.
+		assert.Equal(t, "copilot", runs[0].AgentName)
+	})
+
+	t.Run("run with NULL prompt returns empty string", func(t *testing.T) {
+		db, err := data.NewDB(":memory:")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		// Insert a row with a NULL prompt directly to bypass AgentHistoryEntry.
+		_, err = db.Conn.Exec(
+			`INSERT INTO agent_history (agent_name, prompt, exit_code, started_at, ended_at)
+			 VALUES (?, NULL, ?, ?, ?)`,
+			"claude", 0, time.Now().UTC().Format(time.RFC3339), time.Now().UTC().Format(time.RFC3339),
+		)
+		require.NoError(t, err)
+
+		runs, err := data.GetAgentHistory(db)
+		require.NoError(t, err)
+		require.Len(t, runs, 1)
+		assert.Equal(t, "claude", runs[0].AgentName)
+		assert.Equal(t, "", runs[0].Prompt, "NULL prompt should be empty string")
+	})
+}


### PR DESCRIPTION
Closes #70

## What Changed
Implements the async search index aggregation layer for the Global Fuzzy Finder (part of #68). When `fuzzyOpenMsg` fires, all non-cached sources are fetched concurrently and merged with already-in-memory data to produce a unified `[]domain.SearchResult` index.

## Why Changed
Phase 1 (#69) established the `SearchResult` type and the fuzzy engine. This phase wires up all data sources so the finder has a complete, live index to search against — without blocking the TUI during fetch.

## Changes

### `internal/data/agent_history.go`
- Added `AgentRun` struct (read model with `AgentName`, `Prompt`, `StartedAt`)
- Added `GetAgentHistory(db *DB) ([]AgentRun, error)` — queries last 50 agent runs, handles NULL prompt and NULL `started_at` gracefully

### `cmd/nexus/app.go`
- New messages: `fuzzyOpenMsg` and `fuzzyResultsReadyMsg`
- New `Model` fields: `fuzzyFiles`, `fuzzyBranches`, `fuzzyAllItems`
- New `buildSearchIndexCmd()`: snapshots model state, builds SearchResults from cached sources immediately, then concurrently fetches files (`git ls-files`), branches (`git branch -a`), commits (`git log --oneline -50`), and agent history via 4 goroutines + `sync.WaitGroup` + `sync.Mutex`; git errors are logged at `slog.Debug` and skipped (non-fatal)
- `Update()` handlers: `fuzzyOpenMsg` → triggers `buildSearchIndexCmd`; `fuzzyResultsReadyMsg` → populates `fuzzyAllItems`, extracts `fuzzyFiles`/`fuzzyBranches`

## Testing
- `TestGetAgentHistory` — 4 sub-tests: empty DB, single run, multiple runs, NULL prompt
- `TestBuildSearchIndexCmd` — verifies correct cached-source counts + graceful degradation with no real git repo
- `TestUpdate_FuzzyOpenMsg` — verifies non-nil command returned
- `TestUpdate_FuzzyResultsReadyMsg` — verifies all three model fields populated correctly

All new tests pass. Pre-existing `TestBuildNewTabWithCmdCmd` failures are unrelated to this change (confirmed on base branch).