### PR TITLE
feat(fuzzy): phase 4 - smart actions (Enter dispatches per result type)

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -68,7 +68,8 @@ type lazyLoadContextMsg struct {
 	worktree domain.Worktree
 }
 
-// browserOpenErrMsg carries an error from opening an issue or PR in the browser.
+// browserOpenErrMsg carries an error from launching an external process
+// (browser, editor, gh CLI, etc.).
 type browserOpenErrMsg struct{ err error }
 
 // agentDoneMsg is dispatched when an AI agent process exits.
@@ -2486,6 +2487,7 @@ func openFileInEditorCmd(relPath, repoPath string) tea.Cmd {
 
 // openCommitInBrowserCmd opens the given commit SHA in the browser via the gh CLI.
 func openCommitInBrowserCmd(hash, repoPath string) tea.Cmd {
-	cmd := exec.Command("gh", "-C", repoPath, "browse", hash)
+	cmd := exec.Command("gh", "browse", hash)
+	cmd.Dir = repoPath
 	return tea.ExecProcess(cmd, func(err error) tea.Msg { return browserOpenErrMsg{err: err} })
 }

--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -614,6 +614,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if selected, ok := m.selectedWorktree(); ok {
 				m.activeModal = modal.NewDeleteModal(selected)
 			}
+		case tea.KeyCtrlF:
+			return m, m.openFuzzyCmd()
 		case tea.KeyCtrlR:
 			if m.view != viewPRs {
 				m.statusErr = "PR Review (Ctrl+R) is only available in the PRs view — press P to switch"
@@ -788,19 +790,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.statusErr = "No active session for this worktree"
 				return m, clearErrorCmd()
 			case "/":
-				m.fuzzyInput.SetValue("")
-				focusCmd := m.fuzzyInput.Focus()
-				m.fuzzyActive = true
-				m.fuzzySelIdx = 0
-				if len(m.fuzzyAllItems) > 0 {
-					m.fuzzyLoading = false
-					m.fuzzyResults = fuzzy.FilterAndRank("", m.fuzzyAllItems)
-				} else {
-					m.fuzzyLoading = true
-					m.fuzzyResults = nil
-					return m, tea.Batch(focusCmd, func() tea.Msg { return fuzzyOpenMsg{} })
-				}
-				return m, focusCmd
+				return m, m.openFuzzyCmd()
 			}
 		}
 
@@ -2442,9 +2432,60 @@ func (m *Model) fuzzyConfirmSelection() tea.Cmd {
 				}
 			}
 		}
-	case domain.KindFile, domain.KindBranch, domain.KindAgent, domain.KindCommit:
-		m.statusMsg = fmt.Sprintf("Selected: %s  %s", result.Icon, result.Label)
-		return clearMsgCmd()
+	case domain.KindFile:
+		if relPath, ok := result.Payload.(string); ok {
+			return openFileInEditorCmd(relPath, m.RepoPath)
+		}
+	case domain.KindBranch:
+		if branch, ok := result.Payload.(string); ok {
+			path := prWorktreePath(m.RepoPath, branch)
+			m.activeModal = modal.NewBranchCheckoutModal(branch, path)
+		}
+	case domain.KindCommit:
+		if hash, ok := result.Payload.(string); ok {
+			return openCommitInBrowserCmd(hash, m.RepoPath)
+		}
+	case domain.KindAgent:
+		// No-op — future: show detail modal.
 	}
 	return nil
