### PR TITLE
feat(fuzzy): phase 3 - overlay UI (real-time filtered results panel)

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -20,6 +20,7 @@ import (
 	"github.com/m00nk0d3/nexus/internal/data"
 	"github.com/m00nk0d3/nexus/internal/domain"
 	internalexec "github.com/m00nk0d3/nexus/internal/exec"
+	"github.com/m00nk0d3/nexus/internal/fuzzy"
 	"github.com/m00nk0d3/nexus/internal/tui/modal"
 	"github.com/m00nk0d3/nexus/internal/tui/styles"
 	"github.com/m00nk0d3/nexus/internal/updater"
@@ -321,6 +322,13 @@ type Model struct {
 	fuzzyFiles    []string              // files from git ls-files
 	fuzzyBranches []string              // branches from git branch -a
 	fuzzyAllItems []domain.SearchResult // full unfiltered search index
+
+	// Fuzzy overlay state
+	fuzzyActive  bool                  // true while the fuzzy finder overlay is open
+	fuzzyInput   textinput.Model       // text input for the fuzzy query
+	fuzzyResults []domain.SearchResult // filtered+ranked results for the current query
+	fuzzySelIdx  int                   // selected result index
+	fuzzyLoading bool                  // true while the search index is being built
 }
 
 // NewModel creates and returns a new Model instance with all required fields initialized.
@@ -488,6 +496,62 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		// Non-key message: fall through to the main switch to handle it normally.
+	}
+
+	// While the fuzzy finder overlay is open, route key events here.
+	// Non-key messages (e.g. fuzzyResultsReadyMsg, tea.WindowSizeMsg) fall
+	// through to the main switch so background events are never dropped.
+	if m.fuzzyActive {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			switch keyMsg.Type {
+			case tea.KeyEsc:
+				m.fuzzyActive = false
+				m.fuzzyInput.SetValue("")
+				m.fuzzyResults = nil
+				m.fuzzySelIdx = 0
+				return m, nil
+			case tea.KeyEnter:
+				cmd := m.fuzzyConfirmSelection()
+				m.fuzzyActive = false
+				m.fuzzyInput.SetValue("")
+				m.fuzzyResults = nil
+				m.fuzzySelIdx = 0
+				return m, cmd
+			case tea.KeyUp:
+				if m.fuzzySelIdx > 0 {
+					m.fuzzySelIdx--
+				}
+				return m, nil
+			case tea.KeyDown:
+				if m.fuzzySelIdx < len(m.fuzzyResults)-1 {
+					m.fuzzySelIdx++
+				}
+				return m, nil
+			default:
+				// j/k vim navigation when the input is empty or after rune input.
+				if keyMsg.Type == tea.KeyRunes {
+					switch keyMsg.String() {
+					case "j":
+						if m.fuzzySelIdx < len(m.fuzzyResults)-1 {
+							m.fuzzySelIdx++
+						}
+						return m, nil
+					case "k":
+						if m.fuzzySelIdx > 0 {
+							m.fuzzySelIdx--
+						}
+						return m, nil
+					}
+				}
+				var inputCmd tea.Cmd
+				m.fuzzyInput, inputCmd = m.fuzzyInput.Update(keyMsg)
+				query := m.fuzzyInput.Value()
+				m.fuzzyResults = fuzzy.FilterAndRank(query, m.fuzzyAllItems)
+				m.fuzzySelIdx = 0
+				return m, inputCmd
+			}
+		}
+		// Non-key message: fall through to the main switch.
 	}
 
 	switch msg := msg.(type) {
@@ -735,6 +799,22 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.statusErr = "No active session for this worktree"
 				return m, clearErrorCmd()
+			case "/":
+				ti := textinput.New()
+				ti.Placeholder = "Search worktrees, issues, PRs, files..."
+				focusCmd := ti.Focus()
+				m.fuzzyInput = ti
+				m.fuzzyActive = true
+				m.fuzzySelIdx = 0
+				if len(m.fuzzyAllItems) > 0 {
+					m.fuzzyLoading = false
+					m.fuzzyResults = fuzzy.FilterAndRank("", m.fuzzyAllItems)
+				} else {
+					m.fuzzyLoading = true
+					m.fuzzyResults = nil
+					return m, tea.Batch(focusCmd, func() tea.Msg { return fuzzyOpenMsg{} })
+				}
+				return m, focusCmd
 			}
 		}
 
