### PR TITLE
feat(tui): add Ctrl+B cleanup modal for stale worktrees and branches

### DIFF
--- a/cmd/nexus/app.go
+++ b/cmd/nexus/app.go
@@ -107,6 +107,18 @@ type updateCheckedMsg struct {
 // selfUpdateDoneMsg carries the result of a self-update attempt.
 type selfUpdateDoneMsg struct{ err error }
 
+// cleanupLoadedMsg carries cleanup candidates loaded from git.
+type cleanupLoadedMsg struct {
+	candidates []modal.CleanupCandidate
+	err        error
+}
+
+// cleanupDoneMsg carries the result of a batch worktree/branch cleanup.
+type cleanupDoneMsg struct {
+	deleted int
+	err     error
+}
+
 // fuzzyOpenMsg is dispatched when the user opens the fuzzy finder.
 type fuzzyOpenMsg struct{}
 
@@ -395,6 +407,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case modal.WorktreeDeleteConfirmedMsg:
 			m.activeModal = nil
 			return m, m.removeWorktreeCmd(msg.Path)
+		case modal.CleanupConfirmedMsg:
+			m.activeModal = nil
+			return m, m.performCleanupCmd(msg.Worktrees, msg.Branches)
 		case modal.AiderLaunchMsg:
 			m.activeModal = nil
 			if selected, ok := m.selectedWorktree(); ok {
@@ -615,6 +630,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if selected, ok := m.selectedWorktree(); ok {
 				m.activeModal = modal.NewDeleteModal(selected)
 			}
+		case tea.KeyCtrlB:
+			if m.view != viewWorktrees {
+				m.statusErr = "Cleanup (Ctrl+B) is only available in the Worktrees view — press w to switch"
+				return m, clearErrorCmd()
+			}
+			return m, m.loadCleanupDataCmd()
 		case tea.KeyCtrlF:
 			return m, m.openFuzzyCmd()
 		case tea.KeyCtrlR:
@@ -1054,6 +1075,22 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.statusMsg = "✓ Updated successfully! Please restart nexus to use the new version."
 		return m, clearMsgCmd()
+
+	case cleanupLoadedMsg:
+		if msg.err != nil {
+			m.statusErr = fmt.Sprintf("Failed to load cleanup data: %v", msg.err)
+			return m, clearErrorCmd()
+		}
+		m.activeModal = modal.NewCleanupModal(msg.candidates)
+		return m, nil
+
+	case cleanupDoneMsg:
+		if msg.err != nil {
+			m.statusErr = fmt.Sprintf("Cleanup failed: %v", msg.err)
+			return m, tea.Batch(m.refreshWorktreesCmd(), clearErrorCmd())
+		}
+		m.statusMsg = fmt.Sprintf("✓ Cleaned up %d item(s)", msg.deleted)
+		return m, tea.Batch(m.refreshWorktreesCmd(), clearMsgCmd())
 
 	case fuzzyOpenMsg:
 		return m, m.buildSearchIndexCmd()
@@ -2505,4 +2542,88 @@ func openCommitInBrowserCmd(hash, repoPath string) tea.Cmd {
 	cmd := exec.Command("gh", "browse", hash)
 	cmd.Dir = repoPath
 	return tea.ExecProcess(cmd, func(err error) tea.Msg { return browserOpenErrMsg{err: err} })
+}
+
+// loadCleanupDataCmd detects stale worktrees (branch merged into default) and
+// merged branches without an active worktree, then returns a cleanupLoadedMsg
+// carrying the candidates for the CleanupModal.
+func (m *Model) loadCleanupDataCmd() tea.Cmd {
+	repoPath := m.RepoPath
+	worktrees := m.Worktrees // snapshot to avoid data race
+	return func() tea.Msg {
+		git := internalexec.NewGitCommand(repoPath)
+		defaultBranch := git.DefaultBranch()
+
+		mergedBranches, err := git.ListMergedBranches(defaultBranch)
+		if err != nil {
+			return cleanupLoadedMsg{err: err}
+		}
+
+		// Index merged branches for O(1) lookup.
+		mergedSet := make(map[string]bool, len(mergedBranches))
+		for _, b := range mergedBranches {
+			mergedSet[b] = true
+		}
+
+		// Index branches that already have a worktree.
+		worktreeByBranch := make(map[string]bool, len(worktrees))
+		for _, wt := range worktrees {
+			worktreeByBranch[wt.Branch] = true
+		}
+
+		var candidates []modal.CleanupCandidate
+
+		// Stale worktrees: non-main worktrees whose branch is fully merged.
+		// worktrees[0] is always the main (primary) worktree — skip it.
+		for _, wt := range worktrees[1:] {
+			if mergedSet[wt.Branch] {
+				candidates = append(candidates, modal.CleanupCandidate{
+					Kind:   modal.CandidateWorktree,
+					Path:   wt.Path,
+					Branch: wt.Branch,
+				})
+			}
+		}
+
+		// Merged branches without a worktree.
+		for _, b := range mergedBranches {
+			if !worktreeByBranch[b] {
+				candidates = append(candidates, modal.CleanupCandidate{
+					Kind:   modal.CandidateBranch,
+					Branch: b,
+				})
+			}
+		}
+
+		return cleanupLoadedMsg{candidates: candidates}
+	}
+}
+
+// performCleanupCmd removes the given worktree paths and deletes the given branch
+// names, accumulating errors and returning a cleanupDoneMsg with total deleted count.
+func (m *Model) performCleanupCmd(worktreePaths []string, branches []string) tea.Cmd {
+	repoPath := m.RepoPath
+	return func() tea.Msg {
+		git := internalexec.NewGitCommand(repoPath)
+		var errs []error
+		deleted := 0
+
+		for _, path := range worktreePaths {
+			if err := git.RemoveWorktree(path, true); err != nil {
+				errs = append(errs, fmt.Errorf("remove worktree %s: %w", path, err))
+			} else {
+				deleted++
+			}
+		}
+
+		for _, branch := range branches {
+			if err := git.DeleteBranch(branch, false); err != nil {
+				errs = append(errs, fmt.Errorf("delete branch %s: %w", branch, err))
+			} else {
+				deleted++
+			}
+		}
+
+		return cleanupDoneMsg{deleted: deleted, err: errors.Join(errs...)}
+	}
 }

--- a/internal/exec/git.go
+++ b/internal/exec/git.go
@@ -231,6 +231,38 @@ func (g *GitCommand) GitBranch(path string) (string, error) {
 	return strings.TrimSpace(output), nil
 }
 
+// ListMergedBranches returns local branches that have been fully merged into
+// defaultBranch. The defaultBranch itself is excluded from the result.
+// The current branch marker ("* ") is stripped so every entry is a plain name.
+func (g *GitCommand) ListMergedBranches(defaultBranch string) ([]string, error) {
+	output, err := g.run("list merged branches", "branch", "--merged", defaultBranch)
+	if err != nil {
+		return nil, err
+	}
+
+	var branches []string
+	for _, line := range strings.Split(output, "\n") {
+		// Strip the "* " current-branch marker and surrounding whitespace.
+		line = strings.TrimPrefix(strings.TrimSpace(line), "* ")
+		line = strings.TrimSpace(line)
+		if line == "" || line == defaultBranch {
+			continue
+		}
+		branches = append(branches, line)
+	}
+	return branches, nil
+}
+
+// DeleteBranch deletes the named local branch. When force is true, -D is used
+// (deletes even if unmerged); otherwise -d is used (safe delete).
+func (g *GitCommand) DeleteBranch(branch string, force bool) error {
+	flag := "-d"
+	if force {
+		flag = "-D"
+	}
+	return g.runNoOutput("delete branch", "branch", flag, branch)
+}
+
 func (g *GitCommand) run(op string, args ...string) (string, error) {
 	output, err := g.runner(g.repoPath, args...)
 	if err != nil {

--- a/internal/exec/git_test.go
+++ b/internal/exec/git_test.go
@@ -1318,3 +1318,126 @@ func TestGitCommand_ListModifiedFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestGitCommand_ListMergedBranches(t *testing.T) {
+tests := []struct {
+name          string
+defaultBranch string
+output        string
+runErr        error
+wantArgs      []string
+wantBranches  []string
+expectErr     string
+}{
+{
+name:          "returns merged branches excluding default",
+defaultBranch: "main",
+output:        "  feat/issue-1-something\n  fix/old-bug\n  main\n",
+wantArgs:      []string{"branch", "--merged", "main"},
+wantBranches:  []string{"feat/issue-1-something", "fix/old-bug"},
+},
+{
+name:          "strips current-branch marker",
+defaultBranch: "main",
+output:        "* feat/current\n  feat/old\n",
+wantArgs:      []string{"branch", "--merged", "main"},
+wantBranches:  []string{"feat/current", "feat/old"},
+},
+{
+name:          "returns nil when only default branch present",
+defaultBranch: "main",
+output:        "* main\n",
+wantArgs:      []string{"branch", "--merged", "main"},
+wantBranches:  nil,
+},
+{
+name:          "returns nil on empty output",
+defaultBranch: "main",
+output:        "",
+wantArgs:      []string{"branch", "--merged", "main"},
+wantBranches:  nil,
+},
+{
+name:          "propagates runner error",
+defaultBranch: "main",
+runErr:        errors.New("git exploded"),
+wantArgs:      []string{"branch", "--merged", "main"},
+expectErr:     "git exploded",
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+var calledArgs []string
+runner := func(_ string, args ...string) (string, error) {
+calledArgs = append([]string{}, args...)
+return tt.output, tt.runErr
+}
+cmd := NewGitCommandWithRunner("/repo", runner)
+branches, err := cmd.ListMergedBranches(tt.defaultBranch)
+
+assert.Equal(t, tt.wantArgs, calledArgs)
+
+if tt.expectErr != "" {
+require.Error(t, err)
+assert.Contains(t, err.Error(), tt.expectErr)
+return
+}
+require.NoError(t, err)
+assert.Equal(t, tt.wantBranches, branches)
+})
+}
+}
+
+func TestGitCommand_DeleteBranch(t *testing.T) {
+tests := []struct {
+name      string
+branch    string
+force     bool
+runErr    error
+wantArgs  []string
+expectErr string
+}{
+{
+name:     "safe delete uses -d",
+branch:   "feat/old",
+force:    false,
+wantArgs: []string{"branch", "-d", "feat/old"},
+},
+{
+name:     "force delete uses -D",
+branch:   "feat/old",
+force:    true,
+wantArgs: []string{"branch", "-D", "feat/old"},
+},
+{
+name:      "propagates runner error",
+branch:    "feat/old",
+force:     false,
+runErr:    errors.New("branch not found"),
+wantArgs:  []string{"branch", "-d", "feat/old"},
+expectErr: "branch not found",
+},
+}
+
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+var calledArgs []string
+runner := func(_ string, args ...string) (string, error) {
+calledArgs = append([]string{}, args...)
+return "", tt.runErr
+}
+cmd := NewGitCommandWithRunner("/repo", runner)
+err := cmd.DeleteBranch(tt.branch, tt.force)
+
+assert.Equal(t, tt.wantArgs, calledArgs)
+
+if tt.expectErr != "" {
+require.Error(t, err)
+assert.Contains(t, err.Error(), tt.expectErr)
+return
+}
+require.NoError(t, err)
+})
+}
+}