+}
+
+// openFuzzyCmd opens the fuzzy finder overlay, triggering a background index build
+// when the search index has not yet been populated.
+func (m *Model) openFuzzyCmd() tea.Cmd {
+	m.fuzzyInput.SetValue("")
+	focusCmd := m.fuzzyInput.Focus()
+	m.fuzzyActive = true
+	m.fuzzySelIdx = 0
+	if len(m.fuzzyAllItems) > 0 {
+		m.fuzzyLoading = false
+		m.fuzzyResults = fuzzy.FilterAndRank("", m.fuzzyAllItems)
+		return focusCmd
+	}
+	m.fuzzyLoading = true
+	m.fuzzyResults = nil
+	return tea.Batch(focusCmd, func() tea.Msg { return fuzzyOpenMsg{} })
+}
+
+// openFileInEditorCmd opens relPath (relative to repoPath) in the user's configured
+// $EDITOR. Falls back to "vi" on Unix-like systems and "notepad" on Windows.
+func openFileInEditorCmd(relPath, repoPath string) tea.Cmd {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		if runtime.GOOS == "windows" {
+			editor = "notepad"
+		} else {
+			editor = "vi"
+		}
+	}
+	fullPath := filepath.Join(repoPath, relPath)
+	cmd := exec.Command(editor, fullPath)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg { return browserOpenErrMsg{err: err} })
+}
+
+// openCommitInBrowserCmd opens the given commit SHA in the browser via the gh CLI.
+func openCommitInBrowserCmd(hash, repoPath string) tea.Cmd {
+	cmd := exec.Command("gh", "-C", repoPath, "browse", hash)
+	return tea.ExecProcess(cmd, func(err error) tea.Msg { return browserOpenErrMsg{err: err} })
 }

--- a/cmd/nexus/app_test.go
+++ b/cmd/nexus/app_test.go
@@ -3969,6 +3969,32 @@ func TestUpdate_FuzzyResultsReadyMsg_ClearsLoadingWhenOverlayClosed(t *testing.T
 }
 
 // ---------------------------------------------------------------------------
+// fuzzy keybinding tests
+// ---------------------------------------------------------------------------
+
+// TestFuzzyOpensOnSlash verifies that pressing "/" activates the fuzzy overlay.
+func TestFuzzyOpensOnSlash(t *testing.T) {
+	m := NewModel()
+	m.RepoPath = t.TempDir()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	result := updated.(*Model)
+
+	assert.True(t, result.fuzzyActive, "'/' should activate the fuzzy overlay")
+}
+
+// TestFuzzyOpensOnCtrlF verifies that Ctrl+F activates the fuzzy overlay.
+func TestFuzzyOpensOnCtrlF(t *testing.T) {
+	m := NewModel()
+	m.RepoPath = t.TempDir()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlF})
+	result := updated.(*Model)
+
+	assert.True(t, result.fuzzyActive, "Ctrl+F should activate the fuzzy overlay")
+}
+
+// ---------------------------------------------------------------------------
 // fuzzyConfirmSelection tests
 // ---------------------------------------------------------------------------
 
@@ -4048,31 +4074,58 @@ func TestFuzzyConfirmSelection_PRSelection(t *testing.T) {
 	assert.Equal(t, 1, m.selectedPRIdx, "should select PR at index 1 (Number=20)")
 }
 
-func TestFuzzyConfirmSelection_ToastKinds(t *testing.T) {
-	toastCases := []struct {
-		kind    domain.ResultKind
-		label   string
-		icon    string
-		payload any
-	}{
-		{domain.KindFile, "internal/auth.go", "📄", "internal/auth.go"},
-		{domain.KindBranch, "feat/login", "🌿", "feat/login"},
-		{domain.KindAgent, "fix the null pointer", "🤖", data.AgentRun{AgentName: "copilot", Prompt: "fix the null pointer"}},
-		{domain.KindCommit, "add jwt middleware", "📦", "abc1234"},
+func TestFuzzyConfirmSelection_FileSelection_ReturnsCmd(t *testing.T) {
+	m := NewModel()
+	m.RepoPath = "/repo"
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindFile, Label: "internal/auth.go", Icon: "📄", Payload: "internal/auth.go"},
 	}
+	m.fuzzySelIdx = 0
 
-	for _, tc := range toastCases {
-		t.Run(string(tc.kind), func(t *testing.T) {
-			m := NewModel()
-			m.fuzzyResults = []domain.SearchResult{
-				{Kind: tc.kind, Label: tc.label, Icon: tc.icon, Payload: tc.payload},
-			}
-			m.fuzzySelIdx = 0
+	cmd := m.fuzzyConfirmSelection()
 
-			cmd := m.fuzzyConfirmSelection()
-
-			assert.NotNil(t, cmd, "%s: should return a clearMsgCmd", tc.kind)
-			assert.Contains(t, m.statusMsg, tc.label, "%s: statusMsg should contain the label", tc.kind)
-		})
-	}
+	assert.NotNil(t, cmd, "file selection should return an exec Cmd")
+	assert.Empty(t, m.statusMsg, "file selection should not set statusMsg")
 }