@@ -1007,6 +1087,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 		}
+		// If the overlay is still open, populate results now that the index is ready.
+		if m.fuzzyActive {
+			m.fuzzyLoading = false
+			query := m.fuzzyInput.Value()
+			m.fuzzyResults = fuzzy.FilterAndRank(query, m.fuzzyAllItems)
+			m.fuzzySelIdx = 0
+		}
 	}
 
 	return m, nil
@@ -1049,6 +1136,12 @@ func (m *Model) View() string {
 	if m.claudePromptActive {
 		return overlay("Spawn Claude Code",
 			fmt.Sprintf("> %s\n\nEnter confirm (prompt optional)  •  Esc cancel", m.claudePromptInput.View()))
+	}
+
+	if m.fuzzyActive {
+		theme := styles.NewTheme(styles.Themes[m.themeIdx])
+		overlayContent := renderFuzzyOverlay(m.fuzzyInput, m.fuzzyResults, m.fuzzySelIdx, theme, m.fuzzyLoading, w)
+		return lipgloss.Place(w, h, lipgloss.Center, lipgloss.Center, overlayContent)
 	}
 
 	if m.selfUpdating {
@@ -2329,4 +2422,55 @@ func (m *Model) moveUp() {
 			}
 		}
 	}
+}
+
+// fuzzyConfirmSelection navigates the UI to the selected fuzzy result.
+// Returns a Cmd to execute as part of the selection (e.g. spawn a session), or nil.
+func (m *Model) fuzzyConfirmSelection() tea.Cmd {
+	if len(m.fuzzyResults) == 0 || m.fuzzySelIdx >= len(m.fuzzyResults) {
+		return nil
+	}
+	result := m.fuzzyResults[m.fuzzySelIdx]
+	switch result.Kind {
+	case domain.KindWorktree:
+		m.view = viewWorktrees
+		m.ctxScrollOffset = 0
+		m.currentPage = 0
+		if wt, ok := result.Payload.(domain.Worktree); ok {
+			for i, w := range m.Worktrees {
+				if w.Path == wt.Path {
+					m.selectedIdx = i
+					break
+				}
+			}
+		}
+	case domain.KindIssue:
+		m.view = viewIssues
+		m.ctxScrollOffset = 0
+		m.currentPage = 0
+		if iss, ok := result.Payload.(domain.Issue); ok {
+			for i, issue := range m.issues {
+				if issue.Number == iss.Number {
+					m.selectedIssueIdx = i
+					break
+				}
+			}
+		}
+	case domain.KindPR:
+		m.view = viewPRs
+		m.ctxScrollOffset = 0
+		m.currentPage = 0
+		if pr, ok := result.Payload.(domain.PullRequest); ok {
+			for i, p := range m.prs {
+				if p.Number == pr.Number {
+					m.selectedPRIdx = i
+					break
+				}
+			}
+		}
+	case domain.KindFile, domain.KindBranch, domain.KindAgent, domain.KindCommit:
+		m.statusMsg = fmt.Sprintf("Selected: %s  %s", result.Icon, result.Label)
+		return clearMsgCmd()
+	}
+	return nil
 }

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -354,6 +354,11 @@ func NewModel() *Model {
 		themeIdx:  themeIdx,
 		statusErr: configErr,
 		focused:   panelList,
+		fuzzyInput: func() textinput.Model {
+			ti := textinput.New()
+			ti.Placeholder = "Search worktrees, issues, PRs, files..."
+			return ti
+		}(),
 	}
 }
 
@@ -528,21 +533,6 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				return m, nil
 			default:
-				// j/k vim navigation when the input is empty or after rune input.
-				if keyMsg.Type == tea.KeyRunes {
-					switch keyMsg.String() {
-					case "j":
-						if m.fuzzySelIdx < len(m.fuzzyResults)-1 {
-							m.fuzzySelIdx++
-						}
-						return m, nil
-					case "k":
-						if m.fuzzySelIdx > 0 {
-							m.fuzzySelIdx--
-						}
-						return m, nil
-					}
-				}
 				var inputCmd tea.Cmd
 				m.fuzzyInput, inputCmd = m.fuzzyInput.Update(keyMsg)
 				query := m.fuzzyInput.Value()
@@ -800,10 +790,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.statusErr = "No active session for this worktree"
 				return m, clearErrorCmd()
 			case "/":