--- a/internal/tui/modal/cleanup.go
+++ b/internal/tui/modal/cleanup.go
@@ -1,0 +1,211 @@
+package modal
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/m00nk0d3/nexus/internal/tui/styles"
+)
+
+type cleanupEntry struct {
+	candidate CleanupCandidate
+	selected  bool
+}
+
+// CleanupModal presents a two-section multi-select list of stale worktrees and
+// merged branches. Space toggles selection; Enter confirms; Esc cancels.
+type CleanupModal struct {
+	entries []cleanupEntry
+	cursor  int
+	width   int
+	theme   *styles.Theme
+}
+
+// NewCleanupModal creates a CleanupModal populated with the given candidates.
+// Worktree candidates are shown first, branch-only candidates second.
+func NewCleanupModal(candidates []CleanupCandidate) *CleanupModal {
+	entries := make([]cleanupEntry, len(candidates))
+	for i, c := range candidates {
+		entries[i] = cleanupEntry{candidate: c}
+	}
+	return &CleanupModal{entries: entries}
+}
+
+// SetWidth satisfies the optional SetWidth interface used by the app renderer.
+func (m *CleanupModal) SetWidth(w int) { m.width = w }
+
+// SetTheme satisfies the optional SetTheme interface used by the app renderer.
+func (m *CleanupModal) SetTheme(t styles.Theme) { m.theme = &t }
+
+// Init satisfies tea.Model.
+func (m *CleanupModal) Init() tea.Cmd { return nil }
+
+// Title returns the modal title for themed overlay rendering.
+func (m *CleanupModal) Title() string { return "Cleanup Stale Worktrees & Branches" }
+
+// Update handles keyboard navigation, selection, and confirmation.
+func (m *CleanupModal) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch keyMsg.Type {
+	case tea.KeyEsc:
+		return m, func() tea.Msg { return ModalCancelledMsg{} }
+
+	case tea.KeyEnter:
+		return m, m.confirmCmd()
+
+	case tea.KeyUp:
+		m.moveCursor(-1)
+		return m, nil
+
+	case tea.KeyDown:
+		m.moveCursor(1)
+		return m, nil
+
+	case tea.KeySpace:
+		m.toggleSelected()
+		return m, nil
+	}
+
+	switch keyMsg.String() {
+	case "j":
+		m.moveCursor(1)
+	case "k":
+		m.moveCursor(-1)
+	case " ":
+		m.toggleSelected()
+	case "a", "A":
+		for i := range m.entries {
+			m.entries[i].selected = true
+		}
+	case "n", "N":
+		for i := range m.entries {
+			m.entries[i].selected = false
+		}
+	}
+
+	return m, nil
+}
+
+// View renders the cleanup modal content.
+func (m *CleanupModal) View() string {
+	if len(m.entries) == 0 {
+		return "No stale worktrees or merged branches found.\n\n[Esc] close"
+	}
+
+	var (
+		accentSt  = lipgloss.NewStyle()
+		mutedSt   = lipgloss.NewStyle()
+		selectedSt = lipgloss.NewStyle()
+		cursorSt  = lipgloss.NewStyle().Bold(true)
+	)
+
+	if m.theme != nil {
+		accentSt = accentSt.Foreground(lipgloss.Color(m.theme.Accent()))
+		mutedSt = mutedSt.Foreground(lipgloss.Color(m.theme.Muted()))
+		selectedSt = selectedSt.Foreground(lipgloss.Color(m.theme.Success()))
+		cursorSt = cursorSt.Foreground(lipgloss.Color(m.theme.Accent()))
+	}
+
+	var b strings.Builder
+
+	worktreeHeader := false
+	branchHeader := false
+
+	for i, e := range m.entries {
+		// Section headers — printed once per section.
+		if e.candidate.Kind == CandidateWorktree && !worktreeHeader {
+			b.WriteString(accentSt.Render("─── STALE WORKTREES ───"))
+			b.WriteString("\n")
+			worktreeHeader = true
+		}
+		if e.candidate.Kind == CandidateBranch && !branchHeader {
+			if worktreeHeader {
+				b.WriteString("\n")
+			}
+			b.WriteString(accentSt.Render("─── MERGED BRANCHES ───"))
+			b.WriteString("\n")
+			branchHeader = true
+		}
+
+		// Checkbox.
+		check := "[ ]"
+		if e.selected {
+			check = selectedSt.Render("[✓]")
+		}
+
+		// Cursor indicator.
+		cursor := "  "
+		if i == m.cursor {
+			cursor = cursorSt.Render("▶ ")
+		}
+
+		// Item label.
+		var label string
+		if e.candidate.Kind == CandidateWorktree {
+			label = fmt.Sprintf("%-32s  %s",
+				e.candidate.Branch,
+				mutedSt.Render(filepath.Base(e.candidate.Path)),
+			)
+		} else {
+			label = e.candidate.Branch
+		}
+
+		b.WriteString(fmt.Sprintf("%s%s %s\n", cursor, check, label))
+	}
+
+	// Footer.
+	b.WriteString("\n")
+	b.WriteString(mutedSt.Render("[↑/↓] navigate  [Space] toggle  [a] select all  [n] deselect all"))
+	b.WriteString("\n")
+	b.WriteString(mutedSt.Render("[Enter] delete selected  [Esc] cancel"))
+
+	return b.String()
+}
+
+func (m *CleanupModal) moveCursor(delta int) {
+	if len(m.entries) == 0 {
+		return
+	}
+	m.cursor += delta
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+	if m.cursor >= len(m.entries) {
+		m.cursor = len(m.entries) - 1
+	}
+}
+
+func (m *CleanupModal) toggleSelected() {
+	if m.cursor < len(m.entries) {
+		m.entries[m.cursor].selected = !m.entries[m.cursor].selected
+	}
+}
+
+func (m *CleanupModal) confirmCmd() tea.Cmd {
+	var worktrees, branches []string
+	for _, e := range m.entries {
+		if !e.selected {
+			continue
+		}
+		switch e.candidate.Kind {
+		case CandidateWorktree:
+			worktrees = append(worktrees, e.candidate.Path)
+		case CandidateBranch:
+			branches = append(branches, e.candidate.Branch)
+		}
+	}
+	if len(worktrees) == 0 && len(branches) == 0 {
+		// Nothing selected — cancel silently.
+		return func() tea.Msg { return ModalCancelledMsg{} }
+	}
+	return func() tea.Msg {
+		return CleanupConfirmedMsg{Worktrees: worktrees, Branches: branches}
+	}
+}