+
+func TestFuzzyConfirmSelection_BranchSelection_OpensModal(t *testing.T) {
+	m := NewModel()
+	m.RepoPath = "/repo/main"
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindBranch, Label: "feat/login", Icon: "🌿", Payload: "feat/login"},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.Nil(t, cmd, "branch selection should return nil Cmd (modal handles the action)")
+	assert.NotNil(t, m.activeModal, "branch selection should open a BranchCheckoutModal")
+}
+
+func TestFuzzyConfirmSelection_AgentSelection_IsNoOp(t *testing.T) {
+	m := NewModel()
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindAgent, Label: "fix the null pointer", Icon: "🤖", Payload: data.AgentRun{AgentName: "copilot", Prompt: "fix the null pointer"}},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.Nil(t, cmd, "agent selection is a no-op")
+	assert.Empty(t, m.statusMsg, "agent selection should not set statusMsg")
+}
+
+func TestFuzzyConfirmSelection_CommitSelection_ReturnsCmd(t *testing.T) {
+	m := NewModel()
+	m.RepoPath = "/repo"
+	m.fuzzyResults = []domain.SearchResult{
+		{Kind: domain.KindCommit, Label: "add jwt middleware", Icon: "📦", Payload: "abc1234"},
+	}
+	m.fuzzySelIdx = 0
+
+	cmd := m.fuzzyConfirmSelection()
+
+	assert.NotNil(t, cmd, "commit selection should return a gh browse Cmd")
+	assert.Empty(t, m.statusMsg, "commit selection should not set statusMsg")
+}
+