-				ti := textinput.New()
-				ti.Placeholder = "Search worktrees, issues, PRs, files..."
-				focusCmd := ti.Focus()
-				m.fuzzyInput = ti
+				m.fuzzyInput.SetValue("")
+				focusCmd := m.fuzzyInput.Focus()
 				m.fuzzyActive = true
 				m.fuzzySelIdx = 0
 				if len(m.fuzzyAllItems) > 0 {

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -319,8 +319,6 @@ type Model struct {
 	claudePromptInput  textinput.Model // text input for entering the Claude prompt
 
 	// Fuzzy finder state
-	fuzzyFiles    []string              // files from git ls-files
-	fuzzyBranches []string              // branches from git branch -a
 	fuzzyAllItems []domain.SearchResult // full unfiltered search index
 
 	// Fuzzy overlay state
@@ -1060,24 +1058,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case fuzzyResultsReadyMsg:
 		m.fuzzyAllItems = msg.results
-		// Also extract the file and branch slices for convenience
-		m.fuzzyFiles = m.fuzzyFiles[:0]
-		m.fuzzyBranches = m.fuzzyBranches[:0]
-		for _, r := range msg.results {
-			switch r.Kind {
-			case domain.KindFile:
-				if f, ok := r.Payload.(string); ok {
-					m.fuzzyFiles = append(m.fuzzyFiles, f)
-				}
-			case domain.KindBranch:
-				if b, ok := r.Payload.(string); ok {
-					m.fuzzyBranches = append(m.fuzzyBranches, b)
-				}
-			}
-		}
+		// Always clear the loading flag regardless of whether the overlay is
+		// still open — prevents stale loading state if the user closed the
+		// overlay before the index finished building.
+		m.fuzzyLoading = false
 		// If the overlay is still open, populate results now that the index is ready.
 		if m.fuzzyActive {
-			m.fuzzyLoading = false
 			query := m.fuzzyInput.Value()
 			m.fuzzyResults = fuzzy.FilterAndRank(query, m.fuzzyAllItems)
 			m.fuzzySelIdx = 0

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3930,7 +3930,7 @@ func TestUpdate_FuzzyOpenMsg(t *testing.T) {
 }
 
 // TestUpdate_FuzzyResultsReadyMsg verifies that fuzzyResultsReadyMsg populates
-// m.fuzzyAllItems and extracts the file/branch convenience slices correctly.
+// m.fuzzyAllItems and always clears fuzzyLoading, even when the overlay is closed.
 func TestUpdate_FuzzyResultsReadyMsg(t *testing.T) {
 	m := NewModel()
 	require.NotNil(t, m)
@@ -3951,11 +3951,128 @@ func TestUpdate_FuzzyResultsReadyMsg(t *testing.T) {
 	require.True(t, ok)
 
 	assert.Len(t, result.fuzzyAllItems, 6, "fuzzyAllItems should contain all 6 results")
-	assert.Len(t, result.fuzzyFiles, 2, "fuzzyFiles should contain 2 file results")
-	assert.Len(t, result.fuzzyBranches, 2, "fuzzyBranches should contain 2 branch results")
+}
 
-	assert.Contains(t, result.fuzzyFiles, "cmd/main.go")
-	assert.Contains(t, result.fuzzyFiles, "internal/app.go")
-	assert.Contains(t, result.fuzzyBranches, "main")
-	assert.Contains(t, result.fuzzyBranches, "feat/foo")
+// TestUpdate_FuzzyResultsReadyMsg_ClearsLoadingWhenOverlayClosed verifies that
+// fuzzyLoading is reset to false even when the overlay is not currently open.
+func TestUpdate_FuzzyResultsReadyMsg_ClearsLoadingWhenOverlayClosed(t *testing.T) {
+	m := NewModel()
+	require.NotNil(t, m)
+
+	// Simulate: user opened overlay, triggering async build, then closed before results arrived.
+	m.fuzzyLoading = true
+	m.fuzzyActive = false
+
+	_, _ = m.Update(fuzzyResultsReadyMsg{results: []domain.SearchResult{}})
+
+	assert.False(t, m.fuzzyLoading, "fuzzyLoading must be cleared even when overlay is closed")
+}
+
+// ---------------------------------------------------------------------------
+// fuzzyConfirmSelection tests
+// ---------------------------------------------------------------------------
+
+func TestFuzzyConfirmSelection_EmptyResults_ReturnsNil(t *testing.T) {
+	m := NewModel()
+	m.fuzzyResults = nil
+	cmd := m.fuzzyConfirmSelection()
+	assert.Nil(t, cmd)
+}
+
+func TestFuzzyConfirmSelection_IdxOutOfBounds_ReturnsNil(t *testing.T) {
+	m := NewModel()
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindFile, Label: "x.go", Icon: "📄", Payload: "x.go"},
+	}
+	m.fuzzySelIdx = 5
+	cmd := m.fuzzyConfirmSelection()
+	assert.Nil(t, cmd)
+}
+
+func TestFuzzyConfirmSelection_WorktreeSelection(t *testing.T) {
+	m := NewModel()
+	m.Worktrees = []domain.Worktree{
+		{Path: "/wt/alpha", Branch: "feat/alpha"},
+		{Path: "/wt/beta", Branch: "feat/beta"},
+	}
+	m.view = viewIssues // start on a different view
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindWorktree, Label: "/wt/beta", Sub: "feat/beta", Icon: "🌿", Payload: domain.Worktree{Path: "/wt/beta", Branch: "feat/beta"}},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.Nil(t, cmd, "worktree selection returns no async Cmd")
+	assert.Equal(t, viewWorktrees, m.view, "should switch to worktrees view")
+	assert.Equal(t, 1, m.selectedIdx, "should select /wt/beta (index 1)")
+	assert.Equal(t, 0, m.ctxScrollOffset)
+	assert.Equal(t, 0, m.currentPage)
+}
+
+func TestFuzzyConfirmSelection_IssueSelection(t *testing.T) {
+	m := NewModel()
+	m.issues = []domain.Issue{
+		{Number: 1, Title: "First"},
+		{Number: 42, Title: "Fix auth"},
+	}
+	m.view = viewWorktrees
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindIssue, Label: "Fix auth", Sub: "#42", Icon: "🐛", Payload: domain.Issue{Number: 42, Title: "Fix auth"}},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.Nil(t, cmd)
+	assert.Equal(t, viewIssues, m.view)
+	assert.Equal(t, 1, m.selectedIssueIdx, "should select issue at index 1 (Number=42)")
+}
+
+func TestFuzzyConfirmSelection_PRSelection(t *testing.T) {
+	m := NewModel()
+	m.prs = []domain.PullRequest{
+		{Number: 10, Title: "First PR"},
+		{Number: 20, Title: "Add feature"},
+	}
+	m.view = viewWorktrees
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindPR, Label: "Add feature", Sub: "#20", Icon: "🔀", Payload: domain.PullRequest{Number: 20, Title: "Add feature"}},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.Nil(t, cmd)
+	assert.Equal(t, viewPRs, m.view)
+	assert.Equal(t, 1, m.selectedPRIdx, "should select PR at index 1 (Number=20)")
+}
+
+func TestFuzzyConfirmSelection_ToastKinds(t *testing.T) {
+	toastCases := []struct {
+		kind    domain.ResultKind
+		label   string
+		icon    string
+		payload any
+	}{
+		{domain.KindFile, "internal/auth.go", "📄", "internal/auth.go"},
+		{domain.KindBranch, "feat/login", "🌿", "feat/login"},
+		{domain.KindAgent, "fix the null pointer", "🤖", data.AgentRun{AgentName: "copilot", Prompt: "fix the null pointer"}},
+		{domain.KindCommit, "add jwt middleware", "📦", "abc1234"},
+	}
+
+	for _, tc := range toastCases {
+		t.Run(string(tc.kind), func(t *testing.T) {
+			m := NewModel()
+			m.fuzzyResults = []domain.SearchResult{
+				{Kind: tc.kind, Label: tc.label, Icon: tc.icon, Payload: tc.payload},
+			}
+			m.fuzzySelIdx = 0
+
+			cmd := m.fuzzyConfirmSelection()
+
+			assert.NotNil(t, cmd, "%s: should return a clearMsgCmd", tc.kind)
+			assert.Contains(t, m.statusMsg, tc.label, "%s: statusMsg should contain the label", tc.kind)
+		})
+	}
 }

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [/] Fuzzy | [q/esc] Quit"
-	footerHintsIssues    = "[Tab] Panel | [j/k] Navigate | [Enter] New WT | [t] Settings | [g] GH | [/] Fuzzy | [q/esc] Quit"
-	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [Ctrl+R] Review | [t] Settings | [g] GH | [/] Fuzzy | [q/esc] Quit"
+	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Spc] Agents | [t] Settings | [g] GH | [/] Fuzzy | [q/esc]"
+	footerHintsIssues    = "[Tab] Panel | [j/k] Navigate | [Enter] New WT | [t] Settings | [g] GH | [/] Fuzzy | [q/esc]"
+	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [Ctrl+R] | [t] Settings | [g] GH | [/] Fuzzy | [q/esc]"
 	footerHintsDefault   = footerHintsWorktrees
 	actionBarHints       = "[enter] Open  [c-d] Delete  [c-l] Lock | [f1] Help"
 	defaultTermWidth     = 120