--- a/internal/tui/modal/help.go
+++ b/internal/tui/modal/help.go
@@ -48,6 +48,7 @@ var keybindingGroups = []bindingGroup{
 		bindings: [][2]string{
 			{"Enter (Issues view)", "Create worktree from selected issue"},
 			{"Ctrl+D", "Delete selected worktree"},
+			{"Ctrl+B", "Cleanup stale worktrees & merged branches"},
 			{"s", "Open shell in worktree"},
 			{"x", "Close session and terminal tab"},
 		},

--- a/internal/tui/modal/messages.go
+++ b/internal/tui/modal/messages.go
@@ -66,3 +66,25 @@ type SpawnAgentMsg struct {
 
 // UpdateConfirmedMsg is sent when the user confirms the self-update from the update modal.
 type UpdateConfirmedMsg struct{}
+
+// CandidateKind distinguishes the type of a cleanup candidate.
+type CandidateKind int
+
+const (
+	CandidateWorktree CandidateKind = iota // a worktree whose branch is merged
+	CandidateBranch                        // a merged branch with no active worktree
+)
+
+// CleanupCandidate represents a single item that can be removed in the cleanup flow.
+type CleanupCandidate struct {
+	Kind   CandidateKind
+	Path   string // worktree path (only for CandidateWorktree)
+	Branch string // branch name
+}
+
+// CleanupConfirmedMsg is sent when the user confirms deletion in the cleanup modal.
+// Worktrees contains paths to remove; Branches contains branch names to delete.
+type CleanupConfirmedMsg struct {
+	Worktrees []string
+	Branches  []string
+}


### PR DESCRIPTION
Closes #106

## What Changed

Adds a Ctrl+B keybinding to the Worktrees view that opens a multi-select cleanup panel. Users can select stale worktrees (whose branch has been merged into the default branch) and merged branches (with no corresponding worktree) for deletion — all without leaving the TUI.

## Why Changed

Managing cleanup of merged branches and their worktrees is a common maintenance chore. Doing it manually requires switching between terminal commands. This feature surfaces exactly what can be safely cleaned up and lets you do it in one keystroke.

## Implementation Details

- **internal/exec/git.go**: Added ListMergedBranches(defaultBranch) and DeleteBranch(branch, force) following existing GitCommand patterns
- **internal/exec/git_test.go**: Table-driven tests — correct args, output parsing, current-branch marker stripping, error propagation
- **internal/tui/modal/messages.go**: CandidateKind, CleanupCandidate, CleanupConfirmedMsg types
- **internal/tui/modal/cleanup.go** (new): Full CleanupModal — two sections (STALE WORKTREES, MERGED BRANCHES), Space to toggle, Enter to confirm, Esc to cancel, /
 select/deselect all
- **cmd/nexus/app.go**: Ctrl+B key handler, loadCleanupDataCmd, performCleanupCmd, message routing
- **internal/tui/modal/help.go**: Ctrl+B documented in WORKTREE OPERATIONS section

## Safety Guarantees

- Main worktree (index 0) is never shown as a candidate
- Default branch is excluded from merged-branch results
- Uses git branch -d (safe delete, not force) for branches

## Testing

- Unit tests for ListMergedBranches and DeleteBranch — all pass
- go build ./... — clean
- go test ./internal/exec/..., ./internal/tui/... — pass (pre-existing Windows path separator failures in unrelated tests on ./cmd/nexus/...)