--- a/internal/fuzzy/fuzzy.go
+++ b/internal/fuzzy/fuzzy.go
@@ -74,7 +74,7 @@ func Score(query, candidate string) int {
 // and the remainder are sorted highest-score-first.
 //
 // Note: scoring is performed against item.Label only; item.Sub matching is
-// deferred to a later phase.
+// deferred to a later phase (e.g. searching "#42" won't surface issue #42 by number).
 func FilterAndRank(query string, items []domain.SearchResult) []domain.SearchResult {
 	if query == "" {
 		out := make([]domain.SearchResult, len(items))

--- a/internal/tui/modal/branch_checkout.go
+++ b/internal/tui/modal/branch_checkout.go
@@ -1,0 +1,53 @@
+package modal
+
+import (
+	"fmt"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// BranchCheckoutModal is a single-step confirmation modal for creating a worktree
+// from an existing local or remote branch selected via the fuzzy finder.
+type BranchCheckoutModal struct {
+	branch string
+	path   string
+}
+
+// NewBranchCheckoutModal creates a new BranchCheckoutModal for the given branch and
+// target worktree path.
+func NewBranchCheckoutModal(branch, path string) *BranchCheckoutModal {
+	return &BranchCheckoutModal{branch: branch, path: path}
+}
+
+// Init satisfies tea.Model.
+func (m *BranchCheckoutModal) Init() tea.Cmd { return nil }
+
+// Title returns the modal title for themed overlay rendering.
+func (m *BranchCheckoutModal) Title() string { return "Checkout Branch" }
+
+// Update handles y/n/Esc input and emits the appropriate confirmation or cancel message.
+func (m *BranchCheckoutModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch keyMsg.String() {
+	case "y", "Y":
+		branch, path := m.branch, m.path
+		return m, func() tea.Msg { return PRWorktreeCreateConfirmedMsg{Branch: branch, Path: path} }
+	case "n", "N", "esc":
+		return m, func() tea.Msg { return ModalCancelledMsg{} }
+	}
+
+	return m, nil
+}
+
+// View renders the branch checkout confirmation dialog.
+func (m *BranchCheckoutModal) View() string {
+	return fmt.Sprintf(
+		"Create worktree for branch %q?\n  Path: %s\n\n[y] confirm  [n / Esc] cancel",
+		m.branch,
+		m.path,
+	)
+}

--- a/internal/tui/modal/branch_checkout_test.go
+++ b/internal/tui/modal/branch_checkout_test.go
@@ -1,0 +1,87 @@
+package modal_test
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/tui/modal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBranchCheckoutModal_Title(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+	assert.Equal(t, "Checkout Branch", m.Title())
+}
+
+func TestBranchCheckoutModal_View(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+	view := m.View()
+	assert.Contains(t, view, "feat/login")
+	assert.Contains(t, view, "/worktrees/feat-login")
+	assert.Contains(t, view, "[y]")
+	assert.Contains(t, view, "[n")
+}
+
+func TestBranchCheckoutModal_ConfirmY(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	require.NotNil(t, next)
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	confirmed, ok := msg.(modal.PRWorktreeCreateConfirmedMsg)
+	require.True(t, ok, "expected PRWorktreeCreateConfirmedMsg, got %T", msg)
+	assert.Equal(t, "feat/login", confirmed.Branch)
+	assert.Equal(t, "/worktrees/feat-login", confirmed.Path)
+}
+
+func TestBranchCheckoutModal_ConfirmUpperY(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'Y'}})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, ok := msg.(modal.PRWorktreeCreateConfirmedMsg)
+	assert.True(t, ok)
+}
+
+func TestBranchCheckoutModal_CancelN(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, ok := msg.(modal.ModalCancelledMsg)
+	assert.True(t, ok)
+}
+
+func TestBranchCheckoutModal_CancelEsc(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	require.NotNil(t, cmd)
+
+	msg := cmd()
+	_, ok := msg.(modal.ModalCancelledMsg)
+	assert.True(t, ok)
+}
+
+func TestBranchCheckoutModal_OtherKeyIsNoop(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	assert.Nil(t, cmd)
+	assert.Equal(t, m, next)
+}
+
+func TestBranchCheckoutModal_NonKeyMsgIsNoop(t *testing.T) {
+	m := modal.NewBranchCheckoutModal("feat/login", "/worktrees/feat-login")
+
+	next, cmd := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	assert.Nil(t, cmd)
+	assert.Equal(t, m, next)
+}


### PR DESCRIPTION
Closes #72

## What changed
Wires up smart Enter-dispatch for all 7 fuzzy result kinds and adds Ctrl+F as a second keybinding to open the overlay.

## Why
Phase 4 of the global fuzzy finder (#68). Without this, selecting a result from the overlay did nothing useful (just showed a toast). Now each result kind triggers the correct action.

## Action map implemented
| Result kind | Enter action |
|-------------|--------------|
| worktree | Navigate to Worktrees view + select entry |
| issue | Navigate to Issues view + highlight entry |
| pr | Navigate to PRs view + highlight entry |
| file | Open in `$EDITOR` (fallback: `vi` / `notepad`) via `tea.ExecProcess` |
| branch | Open `BranchCheckoutModal` (y/n confirm → checkout existing branch as worktree) |
| commit | Open commit in browser via `gh browse <hash>` |
| agent | No-op (future: show detail modal) |

## Key changes
- `cmd/nexus/app.go`: extracted `openFuzzyCmd()` helper, added `tea.KeyCtrlF` binding, added `openFileInEditorCmd` and `openCommitInBrowserCmd`, updated `fuzzyConfirmSelection`
- `internal/tui/modal/branch_checkout.go`: new `BranchCheckoutModal` (y/n confirmation, emits `PRWorktreeCreateConfirmedMsg` to reuse existing checkout flow)
- `cmd/nexus/app_test.go`: replaced old toast-based tests with 4 behaviour-specific tests + 2 keybinding tests
- `internal/tui/modal/branch_checkout_test.go`: 8 unit tests covering all input paths

## Testing
- All new tests pass (`go test ./...` — pre-existing `TestBuildNewTabWithCmdCmd` failures are environment-dependent and unrelated to this PR)
- Manual: `/` and Ctrl+F open the overlay; Enter on each result kind triggers the correct action