@@ -1242,17 +1242,17 @@ func kindBadge(k domain.ResultKind) string {
 	case domain.KindWorktree:
 		return "worktree"
 	case domain.KindIssue:
-		return "issue  "
+		return "issue"
 	case domain.KindPR:
-		return "pr     "
+		return "pr"
 	case domain.KindFile:
-		return "file   "
+		return "file"
 	case domain.KindBranch:
-		return "branch "
+		return "branch"
 	case domain.KindAgent:
-		return "agent  "
+		return "agent"
 	case domain.KindCommit:
-		return "commit "
+		return "commit"
 	default:
 		return string(k)
 	}
@@ -1333,6 +1333,7 @@ func renderFuzzyOverlay(input textinput.Model, results []domain.SearchResult, se
 			icon := r.Icon
 			badge := lipgloss.NewStyle().
 				Foreground(mutedColor).
+				Width(8).
 				Render(kindBadge(r.Kind))
 			label := r.Label
 			sub := r.Sub

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -21,7 +21,7 @@ import (
 const (
 	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Spc] Agents | [t] Settings | [g] GH | [/] Fuzzy | [q/esc]"
 	footerHintsIssues    = "[Tab] Panel | [j/k] Navigate | [Enter] New WT | [t] Settings | [g] GH | [/] Fuzzy | [q/esc]"
-	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [Ctrl+R] | [t] Settings | [g] GH | [/] Fuzzy | [q/esc]"
+	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [Ctrl+R] Review | [t] Settings | [g] GH | [/] Fuzzy | [q/esc]"
 	footerHintsDefault   = footerHintsWorktrees
 	actionBarHints       = "[enter] Open  [c-d] Delete  [c-l] Lock | [f1] Help"
 	defaultTermWidth     = 120

--- a/cmd/nexus/renderer.go
+++ b/cmd/nexus/renderer.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/lipgloss"
 	libtable "github.com/charmbracelet/lipgloss/table"
 	"github.com/charmbracelet/x/ansi"
@@ -18,9 +19,9 @@ import (
 )
 
 const (
-	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [q/esc] Quit"
-	footerHintsIssues    = "[Tab] Panel | [j/k] Navigate | [Enter] New WT | [t] Settings | [g] GH | [q/esc] Quit"
-	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [Ctrl+R] Review | [t] Settings | [g] GH | [q/esc] Quit"
+	footerHintsWorktrees = "[Tab] Panel | [j/k] Navigate | [Enter] Select | [Space] Agents | [t] Settings | [g] GH | [/] Fuzzy | [q/esc] Quit"
+	footerHintsIssues    = "[Tab] Panel | [j/k] Navigate | [Enter] New WT | [t] Settings | [g] GH | [/] Fuzzy | [q/esc] Quit"
+	footerHintsPRs       = "[Tab] Panel | [j/k] Navigate | [Enter] Checkout | [Ctrl+R] Review | [t] Settings | [g] GH | [/] Fuzzy | [q/esc] Quit"
 	footerHintsDefault   = footerHintsWorktrees
 	actionBarHints       = "[enter] Open  [c-d] Delete  [c-l] Lock | [f1] Help"
 	defaultTermWidth     = 120
@@ -1233,4 +1234,168 @@ func buildPRHint(branch string, issues []domain.Issue, worktrees []domain.Worktr
 		}
 	}
 	return ""
+}
+
+// kindBadge returns a short display label for the given result kind.
+func kindBadge(k domain.ResultKind) string {
+	switch k {
+	case domain.KindWorktree:
+		return "worktree"
+	case domain.KindIssue:
+		return "issue  "
+	case domain.KindPR:
+		return "pr     "
+	case domain.KindFile:
+		return "file   "
+	case domain.KindBranch:
+		return "branch "
+	case domain.KindAgent:
+		return "agent  "
+	case domain.KindCommit:
+		return "commit "
+	default:
+		return string(k)
+	}
+}
+
+// renderFuzzyOverlay renders the floating fuzzy finder panel.
+//
+// Layout:
+//
+//	╭──────────────────────────────────────────╮
+//	│  > [input text]                     [/]  │
+//	│──────────────────────────────────────────│
+//	│  🗂 worktree  feat/issue-42-auth         │
+//	│  📌 issue     #42  Fix JWT auth...       │
+//	╰──────────────────────────────────────────╯
+func renderFuzzyOverlay(input textinput.Model, results []domain.SearchResult, selIdx int, theme styles.Theme, loading bool, termWidth int) string {
+	const maxVisible = 12
+
+	overlayWidth := termWidth - 8
+	if overlayWidth < 40 {
+		overlayWidth = 40
+	}
+	if overlayWidth > 100 {
+		overlayWidth = 100
+	}
+
+	// Inner content width: overlayWidth minus border (2) minus padding (2).
+	innerWidth := overlayWidth - 4
+
+	accentColor := lipgloss.Color(theme.Accent())
+	mutedColor := lipgloss.Color(theme.Muted())
+	fgColor := lipgloss.Color(theme.Fg())
+	bgColor := lipgloss.Color(theme.Bg())
+
+	// Header row: "  > [input]  [/]"
+	badge := lipgloss.NewStyle().
+		Foreground(accentColor).
+		Bold(true).
+		Render("[/]")
+	prompt := lipgloss.NewStyle().
+		Foreground(accentColor).
+		Render("> ")
+	inputView := input.View()
+	// Available width for the input field itself (subtract prompt + badge + spaces).
+	inputAreaWidth := innerWidth - lipgloss.Width(prompt) - lipgloss.Width(badge) - 2
+	if inputAreaWidth < 1 {
+		inputAreaWidth = 1
+	}
+	inputLine := lipgloss.NewStyle().
+		Width(innerWidth).
+		Render(prompt + truncateStr(inputView, inputAreaWidth) + "  " + badge)
+
+	divider := lipgloss.NewStyle().
+		Foreground(mutedColor).
+		Render(strings.Repeat("─", innerWidth))
+
+	// Build result rows.
+	var rows strings.Builder
+	switch {
+	case loading:
+		rows.WriteString(lipgloss.NewStyle().
+			Foreground(mutedColor).
+			Italic(true).
+			Width(innerWidth).
+			Render("Searching..."))
+	case len(results) == 0:
+		rows.WriteString(lipgloss.NewStyle().
+			Foreground(mutedColor).
+			Italic(true).
+			Width(innerWidth).
+			Render("No results"))
+	default:
+		visible := results
+		if len(visible) > maxVisible {
+			visible = visible[:maxVisible]
+		}
+		for i, r := range visible {
+			icon := r.Icon
+			badge := lipgloss.NewStyle().
+				Foreground(mutedColor).
+				Render(kindBadge(r.Kind))
+			label := r.Label
+			sub := r.Sub
+
+			// Compute available width for label + sub text.
+			iconW := runewidth.StringWidth(icon)
+			badgeW := lipgloss.Width(badge)
+			// "  " (2) between icon and badge, "  " (2) after badge, "  " (2) between label and sub.
+			fixedW := iconW + 2 + badgeW + 2
+			remaining := innerWidth - fixedW
+			if remaining < 1 {
+				remaining = 1
+			}
+			// Split remaining: 60% label, 40% sub.
+			labelW := (remaining * 60) / 100
+			subW := remaining - labelW
+			if subW < 4 {
+				subW = 0
+				labelW = remaining
+			}
+
+			labelStr := lipgloss.NewStyle().Width(labelW).Render(truncateStr(label, labelW))
+			subStr := ""
+			if subW > 0 {
+				subStr = lipgloss.NewStyle().
+					Foreground(mutedColor).
+					Width(subW).
+					Render(truncateStr(sub, subW))
+			}
+
+			line := fmt.Sprintf("%s  %s  %s%s", icon, badge, labelStr, subStr)
+
+			if i == selIdx {
+				line = lipgloss.NewStyle().
+					Background(lipgloss.Color(theme.Accent())).
+					Foreground(bgColor).
+					Bold(true).
+					Width(innerWidth).
+					Render(line)
+			} else {
+				line = lipgloss.NewStyle().
+					Foreground(fgColor).
+					Width(innerWidth).
+					Render(line)
+			}
+
+			if i > 0 {
+				rows.WriteString("\n")
+			}
+			rows.WriteString(line)
+		}
+		if len(results) > maxVisible {
+			more := fmt.Sprintf("…and %d more", len(results)-maxVisible)
+			rows.WriteString("\n" + lipgloss.NewStyle().Foreground(mutedColor).Width(innerWidth).Render(more))
+		}
+	}
+
+	content := inputLine + "\n" + divider + "\n" + rows.String()
+
+	return lipgloss.NewStyle().
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(accentColor).
+		Padding(0, 1).
+		Width(overlayWidth - 2). // -2: rounded border left+right
+		Render(content)
 }

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -143,7 +143,7 @@ func TestRenderFull_ContainsFooterKeyHints(t *testing.T) {
 	}{
 		{
 			name:   "footer contains navigation and action hints",
-			wantIn: []string{"[Enter] Select", "[t] Settings", "[q/esc] Quit"},
+			wantIn: []string{"[Enter] Select", "[t] Settings", "[/] Fuzzy", "[q/esc]"},
 		},
 		{
 			name:   "action bar contains worktree commands",
@@ -1177,7 +1177,8 @@ func TestRenderFull_FooterContainsTabAndJKHints(t *testing.T) {
 	assert.Contains(t, view, "[j/k]")
 	// Old hints must still be present
 	assert.Contains(t, view, "[Enter] Select")
-	assert.Contains(t, view, "[q/esc] Quit")
+	assert.Contains(t, view, "[q/esc]")
+	assert.Contains(t, view, "[/] Fuzzy")
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/nexus/renderer_test.go
+++ b/cmd/nexus/renderer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/m00nk0d3/nexus/internal/domain"
@@ -2192,3 +2193,145 @@ func TestPathsEqual_NormalisedComparison(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Phase 3: Fuzzy Overlay tests
+// ---------------------------------------------------------------------------
+
+// TestRenderFuzzyOverlay_LoadingState verifies that the loading state shows
+// "Searching..." when no results are available yet.
+func TestRenderFuzzyOverlay_LoadingState(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+
+	result := renderFuzzyOverlay(ti, nil, 0, theme, true, 120)
+
+	assert.Contains(t, result, "Searching...")
+}
+
+// TestRenderFuzzyOverlay_EmptyQuery verifies that all items are shown when the
+// query is empty and loading is false.
+func TestRenderFuzzyOverlay_EmptyQuery(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+
+	items := []domain.SearchResult{
+		{Kind: domain.KindWorktree, Icon: "🗂", Label: "feat/issue-42-auth", Sub: "worktree"},
+		{Kind: domain.KindIssue, Icon: "📌", Label: "#42 Fix JWT auth", Sub: "#42"},
+	}
+
+	result := renderFuzzyOverlay(ti, items, 0, theme, false, 120)
+
+	assert.Contains(t, result, "feat/issue-42-auth")
+	assert.Contains(t, result, "#42 Fix JWT auth")
+	// Should not show "No results" when there are items
+	assert.NotContains(t, result, "No results")
+}
+
+// TestRenderFuzzyOverlay_NoMatches verifies that "No results" is shown when
+// the results slice is empty and loading is false.
+func TestRenderFuzzyOverlay_NoMatches(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+	ti.SetValue("xyzzy-no-match")
+
+	result := renderFuzzyOverlay(ti, nil, 0, theme, false, 120)
+
+	assert.Contains(t, result, "No results")
+}
+
+// TestRenderFuzzyOverlay_ResultsPresent verifies that result rows include the
+// icon, kind badge, label, and sub text.
+func TestRenderFuzzyOverlay_ResultsPresent(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+	ti.SetValue("auth")
+
+	items := []domain.SearchResult{
+		{Kind: domain.KindWorktree, Icon: "🗂", Label: "feat/issue-42-auth", Sub: ""},
+		{Kind: domain.KindIssue, Icon: "📌", Label: "Fix auth bug", Sub: "#42"},
+		{Kind: domain.KindPR, Icon: "🔀", Label: "Add auth middleware", Sub: "#38"},
+		{Kind: domain.KindFile, Icon: "📄", Label: "internal/auth/jwt.go", Sub: ""},
+	}
+
+	result := renderFuzzyOverlay(ti, items, 0, theme, false, 120)
+
+	assert.Contains(t, result, "feat/issue-42-auth")
+	assert.Contains(t, result, "Fix auth bug")
+	assert.Contains(t, result, "Add auth middleware")
+	assert.Contains(t, result, "internal/auth/jwt.go")
+	assert.Contains(t, result, "worktree")
+	assert.Contains(t, result, "issue")
+	assert.Contains(t, result, "pr")
+	assert.Contains(t, result, "file")
+}
+
+// TestRenderFuzzyOverlay_SelectedRowDistinct verifies that the selected row
+// index is rendered distinctly from unselected rows (contains the selected label).
+func TestRenderFuzzyOverlay_SelectedRowDistinct(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+
+	items := []domain.SearchResult{
+		{Kind: domain.KindWorktree, Icon: "🗂", Label: "worktree-alpha", Sub: ""},
+		{Kind: domain.KindWorktree, Icon: "🗂", Label: "worktree-beta", Sub: ""},
+		{Kind: domain.KindWorktree, Icon: "🗂", Label: "worktree-gamma", Sub: ""},
+	}
+
+	tests := []struct {
+		name        string
+		selIdx      int
+		wantPresent string
+	}{
+		{"first item selected", 0, "worktree-alpha"},
+		{"second item selected", 1, "worktree-beta"},
+		{"third item selected", 2, "worktree-gamma"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := renderFuzzyOverlay(ti, items, tt.selIdx, theme, false, 120)
+			assert.Contains(t, result, tt.wantPresent)
+		})
+	}
+}
+
+// TestRenderFuzzyOverlay_InputVisible verifies the query text appears in the overlay.
+func TestRenderFuzzyOverlay_InputVisible(t *testing.T) {
+	theme := styles.NewTheme("digital-noir")
+	ti := textinput.New()
+	// Don't focus the input in tests — just verify the value is shown.
+	ti.SetValue("jwt")
+
+	items := []domain.SearchResult{
+		{Kind: domain.KindFile, Icon: "📄", Label: "auth/jwt.go", Sub: ""},
+	}
+
+	result := renderFuzzyOverlay(ti, items, 0, theme, false, 120)
+
+	assert.Contains(t, result, "[/]")
+	assert.Contains(t, result, "auth/jwt.go")
+}
+
+// TestRenderFuzzyOverlay_KindBadges verifies that kindBadge returns the expected
+// display string for each known ResultKind.
+func TestRenderFuzzyOverlay_KindBadges(t *testing.T) {
+	tests := []struct {
+		kind domain.ResultKind
+		want string
+	}{
+		{domain.KindWorktree, "worktree"},
+		{domain.KindIssue, "issue"},
+		{domain.KindPR, "pr"},
+		{domain.KindFile, "file"},
+		{domain.KindBranch, "branch"},
+		{domain.KindAgent, "agent"},
+		{domain.KindCommit, "commit"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.kind), func(t *testing.T) {
+			assert.Contains(t, kindBadge(tt.kind), tt.want)
+		})
+	}
+}
+


### PR DESCRIPTION
Closes #71

## What Changed
Implements the fuzzy finder overlay UI — a floating panel that renders above the base view, shows a text input, and displays filtered+ranked results in real-time as the user types.

## Why
Phase 3 of the global fuzzy finder (#68). Phase 1 built the engine, Phase 2 built the async search index. This phase wires both together into a fully interactive overlay that users can invoke with `/` from any view.

## Key Design Decisions
- **Guard pattern** mirrors the existing copilot/claude prompt guards: key events are intercepted by the fuzzy guard, non-key messages (e.g. `fuzzyResultsReadyMsg`, `tea.WindowSizeMsg`) fall through to the main switch so background events are never swallowed.
- **Loading state** is shown when `/` is pressed before the search index is ready; the index builds async and results populate automatically when `fuzzyResultsReadyMsg` arrives.
- **Selection**: worktree/issue/PR selections navigate the main view to the result; file/branch/agent/commit show a status toast.
- **Overlay width**: 100-column cap so it stays readable on ultra-wide terminals.

## Testing
- 10 new renderer tests covering: loading state, empty query, no matches, results present (all 7 kinds), selected row per index, input label visibility, `kindBadge` for all `ResultKind` values.
- All new tests pass. Pre-existing `TestBuildNewTabWithCmdCmd` failure is unrelated (zellij env detection in CI, present before this branch).